### PR TITLE
Adapt VS Code’s Workspace state restoration feature to Che world

### DIFF
--- a/code/src/vs/workbench/services/workspaces/browser/workspaces.ts
+++ b/code/src/vs/workbench/services/workspaces/browser/workspaces.ts
@@ -30,5 +30,5 @@ export function getSingleFolderWorkspaceIdentifier(folderUri: URI): ISingleFolde
 }
 
 function getWorkspaceId(uri: URI): string {
-	return hash(uri.toString()).toString(16);
+	return hash(window.location.href + uri.toString()).toString(16);
 }


### PR DESCRIPTION
### What does this PR do?
As I described in https://github.com/eclipse/che/issues/21813#issuecomment-1312751451, VS Code's Workspace state restoration feature doesn't work exactly as the Che user would expect. In short: VS Code manages the Workspaces states by the Workspace internal ID (actually URI) ignoring the fact that different DevWorkspaces can host the VS Code Workspaces with the same internal ID. That leads to such problems as described in https://github.com/eclipse/che/issues/21813.

This PR adapts VS Code’s Workspace state restoration feature to Che in such a way that VS Code manages its Workspaces states by `DevWorkspace ID + VS Code Workspace's internal ID`.

##### More technical details
With this patch, Che-Code will start including the DevWorkspace ID in VS Code's Workspace ID. As the VS Code Workspace's internal ID is used as a corresponding [Database's name suffix](https://github.com/microsoft/vscode/blob/b4fbff3218b1ec6102b44ff4283f523019ceb2f9/src/vs/workbench/services/storage/browser/storageService.ts#L336) in the browser's [IndexedDB Storage](https://github.com/microsoft/vscode/blob/b4fbff3218b1ec6102b44ff4283f523019ceb2f9/src/vs/workbench/services/storage/browser/storageService.ts#L300), these change leads to [VS Code Workspace Storage](https://github.com/microsoft/vscode/blob/b4fbff3218b1ec6102b44ff4283f523019ceb2f9/src/vs/workbench/services/storage/browser/storageService.ts#L300) save data not only per VS Code Workspace internal ID, but per a combination of `DevWorkspace ID + VS Code Workspace's internal ID`


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21813

### How to test this PR?
1. Start a new DevWorkspace with the Che-Code editor image `quay.io/che-incubator-pull-requests/che-code:pr-148-amd64` or use my test project https://github.com/azatsarynnyy/java-spring-petclinic/tree/ws-storage.
2. Try to open a few files and run some Tasks.
3. Try to restart DevWorkspace. VS Code should restore its state (e.g. reopen the files, show the recently running Tasks).
4. Remove DevWorkspace.
5. Start a new DevWorkspace with the same project.
6. VS Code should start the "clean" Workspace and should not try to restore the state of its Workspace as it's a new DevWorkspace.
