### PR TITLE
fix: get rid of the connectionToken parameter

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -29,4 +29,4 @@ else
 fi
 
 # Launch che with a custom connection-token
-./node out/server-main.js --port 3100 --connection-token eclipse-che
+./node out/server-main.js --port 3100 --without-connection-token


### PR DESCRIPTION
Che is securing the route so we don't need connectionToken parameter
It's now possible to turn off this feature in VS Code


it might fix https://github.com/eclipse/che/issues/21099 as the gateway can know check if the server is returning 200 and it's no longer returns 403 error