### PR TITLE
Set the workspace folder on server start

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -79,4 +79,4 @@ fi
 echo "Node.js dir for running VS Code: $VSCODE_NODEJS_RUNTIME_DIR"
 
 # Launch che without connection-token, security is managed by Che
-"$VSCODE_NODEJS_RUNTIME_DIR/node" out/server-main.js --host "${CODE_HOST}" --port 3100 --without-connection-token
+"$VSCODE_NODEJS_RUNTIME_DIR/node" out/server-main.js --host "${CODE_HOST}" --port 3100 --without-connection-token --default-folder ${PROJECT_SOURCE}


### PR DESCRIPTION
### What does this PR do?
Sets the folder that VS Code should open by default.

When VS Code server starts, we provided it with `${PROJECT_SOURCE}` environment variable value as the `--default-folder`.
When the user's browser loads frontend, it receives that value as part of [the workbench web configuration](https://github.com/che-incubator/che-code/blob/717d2191a4f81a1859b613c29899f64d8c660e24/code/src/vs/server/node/webClientServer.ts#L303). Then, VS Code opens the corresponding folder. So, no need to load VS Code twice (as it used to be) to detect (on the first load) the folder that needs to be opened.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21400 and possibly https://github.com/eclipse/che/issues/21392

### How to test this PR?
1. Start a new DevWorkspace from the following test project: https://github.com/azatsarynnyy/java-spring-petclinic/tree/term-native.
2. Check that VS Code is loaded once with the correct path opened as the VS Code Workspace Folder.
