### PR TITLE
feat: Allow to use OpenVSX instance from the plug-in registry

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -45,5 +45,26 @@ if [ -z "$CODE_HOST" ]; then
   CODE_HOST="127.0.0.1"
 fi
 
+# First, check if OPENVSX_REGISTRY_URL environment variable is defined
+# If it is, then it means CheServer has a way to provide this information
+if [ -n "${OPENVSX_REGISTRY_URL+x}" ]; then
+
+  # now check if it's empty, in that case we use Plugin Registry OpenVSX
+  if [ -z "$OPENVSX_REGISTRY_URL" ]; then
+    # remove the suffix /v3 from this variable
+    CHE_PLUGIN_REGISTRY_ROOT_URL=${CHE_PLUGIN_REGISTRY_URL%/v3}
+
+    # Use OpenVSX of the plug-in registry
+    OPENVSX_URL="$CHE_PLUGIN_REGISTRY_ROOT_URL/openvsx/vscode"
+  else
+    # Use OpenVSX URL provided by the env variable
+    OPENVSX_URL="$OPENVSX_REGISTRY_URL"
+  fi
+  echo "using OPENVSX_URL=$OPENVSX_URL"
+  sed -i -r -e "s|\"serviceUrl\": \"..*\"|\"serviceUrl\": \"${OPENVSX_URL}/gallery\"|" product.json
+  sed -i -r -e "s|\"itemUrl\": \"..*\"|\"itemUrl\": \"${OPENVSX_URL}/item\"|" product.json
+  sed -i -e "s|serviceUrl:\".*\",itemUrl:\".*\"},version|serviceUrl:\"${OPENVSX_URL}/gallery\",itemUrl:\"${OPENVSX_URL}/item\"},version|" out/vs/workbench/workbench.web.main.js
+fi
+
 # Launch che without connection-token, security is managed by Che
 ./node out/server-main.js --host "${CODE_HOST}" --port 3100 --without-connection-token


### PR DESCRIPTION
If OpenVSX URL is empty, use the OpenVSX from the plug-in registry, else use the link provided (that should be open-vsx.org)

Requires https://github.com/eclipse-che/che-plugin-registry/pull/1324

Part of https://github.com/eclipse/che/issues/20549
Fixes https://github.com/eclipse/che/issues/21601

Should then be updated to match new fields of CheCluster CR https://github.com/eclipse/che/issues/21598

![image](https://user-images.githubusercontent.com/436777/181741049-84710b31-5170-464b-966a-5b5d233947d0.png)

you can see in top left that extensions are coming from the che plug-in registry URL

Change-Id: I9c349f435a399e23c38819e9f3d2d80e7b9a85b0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>