### PR TITLE
Switch publishing the `next` images from a dedicated branch to fix the `next`image

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
   push:
     branches: 
-      - fix-insider
+      - fix-insiders
     tags:
       - '7.*.*'
 
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: fix-insider
+          ref: fix-insiders
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: fix-insider
+          ref: fix-insiders
       - name: Download linux-libc-amd64 image
         uses: ishworkh/docker-image-artifact-download@v1
         with:
@@ -110,12 +110,12 @@ jobs:
   dev:
     name: dev
     runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/fix-insider'
+    if: github.ref == 'refs/heads/fix-insiders'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: fix-insider
+          ref: fix-insiders
       - name: Login to Quay.io
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -10,9 +10,10 @@
 name: image-publish
 
 on:
+  workflow_dispatch:
   push:
     branches: 
-      - main
+      - fix-insider
     tags:
       - '7.*.*'
 
@@ -29,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: fix-insider
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -51,6 +54,8 @@ jobs:
           echo "BRANCH_NAME=${BRANCH_NAME##*/}" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: fix-insider
       - name: Download linux-libc-amd64 image
         uses: ishworkh/docker-image-artifact-download@v1
         with:
@@ -105,10 +110,12 @@ jobs:
   dev:
     name: dev
     runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/fix-insider'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: fix-insider
       - name: Login to Quay.io
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
related to https://github.com/eclipse/che/issues/21708