### PR TITLE
Disable shell integration

### DIFF
--- a/code/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/code/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -535,7 +535,7 @@ const terminalConfiguration: IConfigurationNode = {
 			restricted: true,
 			markdownDescription: localize('terminal.integrated.shellIntegration.enabled', "Determines whether or not shell integration is auto-injected to support features like enhanced command tracking and current working directory detection. \n\nShell integration works by injecting the shell with a startup script. The script gives VS Code insight into what is happening within the terminal.\n\nSupported shells:\n\n- Linux/macOS: bash, pwsh, zsh\n - Windows: pwsh\n\nThis setting applies only when terminals are created, so you will need to restart your terminals for it to take effect.\n\n Note that the script injection may not work if you have custom arguments defined in the terminal profile, a [complex bash `PROMPT_COMMAND`](https://code.visualstudio.com/docs/editor/integrated-terminal#_complex-bash-promptcommand), or other unsupported setup. To disable decorations, see {0}", '`#terminal.integrated.shellIntegrations.decorationsEnabled#`'),
 			type: 'boolean',
-			default: true
+			default: false // disabled, for machin-exec support
 		},
 		[TerminalSettingId.ShellIntegrationDecorationsEnabled]: {
 			restricted: true,

--- a/code/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/code/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -535,7 +535,7 @@ const terminalConfiguration: IConfigurationNode = {
 			restricted: true,
 			markdownDescription: localize('terminal.integrated.shellIntegration.enabled', "Determines whether or not shell integration is auto-injected to support features like enhanced command tracking and current working directory detection. \n\nShell integration works by injecting the shell with a startup script. The script gives VS Code insight into what is happening within the terminal.\n\nSupported shells:\n\n- Linux/macOS: bash, pwsh, zsh\n - Windows: pwsh\n\nThis setting applies only when terminals are created, so you will need to restart your terminals for it to take effect.\n\n Note that the script injection may not work if you have custom arguments defined in the terminal profile, a [complex bash `PROMPT_COMMAND`](https://code.visualstudio.com/docs/editor/integrated-terminal#_complex-bash-promptcommand), or other unsupported setup. To disable decorations, see {0}", '`#terminal.integrated.shellIntegrations.decorationsEnabled#`'),
 			type: 'boolean',
-			default: false // disabled, for machin-exec support
+			default: false // disabled, for machine-exec support
 		},
 		[TerminalSettingId.ShellIntegrationDecorationsEnabled]: {
 			restricted: true,


### PR DESCRIPTION
Disable the [extended shell integration](https://code.visualstudio.com/updates/v1_70#_shell-integration-enabled-by-default) feature as it breaks the machine-exec terminal.

fixes https://github.com/eclipse/che/issues/21537


#### How to test
Once the github-actions bot publishes the quay.io/che-incubator-pull-requests/che-code:pr-90-amd64 image (it should comment on the PR), run <che-host>#https://github.com/azatsarynnyy/java-spring-petclinic/tree/devfilev2.
Check that the terminal, opened on Che-Code start, works as expected.
