### PR TITLE
chore: Keep workbench config in json file

### DIFF
--- a/code/build/gulpfile.reh.js
+++ b/code/build/gulpfile.reh.js
@@ -12,6 +12,7 @@ const util = require('./lib/util');
 const task = require('./lib/task');
 const common = require('./lib/optimize');
 const product = require('../product.json');
+const workbenchConfig = require('../src/vs/code/browser/workbench/che/workbench-config.json');
 const rename = require('gulp-rename');
 const replace = require('gulp-replace');
 const filter = require('gulp-filter');
@@ -368,7 +369,7 @@ function tweakProductForServerWeb(product) {
 			out: `out-vscode-${type}`,
 			inlineAmdImages: true,
 			bundleInfo: undefined,
-			fileContentMapper: createVSCodeWebFileContentMapper('.build/extensions', type === 'reh-web' ? tweakProductForServerWeb(product) : product)
+			fileContentMapper: createVSCodeWebFileContentMapper('.build/extensions', type === 'reh-web' ? tweakProductForServerWeb(product) : product, workbenchConfig)
 		})
 	));
 

--- a/code/build/gulpfile.vscode.web.js
+++ b/code/build/gulpfile.vscode.web.js
@@ -12,6 +12,7 @@ const util = require('./lib/util');
 const task = require('./lib/task');
 const common = require('./lib/optimize');
 const product = require('../product.json');
+const workbenchConfig = require('../src/vs/code/browser/workbench/che/workbench-config.json');
 const rename = require('gulp-rename');
 const filter = require('gulp-filter');
 const _ = require('underscore');
@@ -122,6 +123,23 @@ const createVSCodeWebBuiltinExtensionsPatcher = (extensionsRoot) => {
 	return result;
 };
 
+const createWorkbenchConfigurationPatcher = (workbenchConfig) => {
+	/**
+	 * @param content {string} The contens of the file
+	 * @param path {string} The absolute file path, always using `/`, even on Windows
+	 */
+	const result = (content, path) => {
+		// (3) Patch workbench configuration
+		if (path.endsWith('vs/code/browser/workbench/che/workbench-che-config.js')) {
+			const workbenchConfiguration = JSON.stringify({ ...workbenchConfig });
+			return content.replace('/*BUILD->INSERT_WORKBENCH_CONFIGURATION*/', workbenchConfiguration.substr(1, workbenchConfiguration.length - 2) /* without { and }*/);
+		}
+
+		return content;
+	};
+	return result;
+};
+
 /**
  * @param patchers {((content:string, path: string)=>string)[]}
  */
@@ -142,9 +160,11 @@ const combineContentPatchers = (...patchers) => {
 /**
  * @param extensionsRoot {string} The location where extension will be read from
  * @param {object} product The parsed product.json file contents
+ * @param {object} workbenchConfig The parsed workbench-config.json file contents
  */
-const createVSCodeWebFileContentMapper = (extensionsRoot, product) => {
+const createVSCodeWebFileContentMapper = (extensionsRoot, product, workbenchConfig) => {
 	return combineContentPatchers(
+		createWorkbenchConfigurationPatcher(workbenchConfig),
 		createVSCodeWebProductConfigurationPatcher(product),
 		createVSCodeWebBuiltinExtensionsPatcher(extensionsRoot)
 	);
@@ -163,7 +183,7 @@ const optimizeVSCodeWebTask = task.define('optimize-vscode-web', task.series(
 		out: 'out-vscode-web',
 		inlineAmdImages: true,
 		bundleInfo: undefined,
-		fileContentMapper: createVSCodeWebFileContentMapper('.build/web/extensions', product)
+		fileContentMapper: createVSCodeWebFileContentMapper('.build/web/extensions', product, workbenchConfig)
 	})
 ));
 

--- a/code/src/vs/code/browser/workbench/che/workbench-che-config.ts
+++ b/code/src/vs/code/browser/workbench/che/workbench-che-config.ts
@@ -13,28 +13,44 @@
 import { ColorScheme } from 'vs/platform/theme/common/theme';
 import { IInitialColorTheme, IWindowIndicator, IWorkbenchConstructionOptions } from 'vs/workbench/workbench.web.main';
 
+/**
+ * Built time configuration (do NOT modify the value below)
+ * Modify workbench-config.json file to apply a change for the configuration 
+ */
+const workbenchConfiguration = { /*BUILD->INSERT_WORKBENCH_CONFIGURATION*/ } as IWorkbenchConstructionOptions;
+
+const windowIndicator: IWindowIndicator = {
+    label: `$(eclipse-che) Eclipse Che`,
+    tooltip: 'Eclipse Che'
+};
+
+const statusBarColorCustomizations: { [colorId: string]: string } = {
+    // use colors from che logo: yellow/#FDB940 and blue/#525C86
+    'statusBarItem.remoteBackground': '#FDB940',
+    'statusBarItem.remoteForeground': '#525C86',
+}
+
+const configurationDefaults: Record<string, any> = {
+    'workbench.colorTheme': 'Dark',
+    'workbench.colorCustomizations': statusBarColorCustomizations
+}
+
+const initialColorTheme: IInitialColorTheme = {
+    themeType: ColorScheme.DARK,
+    colors: statusBarColorCustomizations
+}
+
+// the configuration should be applied if built time configuration is not handled 
+// the values are the same as in the workbench-config.json file
+const defaultWorkbenchConfiguration = {
+    windowIndicator,
+    configurationDefaults,
+    initialColorTheme
+};
+
 export function getCheConfig(): IWorkbenchConstructionOptions {
-
-    const windowIndicator: IWindowIndicator = {
-        label: `$(eclipse-che) Eclipse Che`,
-        tooltip: 'Eclipse Che'
-    };
-
-    const statusBarColorCustomizations: { [colorId: string]: string } = {
-        // use colors from che logo: yellow/#FDB940 and blue/#525C86
-        'statusBarItem.remoteBackground': '#FDB940',
-        'statusBarItem.remoteForeground': '#525C86',
+    if (Object.keys(workbenchConfiguration).length === 0) {
+        Object.assign(workbenchConfiguration, defaultWorkbenchConfiguration);
     }
-
-    const configurationDefaults: Record<string, any> = {
-        'workbench.colorTheme': 'Dark',
-        'workbench.colorCustomizations': statusBarColorCustomizations
-    }
-
-    const initialColorTheme: IInitialColorTheme = {
-        themeType: ColorScheme.DARK,
-        colors: statusBarColorCustomizations
-    }
-
-    return { windowIndicator, configurationDefaults, initialColorTheme };
+    return workbenchConfiguration;
 }

--- a/code/src/vs/code/browser/workbench/che/workbench-config.json
+++ b/code/src/vs/code/browser/workbench/che/workbench-config.json
@@ -1,0 +1,20 @@
+{
+	"windowIndicator": {
+		"label": "$(eclipse-che) Eclipse Che",
+		"tooltip": "Eclipse Che"
+	},
+	"configurationDefaults": {
+		"workbench.colorTheme": "Dark",
+		"workbench.colorCustomizations": {
+			"statusBarItem.remoteBackground": "#FDB940",
+			"statusBarItem.remoteForeground": "#525C86"
+		}
+	},
+	"initialColorTheme": {
+		"themeType": "dark",
+		"colors": {
+			"statusBarItem.remoteBackground": "#FDB940",
+			"statusBarItem.remoteForeground": "#525C86"
+		}
+	}
+}


### PR DESCRIPTION
The changes should simplify a way for workbench configuration customization.

The idea is: 
- we keep che-configuration as a json file ([workbench-config.json](https://github.com/che-incubator/che-code/pull/95/files#diff-4a579da5987019fe6e18c54b80ff1aad39d3be047253b8a32399df68a81877efR1))
- we put content of the json file to [the corresponding constant](https://github.com/che-incubator/che-code/pull/95/files#diff-1ef0bbcb916647818826976f680d2c50aeca00d2bb095e3ef1ca62cc8bd1f5fcR20) at build time
- [workbench-config.json](https://github.com/che-incubator/che-code/pull/95/files#diff-4a579da5987019fe6e18c54b80ff1aad39d3be047253b8a32399df68a81877efR1) should be modified to apply a change for workbench configuration (to override any property)

About testing - I checked that the status bar item looks as usual - nothing was broken.

<img width="167" alt="status_bar_item_dark" src="https://user-images.githubusercontent.com/5676062/186648460-ecb7f314-e440-441c-91df-3596ac8acebc.png">

  
<img width="167" alt="status_bar_item" src="https://user-images.githubusercontent.com/5676062/186648143-f8ccd1ac-503c-4d69-a69a-b4614f768c0c.png">

  
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>