### PR TITLE
Update entrypoint volume to support arbitrary user

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -11,6 +11,14 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
+# Boilerplate code for arbitrary user support
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+  fi
+fi
+
 # list checode
 ls -la /checode/
 


### PR DESCRIPTION
When using che-code with Che, the entrypoint of the container that will host che-code is overridden and `entrypoint-volume.sh` is executed. This is problematic when the container is run as an arbitrary user and files `/etc/passwd` and `/etc/group` are supposed to be patched. See screenshot below.

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/606959/168658041-3730bb69-3b6a-471e-9120-2df723ee9e87.png">

To fix that I have added the boilerplate code that patches `/etc/passwd` and `/etc/group` in the script `entrypoint-volume.sh`.
