### PR TITLE
chore: timeout + retry for musl as well

### DIFF
--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -67,13 +67,12 @@ RUN [[ $(uname -m) == "x86_64" ]] && \
     ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"
 
 # Run integration tests (Browser)
-RUN [[ $(uname -m) == "x86_64" ]] && VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-alpine" \
+RUN [[ $(uname -m) == "x86_64" ]] && VSCODE_REMOTE_SERVER_PATH="/vscode-reh-web-linux-alpine" \
     retry -v -t 3 -s 2 -- timeout 5m ./scripts/test-web-integration.sh --browser chromium
 
 # Run smoke tests (Browser)
-RUN [[ $(uname -m) == "x86_64" ]] && VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-alpine" \
+RUN [[ $(uname -m) == "x86_64" ]] && VSCODE_REMOTE_SERVER_PATH="/vscode-reh-web-linux-alpine" \
     retry -v -t 3 -s 2 -- timeout 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
-
 
 FROM scratch as linux-musl-content
 COPY --from=linux-musl-builder /checode /checode-linux-musl

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -52,6 +52,10 @@ RUN chmod a+x /checode/out/server-main.js \
 # https://github.com/microsoft/vscode/blob/cdde5bedbf3ed88f93b5090bb3ed9ef2deb7a1b4/test/integration/browser/README.md#compile
 RUN [[ $(uname -m) == "x86_64" ]] && yarn --cwd test/smoke compile && yarn --cwd test/integration/browser compile
 
+# use of retry and timeout
+COPY /build/scripts/helper/retry.sh /usr/bin/retry
+RUN chmod u+x /usr/bin/retry
+
 # install test dependencies
 # chromium for tests and procps as tests are using kill commands and it does not work with busybox implementation
 RUN [[ $(uname -m) == "x86_64" ]] && apk add --update --no-cache chromium procps
@@ -64,11 +68,11 @@ RUN [[ $(uname -m) == "x86_64" ]] && \
 
 # Run integration tests (Browser)
 RUN [[ $(uname -m) == "x86_64" ]] && VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-alpine" \
-    ./scripts/test-web-integration.sh --browser chromium
+    retry -v -t 3 -s 2 -- timeout 5m ./scripts/test-web-integration.sh --browser chromium
 
 # Run smoke tests (Browser)
 RUN [[ $(uname -m) == "x86_64" ]] && VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-alpine" \
-    yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
+    retry -v -t 3 -s 2 -- timeout 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
 
 
 FROM scratch as linux-musl-content


### PR DESCRIPTION
sometimes integration tests are freezing and then it can take hours. (it's reaching the 6hours delay)
Here set a timeout to 5mn so we end shortly the build and try again integration step (to avoid to relaunch the full docker build workflow)