### PR TITLE
Update `when` clause for che task definition

### DIFF
--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -94,7 +94,7 @@
             "description": "Target Container"
           }
         },
-        "when": "shellExecutionSupported"
+        "when": "customExecutionSupported"
       }
     ]
   }


### PR DESCRIPTION
As described in [the docs](https://code.visualstudio.com/api/extension-guides/task-provider#when-clause), Task Definition's `when` clause has no effect for Che-Code. But I'm updating it, as the Che Tasks are running [now via a `CustomExecution` API instead of `ShellExecution`](https://github.com/che-incubator/che-code/commit/922f909a6d1881d08c97222dbfbadad0d86048fd#diff-e505171c2bbd2db1494bbb49e7c7ccaad44644b923a12f6c5ca2ebdedd0fdbcdL80-R78).