### PR TITLE
Fix rounding issue when parsing CPU k8s resources

### DIFF
--- a/tools/devworkspace-handler/src/k8s/k8s-units.ts
+++ b/tools/devworkspace-handler/src/k8s/k8s-units.ts
@@ -101,7 +101,9 @@ export class K8SUnits {
     const i = Math.floor(Math.log(value) / Math.log(k));
     let computedValue = parseFloat((value / Math.pow(k, i)).toFixed(dm));
     if (i > 2) {
-      return `${computedValue * (i - 2) * 1000}m`;
+      // Take Math.floor to avoid float representation errors
+      let computedValueMillis = Math.floor(computedValue * (i - 2) * 1000)
+      return `${computedValueMillis}m`;
     } else {
       return `${parseFloat((value / Math.pow(k, i)).toFixed(dm))}${sizes[i]}`;
     }


### PR DESCRIPTION
### What does this PR do?
Fix issue where adding Kubernetes resource units results in invalid values:

```
k8sUnits.sumUnits("4000m", "30m", "cpu")
```
returns `4030.0000000000005m`

### What issues does this PR fix?
Part of https://github.com/eclipse/che/issues/21811

### How to test this PR?
`k8sUnits.sumUnits("4000m", "30m", "cpu")` should return `4030m`
