### PR TITLE
Restore publishing the `next` images from the `main` branch

### DIFF
--- a/.github/workflows/image-publish-insiders.yml
+++ b/.github/workflows/image-publish-insiders.yml
@@ -10,7 +10,6 @@
 name: image-publish-insiders
 
 on:
-  workflow_dispatch:
   push:
     branches: [ main ]
 

--- a/.github/workflows/image-publish-insiders.yml
+++ b/.github/workflows/image-publish-insiders.yml
@@ -12,7 +12,7 @@ name: image-publish-insiders
 on:
   workflow_dispatch:
   push:
-    branches: [ trm-fix ]
+    branches: [ main ]
 
 jobs:
 
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: trm-fix
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -47,8 +45,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: trm-fix
       - name: Download linux-libc-amd64 image
         uses: ishworkh/docker-image-artifact-download@v1
         with:
@@ -76,8 +72,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: trm-fix
       - name: Login to Quay.io
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Since https://github.com/eclipse/che/issues/21537 is fixed by https://github.com/che-incubator/che-code/pull/90, we can restore publishing the `next` images from the `main` branch.

See https://github.com/che-incubator/che-code/pull/69 for more details.

It depends on merging https://github.com/che-incubator/che-code/pull/90.
