### PR TITLE
Don't ask for choosing a problem matcher when running a Devfile Command

### DIFF
--- a/code/extensions/che-commands/src/taskProvider.ts
+++ b/code/extensions/che-commands/src/taskProvider.ts
@@ -76,7 +76,7 @@ export class CheTaskProvider implements vscode.TaskProvider {
 		const execution = new vscode.CustomExecution(async (): Promise<vscode.Pseudoterminal> => {
 			return this.terminalExtAPI.getMachineExecPTY(component, command, expandEnvVariables(workdir));
 		});
-		const task = new vscode.Task(kind, vscode.TaskScope.Workspace, name, 'che', execution);
+		const task = new vscode.Task(kind, vscode.TaskScope.Workspace, name, 'che', execution, []);
 		return task;
 	}
 }


### PR DESCRIPTION
Don't ask for choosing a problem matcher when running a Devfile Command

Issue: https://github.com/eclipse/che/issues/21651 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>