### PR TITLE
Allow to configure the Che-Code hostname

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -32,5 +32,9 @@ fi
 # into a persistent volume
 export VSCODE_AGENT_FOLDER=/checode/remote
 
+if [ -z "$CODE_HOST" ]; then
+  CODE_HOST="127.0.0.1"
+fi
+
 # Launch che without connection-token, security is managed by Che
-./node out/server-main.js --port 3100 --without-connection-token
+./node out/server-main.js --host ${CODE_HOST} --port 3100 --without-connection-token

--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -28,10 +28,14 @@ if ! grep -Fq "${USER_ID}" /etc/passwd; then
     sed "s/\${HOME}/\/che-vscode/g" > /etc/group
 fi
 
+if [ -z "$CODE_HOST" ]; then
+  CODE_HOST="127.0.0.1"
+fi
+
 # detect if we're using alpine/musl
 libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
 if [ -n "$libc" ]; then
-    /checode-linux-musl/node /checode-linux-musl/out/server-main.js --port 3100
+    /checode-linux-musl/node /checode-linux-musl/out/server-main.js --host ${CODE_HOST} --port 3100
 else
-    /checode-linux-libc/node /checode-linux-libc/out/server-main.js --port 3100
+    /checode-linux-libc/node /checode-linux-libc/out/server-main.js --host ${CODE_HOST} --port 3100
 fi


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

This PR addresses https://github.com/eclipse/che/issues/21345

It allows configuring the Che-Code hostname.
For example, it helps to run Che-Code without Che (accessing it by a public URL) by binding Che-Code to `0.0.0.0`.
