### PR TITLE
chore: Validate an authentication session before using it

### DIFF
--- a/code/extensions/che-api/src/api/github-service.ts
+++ b/code/extensions/che-api/src/api/github-service.ts
@@ -21,6 +21,6 @@ export const GithubService = Symbol('GithubService');
 
 export interface GithubService {
     getToken(): Promise<string>;
-
     getUser(): Promise<GithubUser>;
+    getTokenScopes(token: string): Promise<string[]>;
 }

--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -46,4 +46,12 @@ export class GithubServiceImpl implements GithubService {
         });
         return result.data;
     }
+
+    async getTokenScopes(token: string): Promise<string[]> {
+        this.checkToken();
+        const result = await this.axiosInstance.get<GithubUser>('https://api.github.com/user', {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        return result.headers['x-oauth-scopes'].split(', ');
+    }
 }


### PR DESCRIPTION
when returning an authentication session validate it:
* Check the session's token to be able to retraive a GitHub user.
* Check the requiered scopes to be covered by the session's token scopes.

**How to test:**
1. Start a factory form:
```
https://gist.githubusercontent.com/vinokurig/d8eb43f1b379edd1fb1ec3f77e951594/raw/147d81e4d00e3d410970f0bf8e08725e9b41e079/che-editor.yaml
```
2. Install the `vscode-github-pull-request` extension

See: no warnings appear

fixes https://github.com/eclipse/che/issues/21581