### PR TITLE
chore: Exclude native vscode.github-authentication from extension dependencies

### DIFF
--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -14,15 +14,13 @@ import { GithubService, GithubUser } from '../api/github-service';
 import { inject, injectable } from 'inversify';
 import { AxiosInstance } from 'axios';
 import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as os from 'os';
 
 @injectable()
 export class GithubServiceImpl implements GithubService {
     private readonly token: string | undefined;
 
     constructor(@inject(Symbol.for('AxiosInstance')) private readonly axiosInstance: AxiosInstance) {
-        const credentialsPath = path.resolve(os.homedir(), '.git-credentials', 'credentials');
+        const credentialsPath = '/.git-credentials/credentials';
         if (fs.existsSync(credentialsPath)) {
             const token = fs.readFileSync(credentialsPath).toString();
             this.token = token.substring(token.lastIndexOf(':') + 1, token.indexOf('@'));

--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -14,13 +14,14 @@ import { GithubService, GithubUser } from '../api/github-service';
 import { inject, injectable } from 'inversify';
 import { AxiosInstance } from 'axios';
 import * as fs from 'fs-extra';
+import * as path from 'path';
 
 @injectable()
 export class GithubServiceImpl implements GithubService {
     private readonly token: string | undefined;
 
     constructor(@inject(Symbol.for('AxiosInstance')) private readonly axiosInstance: AxiosInstance) {
-        const credentialsPath = '/.git-credentials/credentials';
+        const credentialsPath = path.resolve('/.git-credentials', 'credentials');
         if (fs.existsSync(credentialsPath)) {
             const token = fs.readFileSync(credentialsPath).toString();
             this.token = token.substring(token.lastIndexOf(':') + 1, token.indexOf('@'));

--- a/code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -25,6 +25,7 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { excludedExtensions } from 'vs/platform/extensionManagement/common/extensionsScannerService';
 
 export interface IInstallExtensionTask {
 	readonly identifier: IExtensionIdentifier;
@@ -170,6 +171,9 @@ export abstract class AbstractExtensionManagementService extends Disposable impl
 				try {
 					const allDepsAndPackExtensionsToInstall = await this.getAllDepsAndPackExtensionsToInstall(installExtensionTask.identifier, manifest, !!options.installOnlyNewlyAddedFromExtensionPack, !!options.installPreReleaseVersion, options.profileLocation);
 					for (const { gallery, manifest } of allDepsAndPackExtensionsToInstall) {
+						if (excludedExtensions.includes(gallery.name)) {
+							continue;
+						}
 						installExtensionHasDependents = installExtensionHasDependents || !!manifest.extensionDependencies?.some(id => areSameExtensions({ id }, installExtensionTask.identifier));
 						const key = ExtensionKey.create(gallery).toString();
 						if (this.installingExtensions.has(key)) {

--- a/code/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
+++ b/code/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
@@ -472,6 +472,10 @@ type NlsConfiguration = {
 	translations: Translations;
 };
 
+export const excludedExtensions = [
+	'github-authentication',
+];
+
 class ExtensionsScanner extends Disposable {
 
 	constructor(
@@ -482,10 +486,6 @@ class ExtensionsScanner extends Disposable {
 	) {
 		super();
 	}
-
-	private readonly excludedExtensions = [
-		'github-authentication',
-	];
 
 	async scanExtensions(input: ExtensionScannerInput): Promise<IRelaxedScannedExtension[]> {
 		const extensions = input.profile ? await this.scanExtensionsFromProfile(input) : await this.scanExtensionsFromLocation(input);
@@ -506,7 +506,7 @@ class ExtensionsScanner extends Disposable {
 		}
 		const extensions = await Promise.all<IRelaxedScannedExtension | null>(
 			stat.children
-			.filter(c => !this.excludedExtensions.includes(c.name))
+			.filter(c => !excludedExtensions.includes(c.name))
 			.map(async c => {
 				if (!c.isDirectory) {
 					return null;

--- a/code/src/vs/workbench/api/common/extHostExtensionActivator.ts
+++ b/code/src/vs/workbench/api/common/extHostExtensionActivator.ts
@@ -170,6 +170,9 @@ export class ExtensionsActivator implements IDisposable {
 	private readonly _externalExtensionsMap: Map<string, ExtensionIdentifier>;
 	private readonly _host: IExtensionsActivatorHost;
 	private readonly _operations: Map<string, ActivationOperation>;
+	private readonly _excludedDependencies = [
+		'vscode.github-authentication',
+	];
 	/**
 	 * A map of already activated events to speed things up if the same activation event is triggered multiple times.
 	 */
@@ -269,7 +272,9 @@ export class ExtensionsActivator implements IDisposable {
 		const deps: ActivationOperation[] = [];
 		const depIds = (typeof currentExtension.extensionDependencies === 'undefined' ? [] : currentExtension.extensionDependencies);
 		for (const depId of depIds) {
-
+			if (this._excludedDependencies.includes(depId)) {
+				continue;
+			}
 			if (this._resolvedExtensionsSet.has(ExtensionIdentifier.toKey(depId))) {
 				// This dependency is already resolved
 				continue;

--- a/code/src/vs/workbench/api/common/extHostExtensionActivator.ts
+++ b/code/src/vs/workbench/api/common/extHostExtensionActivator.ts
@@ -11,6 +11,7 @@ import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { ExtensionActivationReason, MissingExtensionDependency } from 'vs/workbench/services/extensions/common/extensions';
 import { ILogService } from 'vs/platform/log/common/log';
 import { Barrier } from 'vs/base/common/async';
+import { excludedExtensions } from 'vs/platform/extensionManagement/common/extensionsScannerService';
 
 /**
  * Represents the source code (module) of an extension.
@@ -170,9 +171,6 @@ export class ExtensionsActivator implements IDisposable {
 	private readonly _externalExtensionsMap: Map<string, ExtensionIdentifier>;
 	private readonly _host: IExtensionsActivatorHost;
 	private readonly _operations: Map<string, ActivationOperation>;
-	private readonly _excludedDependencies = [
-		'vscode.github-authentication',
-	];
 	/**
 	 * A map of already activated events to speed things up if the same activation event is triggered multiple times.
 	 */
@@ -272,7 +270,7 @@ export class ExtensionsActivator implements IDisposable {
 		const deps: ActivationOperation[] = [];
 		const depIds = (typeof currentExtension.extensionDependencies === 'undefined' ? [] : currentExtension.extensionDependencies);
 		for (const depId of depIds) {
-			if (this._excludedDependencies.includes(depId)) {
+			if (excludedExtensions.includes(depId.substring('vscode.'.length))) {
 				continue;
 			}
 			if (this._resolvedExtensionsSet.has(ExtensionIdentifier.toKey(depId))) {


### PR DESCRIPTION
* Ignore the native `github-authentication` extension from extension dependencies to not coliede with `che-github-authentication` extension which overrides the native one.
* Fix the credentials file location.
fixes https://github.com/eclipse/che/issues/21492, https://github.com/eclipse/che/issues/21443