### PR TITLE
fix: `server-main.js` should respect the `--port` argument

### DIFF
--- a/code/src/server-main.js
+++ b/code/src/server-main.js
@@ -188,14 +188,10 @@ function sanitizeStringArg(val) {
  * @throws
  */
 async function parsePort(host, strPort) {
-	let specificPort;
 	if (strPort) {
 		let range;
 		if (strPort.match(/^\d+$/)) {
-			specificPort = parseInt(strPort, 10);
-			if (specificPort === 0) {
-				return specificPort;
-			}
+			return parseInt(strPort, 10);
 		} else if (range = parseRange(strPort)) {
 			const port = await findFreePort(host, range.start, range.end);
 			if (port !== undefined) {


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

fixes https://github.com/eclipse/che/issues/21711

I've proposed the same patch upstream https://github.com/microsoft/vscode/pull/161254
And this is a temporary fix while it's not fixed upstream.
