### PR TITLE
Use the default working directory if none is specified for a Devfile command

### DIFF
--- a/code/extensions/che-commands/src/taskProvider.ts
+++ b/code/extensions/che-commands/src/taskProvider.ts
@@ -34,7 +34,7 @@ export class CheTaskProvider implements vscode.TaskProvider {
 
 		const cheTasks: vscode.Task[] = devfileCommands!
 			.filter(command => command.exec?.commandLine)
-			.map(command => this.createCheTask(command.id, command.exec?.commandLine!, command.exec?.workingDir!, command.exec?.component!));
+			.map(command => this.createCheTask(command.id, command.exec?.commandLine!, command.exec?.workingDir || '${PROJECT_SOURCE}', command.exec?.component!));
 		return cheTasks;
 	}
 


### PR DESCRIPTION
fixes https://github.com/eclipse/che/issues/21455

#### How to test
1. Spin up a DevWorkspace using the following link:
che-host#https://github.com/azatsarynnyy/java-spring-petclinic/tree/devfilev2. In the test repository, `maven-build` is defined with no `workingDir`.
2. In the command palette type a `task ` shortcut and choose a `che` task type.
3. The task list should be populated with the commands from the Devfile:

![image](https://user-images.githubusercontent.com/1636395/172914489-906c575e-c406-4d70-9353-88e19741e68b.png)

