### PR TITLE
chore: Update from quay.io/eclipse/che-machine-exec:7.51.0 to quay.io/eclipse/che-machine-exec:7.51.0

### DIFF
--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -11,7 +11,7 @@ FROM linux-libc-amd64 as linux-libc-content
 FROM linux-musl-amd64 as linux-musl-content
 
 # https://quay.io/eclipse/che-machine-exec#^7\.
-FROM quay.io/eclipse/che-machine-exec:7.39.1 as machine-exec
+FROM quay.io/eclipse/che-machine-exec:7.51.0 as machine-exec
 
 # https://registry.access.redhat.com/ubi8
 FROM registry.access.redhat.com/ubi8/ubi:8.5-214 AS ubi-builder

--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -9,8 +9,11 @@
 # Grab content from previously build images
 FROM linux-libc-amd64 as linux-libc-content
 FROM linux-musl-amd64 as linux-musl-content
+
+# https://quay.io/eclipse/che-machine-exec#^7\.
 FROM quay.io/eclipse/che-machine-exec:7.39.1 as machine-exec
 
+# https://registry.access.redhat.com/ubi8
 FROM registry.access.redhat.com/ubi8/ubi:8.5-214 AS ubi-builder
 RUN mkdir -p /mnt/rootfs
 RUN yum install --installroot /mnt/rootfs brotli libstdc++ coreutils glibc-minimal-langpack --releasever 8 --setopt install_weak_deps=false --nodocs -y && yum --installroot /mnt/rootfs clean all

--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -14,7 +14,7 @@ FROM linux-musl-amd64 as linux-musl-content
 FROM quay.io/eclipse/che-machine-exec:7.51.0 as machine-exec
 
 # https://registry.access.redhat.com/ubi8/ubi
-FROM registry.access.redhat.com/ubi8/ubi:8.5-214 AS ubi-builder
+FROM registry.access.redhat.com/ubi8/ubi:8.6-855 AS ubi-builder
 RUN mkdir -p /mnt/rootfs
 RUN yum install --installroot /mnt/rootfs brotli libstdc++ coreutils glibc-minimal-langpack --releasever 8 --setopt install_weak_deps=false --nodocs -y && yum --installroot /mnt/rootfs clean all
 RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*

--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -13,7 +13,7 @@ FROM linux-musl-amd64 as linux-musl-content
 # https://quay.io/eclipse/che-machine-exec#^7\.
 FROM quay.io/eclipse/che-machine-exec:7.51.0 as machine-exec
 
-# https://registry.access.redhat.com/ubi8
+# https://registry.access.redhat.com/ubi8/ubi
 FROM registry.access.redhat.com/ubi8/ubi:8.5-214 AS ubi-builder
 RUN mkdir -p /mnt/rootfs
 RUN yum install --installroot /mnt/rootfs brotli libstdc++ coreutils glibc-minimal-langpack --releasever 8 --setopt install_weak_deps=false --nodocs -y && yum --installroot /mnt/rootfs clean all

--- a/build/dockerfiles/dev.Dockerfile
+++ b/build/dockerfiles/dev.Dockerfile
@@ -6,8 +6,10 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+# https://quay.io/eclipse/che-machine-exec#^7\.
 FROM quay.io/eclipse/che-machine-exec:7.42.0 as machine-exec
 
+# https://registry.access.redhat.com/ubi8
 FROM registry.access.redhat.com/ubi8/ubi:8.5-214 AS ubi-micro-build
 RUN mkdir -p /mnt/rootfs
 RUN ARCH=$(uname -m) && yum install --installroot /mnt/rootfs libsecret curl make cmake gcc gcc-c++ python3 git git-core-doc openssh less wget \

--- a/build/dockerfiles/linux-libc.Dockerfile
+++ b/build/dockerfiles/linux-libc.Dockerfile
@@ -6,8 +6,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-# https://catalog.redhat.com/software/containers/ubi8/nodejs-16/615aee9fc739c0a4123a87e1?container-tabs=overview
-FROM registry.access.redhat.com/ubi8/nodejs-16:1-37.1652296488 as linux-libc-builder
+# https://registry.access.redhat.com/ubi8/nodejs-16
+FROM registry.access.redhat.com/ubi8/nodejs-16:1-42 as linux-libc-builder
 
 USER root
 


### PR DESCRIPTION
Change-Id: Id7853d280cac51178569eaa376ca81769c0f49ad
Signed-off-by: Nick Boldt <nboldt@redhat.com>