### PR TITLE
Publish the `next` images from the dedicated branch

### DIFF
--- a/.github/workflows/image-publish-insiders.yml
+++ b/.github/workflows/image-publish-insiders.yml
@@ -10,6 +10,7 @@
 name: image-publish-insiders
 
 on:
+  workflow_dispatch:
   push:
     branches: [ trm-fix ]
 

--- a/.github/workflows/image-publish-insiders.yml
+++ b/.github/workflows/image-publish-insiders.yml
@@ -11,7 +11,7 @@ name: image-publish-insiders
 
 on:
   push:
-    branches: [ main ]
+    branches: [ trm-fix ]
 
 jobs:
 
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: trm-fix
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -44,8 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Checkout
-        uses: actions/checkout@v2
+        with:
+          ref: trm-fix
       - name: Download linux-libc-amd64 image
         uses: ishworkh/docker-image-artifact-download@v1
         with:
@@ -73,8 +75,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Checkout
-        uses: actions/checkout@v2
+        with:
+          ref: trm-fix
       - name: Login to Quay.io
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Publish the `next` images from the dedicated branch that points to a previous commit. It's because the current state of the `main` branch requires some adaptation to the upstream changes.
This PR allows us to get `che-incubator/che-code/insiders` with a working terminal until we investigate and fix the https://github.com/eclipse/che/issues/21537