### PR TITLE
Auto-install the recommended extensions (backport to 7.56.x)

### DIFF
--- a/code/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -163,6 +163,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				default: false,
 				tags: ['usesOnlineServices']
 			},
+			'extensions.autoInstallRecommendations': {
+				type: 'boolean',
+				description: localize('extensionsAutoInstallRecommendations', "When enabled, the extension recommendations will be installed automatically."),
+				default: true
+			},
 			'extensions.closeExtensionDetailsOnViewChange': {
 				type: 'boolean',
 				description: localize('extensionsCloseExtensionDetailsOnViewChange', "When enabled, editors with extension details will be automatically closed upon navigating away from the Extensions View."),


### PR DESCRIPTION
### What does this PR do?
Backports https://github.com/che-incubator/che-code/pull/153 to 7.56.x

https://github.com/eclipse/che/issues/21701
https://issues.redhat.com/browse/CRW-3483
