### PR TITLE
fix: double quote the environment variable to fix SC2086

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -37,4 +37,4 @@ if [ -z "$CODE_HOST" ]; then
 fi
 
 # Launch che without connection-token, security is managed by Che
-./node out/server-main.js --host ${CODE_HOST} --port 3100 --without-connection-token
+./node out/server-main.js --host "${CODE_HOST}" --port 3100 --without-connection-token

--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 # detect if we're using alpine/musl
 libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
 if [ -n "$libc" ]; then
-    /checode-linux-musl/node /checode-linux-musl/out/server-main.js --host ${CODE_HOST} --port 3100
+    /checode-linux-musl/node /checode-linux-musl/out/server-main.js --host "${CODE_HOST}" --port 3100
 else
-    /checode-linux-libc/node /checode-linux-libc/out/server-main.js --host ${CODE_HOST} --port 3100
+    /checode-linux-libc/node /checode-linux-libc/out/server-main.js --host "${CODE_HOST}" --port 3100
 fi


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

The PR fixes https://github.com/koalaman/shellcheck/wiki/SC2086 which is a follow up to https://github.com/che-incubator/che-code/pull/41#pullrequestreview-952430044