### PR TITLE
ci: Fix Dev image publishing at the Pull Request check

### DIFF
--- a/.github/workflows/pr-check-image-publish.yml
+++ b/.github/workflows/pr-check-image-publish.yml
@@ -47,7 +47,27 @@ jobs:
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_PULL_REQUESTS_USERNAME }}
-          password: ${{ secrets.QUAY_PULL_REQUESTS_PASSWORD }} 
+          password: ${{ secrets.QUAY_PULL_REQUESTS_PASSWORD }}
+      - name: Increase Swap Space # implemented for the Linux system only
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "Current swap area:"
+          sudo swapon --show
+
+          export SWAP_SIZE=7
+          export SWAP_FILE_PATH=$(swapon --show=NAME | tail -n 1)
+          
+          sudo swapoff $SWAP_FILE_PATH
+          sudo rm $SWAP_FILE_PATH
+          
+          sudo fallocate -l ${SWAP_SIZE}G $SWAP_FILE_PATH
+          sudo chmod 600 $SWAP_FILE_PATH
+          sudo mkswap $SWAP_FILE_PATH
+          sudo swapon $SWAP_FILE_PATH
+
+          echo "Updated swap area:"
+          sudo swapon --show 
       - name: Download assembly image
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION

### What does this PR do?
There is [Download dev image](https://github.com/che-incubator/che-code/blob/2529537f93db5431697ecf003783bc08a8d85368/.github/workflows/pr-check-image-publish.yml#L72) step within `Publish Image PR check` github workflow. It contains `docker load -i dev-pr.tgz` command. The command started failing when `dev-image.zip` became ~ 2GB.

<img width="824" alt="image" src="https://user-images.githubusercontent.com/5676062/197717071-919a8ece-ae91-4be0-9eea-5bd7f5d64979.png">

I guess the cause of the problem is: there isn’t enough memory for the command execution.
Taking into account that [github runner provides](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources):
- 7GB of RAM 
- 14 GB of SSD space 
- 4 GB for the swap space

my propose is: increase swap space to 7 GB.
In my PR I use instructions from [this resource](https://linuxize.com/post/how-to-add-swap-space-on-ubuntu-20-04/).

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21723

### How to test this PR?
It looks like `Publish Image PR check` github workflow takes content of the `pr-check-image-publish.yml` from the `main` branch (not from the PR branch). So, I had to push my changes to the `main` branch of my fork to check it.

The output for the `Increase Swap Space` step looks like:

<img width="589" alt="Screenshot 2022-10-28 at 08 51 19" src="https://user-images.githubusercontent.com/5676062/198513465-48efd7fe-6cac-44bf-ae26-45a1b3c7f977.png">

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>