### PR TITLE
Update machine-exec to the latest released version - 7.51.0

### DIFF
--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -9,7 +9,7 @@
 # Grab content from previously build images
 FROM linux-libc-amd64 as linux-libc-content
 FROM linux-musl-amd64 as linux-musl-content
-FROM quay.io/eclipse/che-machine-exec:7.39.1 as machine-exec
+FROM quay.io/eclipse/che-machine-exec:7.51.0 as machine-exec
 
 FROM registry.access.redhat.com/ubi8/ubi:8.5-214 AS ubi-builder
 RUN mkdir -p /mnt/rootfs

--- a/build/dockerfiles/dev.Dockerfile
+++ b/build/dockerfiles/dev.Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-FROM quay.io/eclipse/che-machine-exec:7.42.0 as machine-exec
+FROM quay.io/eclipse/che-machine-exec:7.51.0 as machine-exec
 
 FROM registry.access.redhat.com/ubi8/ubi:8.5-214 AS ubi-micro-build
 RUN mkdir -p /mnt/rootfs


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

It's a cherry-pick of https://github.com/che-incubator/che-code/pull/74 to `devspaces-3.1-rhel-8` branch to include it in DS.