### PR TITLE
Use a Command's label as Che-Code Task name

### DIFF
--- a/code/extensions/che-commands/src/taskProvider.ts
+++ b/code/extensions/che-commands/src/taskProvider.ts
@@ -37,7 +37,7 @@ export class CheTaskProvider implements vscode.TaskProvider {
 
 		const cheTasks: vscode.Task[] = devfileCommands!
 			.filter(command => command.exec?.commandLine)
-			.map(command => this.createCheTask(command.id, command.exec?.commandLine!, command.exec?.workingDir || '${PROJECT_SOURCE}', command.exec?.component!));
+			.map(command => this.createCheTask(command.exec?.label || command.id, command.exec?.commandLine!, command.exec?.workingDir || '${PROJECT_SOURCE}', command.exec?.component!));
 		return cheTasks;
 	}
 


### PR DESCRIPTION
Use a Command's label as Che-Code Task name

Issue: https://github.com/eclipse/che/issues/21625

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>