### PR TITLE
Align the colors of `try-in-web-ide` badges

### DIFF
--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -33,4 +33,4 @@ jobs:
           add_comment: true
           add_status: false
           web_ide_instance: https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com
-          comment_badge: https://img.shields.io/static/v1?label=Eclipse%20Che%20(nightly)&message=Dev%20cluster%20(for%20maintainers)&logo=eclipseche&color=FDB940&labelColor=525C86
+          comment_badge: https://img.shields.io/static/v1?label=Eclipse%20Che%20(nightly)&message=Dev%20cluster%20(for%20maintainers)&logo=eclipseche&color=525C86&labelColor=FDB940


### PR DESCRIPTION
### What does this PR do?
Makes the colors of both `try-in-web-ide` badges in the same style.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
n/a

### How to test this PR?

After merging, it should be 
![image](https://user-images.githubusercontent.com/1636395/203035682-cea1a82f-ca35-4c3d-92a7-895d0531fb20.png)
instead of 
![image](https://user-images.githubusercontent.com/1636395/203035943-27a05a4e-d68a-40c5-902f-3097f0654829.png)
