### PR TITLE
fix: Add build targets for ppc64 and s390x platforms

### DIFF
--- a/code/build/gulpfile.reh.js
+++ b/code/build/gulpfile.reh.js
@@ -43,6 +43,8 @@ const BUILD_TARGETS = [
 	{ platform: 'darwin', arch: 'arm64' },
 	{ platform: 'linux', arch: 'ia32' },
 	{ platform: 'linux', arch: 'x64' },
+	{ platform: 'linux', arch: 'ppc64' },
+	{ platform: 'linux', arch: 's390x' },
 	{ platform: 'linux', arch: 'armhf' },
 	{ platform: 'linux', arch: 'arm64' },
 	{ platform: 'alpine', arch: 'arm64' },


### PR DESCRIPTION
should fix: https://issues.redhat.com/browse/CRW-3281

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>