### PR TITLE
Auto-install the recommended extensions

### DIFF
--- a/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService.ts
@@ -146,6 +146,10 @@ export class ExtensionRecommendationNotificationService implements IExtensionRec
 		return config.ignoreRecommendations || !!config.showRecommendationsOnlyOnDemand;
 	}
 
+	hasToInstallRecommendedExtensionsAutomatically(): boolean {
+		return this.configurationService.getValue('extensionsAutoInstallRecommendations');
+	}
+
 	async promptImportantExtensionsInstallNotification(extensionIds: string[], message: string, searchValue: string, source: RecommendationSource): Promise<RecommendationsNotificationResult> {
 		const ignoredRecommendations = [...this.extensionIgnoredRecommendationsService.ignoredRecommendations, ...this.ignoredRecommendations];
 		extensionIds = extensionIds.filter(id => !ignoredRecommendations.includes(id));
@@ -245,6 +249,10 @@ export class ExtensionRecommendationNotificationService implements IExtensionRec
 	private showRecommendationsNotification(extensions: IExtension[], message: string, searchValue: string, source: RecommendationSource,
 		{ onDidInstallRecommendedExtensions, onDidShowRecommendedExtensions, onDidCancelRecommendedExtensions, onDidNeverShowRecommendedExtensionsAgain }: RecommendationsNotificationActions): CancelablePromise<RecommendationsNotificationResult> {
 		return createCancelablePromise<RecommendationsNotificationResult>(async token => {
+			if (this.hasToInstallRecommendedExtensionsAutomatically()) {
+				this.extensionManagementService.installExtensions(extensions.map(e => e.gallery!))
+				return RecommendationsNotificationResult.Accepted;
+			}
 			let accepted = false;
 			const choices: (IPromptChoice | IPromptChoiceWithMenu)[] = [];
 			const installExtensions = async (isMachineScoped?: boolean) => {

--- a/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService.ts
@@ -147,7 +147,7 @@ export class ExtensionRecommendationNotificationService implements IExtensionRec
 	}
 
 	hasToInstallRecommendedExtensionsAutomatically(): boolean {
-		return this.configurationService.getValue('extensionsAutoInstallRecommendations');
+		return this.configurationService.getValue('extensions.autoInstallRecommendations');
 	}
 
 	async promptImportantExtensionsInstallNotification(extensionIds: string[], message: string, searchValue: string, source: RecommendationSource): Promise<RecommendationsNotificationResult> {

--- a/code/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -163,6 +163,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				default: false,
 				tags: ['usesOnlineServices']
 			},
+			'extensions.autoInstallRecommendations': {
+				type: 'boolean',
+				description: localize('extensionsAutoInstallRecommendations', "When enabled, the extension recommendations will be installed automatically."),
+				default: true
+			},
 			'extensions.closeExtensionDetailsOnViewChange': {
 				type: 'boolean',
 				description: localize('extensionsCloseExtensionDetailsOnViewChange', "When enabled, editors with extension details will be automatically closed upon navigating away from the Extensions View."),


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
It modifies the VS Code's default experience of installing the recommended extensions in a way that the recommendations are installed automatically on VS Code start, without requiring the user's approval.

It's possible to opt-out of this new behavior with the new setting `extensions.autoInstallRecommendations`:
![image](https://user-images.githubusercontent.com/1636395/203783481-44a4f499-2315-447d-8877-0ea2de5d2bf5.png)

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21701
https://issues.redhat.com/browse/CRW-3483

### How to test this PR?
#### Use case1: Auto-installation enabled
1. Start a DevWorkspace from the test repository https://github.com/azatsarynnyy/java-spring-petclinic/tree/ext-auto-install. Or use your own repository with the Che-Code editor build that includes this patch, e.g.: `quay.io/che-incubator-pull-requests/che-code:153`.
2. Make sure that VS Code does not suggest installing the recommended extensions. There should be **no notification** like this:
![image](https://user-images.githubusercontent.com/1636395/203743375-46a5921b-5818-4c9a-9179-a75c3e34ec7a.png)
3. Open the `Extensions` view and make sure that either all the extensions declared in the `.vscode/extensions.json` file are already installed or the installation process is in progress. E.g.:
![Screenshot from 2022-11-24 10-20-36](https://user-images.githubusercontent.com/1636395/203745856-d0579664-4013-4079-9172-714e3398d542.png)

#### Use case 2: Auto-installation disabled
1. Disable the auto-installation mode in the user's scoped settings:
![image](https://user-images.githubusercontent.com/1636395/203749538-6d4462e4-4ab1-46b2-a0a5-02510bd33e92.png)
2. Remove the existing DevWorksapce and create a new one from the same test repository. 
3. Make sure VS Code suggests installing the extensions recommendations and auto-installation is not started without the user's confirmation.
