### PR TITLE
Add a special workflow to skip the mandatory pr-check on the PRs with the changes in the build non-related files

### DIFF
--- a/.github/workflows/pr-check-ignore.yml
+++ b/.github/workflows/pr-check-ignore.yml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2023 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# The workflow allows to pass the mandatory pr-check.yaml in case
+# of the changes made in the files that aren't related to the build.
+name: Pull Request Check
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'build/**'
+      - 'code/**'
+      - 'package.json'
+      - 'yarn.lock'
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-20.04
+  assemble:
+    name: assemble
+    needs: build
+    runs-on: ubuntu-20.04
+  dev:
+    name: dev
+    runs-on: ubuntu-20.04

--- a/.github/workflows/pr-check-ignore.yml
+++ b/.github/workflows/pr-check-ignore.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Red Hat, Inc.
+# Copyright (c) 2022 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/pr-check-ignore.yml
+++ b/.github/workflows/pr-check-ignore.yml
@@ -9,6 +9,7 @@
 
 # The workflow allows to pass the mandatory pr-check.yaml in case
 # of the changes made in the files that aren't related to the build.
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 name: Pull Request Check
 
 on:


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

The PR adds the workflow that allows passing the mandatory [`pr-check.yaml`](https://github.com/che-incubator/che-code/blob/main/.github/workflows/pr-check.yml) in case
of the changes made in the files that aren't related to the build.

For more details, see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

Part of the fix for https://github.com/eclipse/che/issues/21495

The second part is https://github.com/che-incubator/che-code/pull/57