### PR TITLE
Optimize running the `pr-check` workflow

### DIFF
--- a/.github/workflows/pr-check-ignore.yml
+++ b/.github/workflows/pr-check-ignore.yml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# The workflow allows to pass the mandatory pr-check.yaml in case
+# of the changes made in the files that aren't related to the build.
+name: Pull Request Check
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'build/**'
+      - 'code/**'
+      - 'package.json'
+      - 'yarn.lock'
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-20.04
+  assemble:
+    name: assemble
+    needs: build
+    runs-on: ubuntu-20.04
+  dev:
+    name: dev
+    runs-on: ubuntu-20.04

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,7 +10,13 @@
 name: Pull Request Check
 
 # Trigger the workflow on pull request
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'build/**'
+      - 'code/**'
+      - 'package.json'
+      - 'yarn.lock'
 
 jobs:
 


### PR DESCRIPTION
Don't start `pr-check` workflow if the changes don't affect the build.
It's the second part. The first one is https://github.com/che-incubator/che-code/pull/59

closes https://github.com/eclipse/che/issues/21495
