### PR TITLE
Run the DevFile Commands by calling the `che-terminal` extension's API

### DIFF
--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -49,7 +49,8 @@
     "url": "https://github.com/che-incubator/che-code.git"
   },
   "extensionDependencies": [
-    "eclipse-che.api"
+    "eclipse-che.api",
+    "eclipse-che.terminal"
   ],
   "jest": {
     "collectCoverage": true,

--- a/code/extensions/che-commands/src/extension.ts
+++ b/code/extensions/che-commands/src/extension.ts
@@ -8,21 +8,34 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+/* eslint-disable header/header */
+
 import * as vscode from 'vscode';
 import { CheTaskProvider } from './taskProvider';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	const channel: vscode.OutputChannel = vscode.window.createOutputChannel('Che Commands');
 
-	registerTaskProvider(context, channel);
-}
+	const cheAPI = await getExtensionAPI('eclipse-che.api');
+	const terminalExtAPI = await getExtensionAPI('eclipse-che.terminal');
 
-function registerTaskProvider(context: vscode.ExtensionContext, channel: vscode.OutputChannel) {
-	const taskProvider = new CheTaskProvider(channel);
+	const taskProvider = new CheTaskProvider(channel, cheAPI, terminalExtAPI);
 	const disposable = vscode.tasks.registerTaskProvider('che', taskProvider);
+
 	context.subscriptions.push(disposable);
 }
 
-export function deactivate(): void {
+async function getExtensionAPI(extID: string): Promise<any> {
+	const ext = vscode.extensions.getExtension(extID);
+	if (!ext) {
+		throw Error(`Extension ${extID} is not installed.`);
+	}
+	try {
+		return await ext.activate();
+	} catch {
+		throw Error(`Failed to activate ${extID} extension.`);
+	}
+}
 
+export function deactivate(): void {
 }

--- a/code/extensions/che-terminal/src/machine-exec-client.ts
+++ b/code/extensions/che-terminal/src/machine-exec-client.ts
@@ -127,13 +127,13 @@ export class MachineExecClient implements vscode.Disposable {
 	 * Asks the machine-exec server to start a new terminal session to the specified container.
 	 *
 	 * @param component name of the DevWorkspace component that represents a container to create a terminal session to
-	 * @param workdir optional working directory
 	 * @param commandLine optional command line to execute when starting a terminal session. If empty, machine-exec will start a default shell.
+	 * @param workdir optional working directory
 	 * @param columns the initial width of the new terminal
 	 * @param rows the initial height of the new terminal
 	 * @returns a TerminalSession object to manage the created terminal session
 	 */
-	async createTerminalSession(component: string, workdir?: string, commandLine?: string, columns: number = 80, rows: number = 24): Promise<TerminalSession> {
+	async createTerminalSession(component: string, commandLine?: string, workdir?: string, columns: number = 80, rows: number = 24): Promise<TerminalSession> {
 		const createTerminalSessionCall = {
 			identifier: {
 				machineName: component


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
1. `che-terminal` extension exposes its API to get a `vscode.Pseudoterminal` that is passed to a Tasks's `vscode.CustomExecution`.
2. Switches the `che-commands` extension to use `che-terminal` extension API when running the Devfile Commands.

This is step 2/3 in migrating from [the current implementation of the machine-exec-based terminal](https://github.com/che-incubator/che-code/blob/7.54.0/code/src/vs/server/node/che/remoteTerminalMachineExecChannel.ts), that replaces the built-in VS Code terminal, to [the dedicated extension](https://github.com/che-incubator/che-code/tree/main/code/extensions/che-terminal).
1/3 was introduced in https://github.com/che-incubator/che-code/pull/122.

### What issues does this PR fix or reference?
Related to:
- https://github.com/eclipse/che/issues/21673
- https://github.com/eclipse/che/issues/21626

### How to test this PR?
1. Start a DevWorkspace with the test project https://github.com/azatsarynnyy/java-spring-petclinic/tree/commands-ext
2. Try to run a Che Task. E.g.: `Terminal > Run Task... > che`.
3. The task should be executed as expected, without any visible changes. Under the hood, the task is executed by calling the `che-terminal` extension's API. It can be verified by checking the `Che Terminal` output channel (`View > Output`).
