### PR TITLE
fix: Fix 'unsupported platform' error for s390x platform

### DIFF
--- a/.rebase/override/code/build/package.json
+++ b/.rebase/override/code/build/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "esbuild": "^0.14.49"
+  }
+}

--- a/.rebase/override/code/extensions/package.json
+++ b/.rebase/override/code/extensions/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "esbuild": "^0.14.49"
+  }
+}

--- a/code/build/package.json
+++ b/code/build/package.json
@@ -48,7 +48,7 @@
     "commander": "^7.0.0",
     "debug": "^4.3.2",
     "electron-osx-sign": "^0.4.16",
-    "esbuild": "^0.14.2",
+    "esbuild": "^0.14.49",
     "extract-zip": "^2.0.1",
     "fs-extra": "^9.1.0",
     "got": "11.8.5",

--- a/code/extensions/package.json
+++ b/code/extensions/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@parcel/watcher": "2.0.5",
-    "esbuild": "^0.11.12",
+    "esbuild": "^0.14.49",
     "vscode-grammar-updater": "^1.1.0"
   }
 }

--- a/rebase.sh
+++ b/rebase.sh
@@ -107,6 +107,28 @@ apply_code_remote_package_changes() {
   git add code/remote/package.json > /dev/null 2>&1
 }
 
+# Apply changes on $1 package.json file
+# A path to the file should be passed, for example: code/build/package.json 
+apply_package_changes_by_path() {
+  local filePath="$1"
+  
+  if [ -z "$filePath" ]; then
+     echo "Can not apply changes for package.json file - the path was not passed"
+     exit 1;
+  fi
+
+  echo "  ⚙️ reworking $filePath..."
+  
+  # reset the file from what is upstream
+  git checkout --theirs $filePath > /dev/null 2>&1
+  
+  # now apply again the changes
+  override_json_file $filePath
+  
+  # resolve the change
+  git add $filePath > /dev/null 2>&1
+}
+
 # Apply changes on code/remote/yarn.lock file
 apply_code_remote_yarn_lock_changes() {
 
@@ -196,6 +218,10 @@ resolve_conflicts() {
       apply_code_package_changes
     elif [[ "$conflictingFile" == "code/product.json" ]]; then
       apply_code_product_changes
+    elif [[ "$conflictingFile" == "code/build/package.json" ]]; then
+      apply_package_changes_by_path "code/build/package.json"
+    elif [[ "$conflictingFile" == "code/extensions/package.json" ]]; then
+      apply_package_changes_by_path "code/extensions/package.json"
     elif [[ "$conflictingFile" == "code/remote/package.json" ]]; then
       apply_code_remote_package_changes
     elif [[ "$conflictingFile" == "code/remote/yarn.lock" ]]; then

--- a/rebase.sh
+++ b/rebase.sh
@@ -29,7 +29,11 @@ override_json_file() {
   fi
   
   # and now, add the values (not overriding)
-  jq "${INDENT[@]}" -s '.[1] * .[0]' ".rebase/add/$filename" "$filename.tmp" > "$filename"
+  local addFile=".rebase/add/$filename"
+  if [ -f "$addFile" ]; then
+    echo "  ⚙️  adding values from $addFile..."
+    jq "${INDENT[@]}" -s '.[1] * .[0]' "$addFile" "$filename.tmp" > "$filename"
+  fi
   
   # delete previous file
   rm "$filename.tmp"


### PR DESCRIPTION
We have an error for `s390x` platform on `yarn install` step:

<img width="760" alt="image" src="https://user-images.githubusercontent.com/5676062/180597843-540a2f55-ad45-4d49-bc3d-379c66d1f52e.png">

It's because of `esbuild` version:

![image](https://user-images.githubusercontent.com/5676062/182853777-949d7a90-c898-45c3-9e0b-b42ba916e885.png)

The upgrade of `esbuild` version fixes the problem:
<img width="760" alt="Screenshot 2022-07-23 at 13 18 48" src="https://user-images.githubusercontent.com/5676062/180601377-5ca591fb-5062-46d7-a758-d250c0406c0e.png">

The change was tested on `s390x` platform, please see details [here](https://issues.redhat.com/browse/CRW-3171?focusedCommentId=20709740&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-20709740) 

Steps for testing `rebase.sh` script changes please see here: https://github.com/che-incubator/che-code/pull/86#issuecomment-1207371544

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>