### PR TITLE
fix: add extra truststore in case of self-signed certificates

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -66,5 +66,11 @@ if [ -n "${OPENVSX_REGISTRY_URL+x}" ]; then
   sed -i -e "s|serviceUrl:\".*\",itemUrl:\".*\"},version|serviceUrl:\"${OPENVSX_URL}/gallery\",itemUrl:\"${OPENVSX_URL}/item\"},version|" out/vs/workbench/workbench.web.main.js
 fi
 
+# Check if we have a custom CA certificate
+if [ -f /tmp/che/secret/ca.crt ]; then
+  echo "Adding custom CA certificate"
+  export NODE_EXTRA_CA_CERTS=/tmp/che/secret/ca.crt
+fi
+
 # Launch che without connection-token, security is managed by Che
 ./node out/server-main.js --host "${CODE_HOST}" --port 3100 --without-connection-token


### PR DESCRIPTION
Add the Che truststore to the nodejs ca if it exists

![image](https://user-images.githubusercontent.com/436777/187945056-78afd668-6280-4f2d-b954-99430ffdc564.png)

I was able to download/install the extensions

Fixes https://github.com/eclipse/che/issues/21662

Change-Id: I1a4a052c48cfedbd9906b9ebc9789bea9bacfbd4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>