### PR TITLE
docs: Update the README with the branding procedure from the docs PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,10 @@ Here are some examples of the UI elements in Visual Studio Code - Open Source th
 * The tab icon for the Get Started page
 * The application name in the **About** dialog
 
-
 ### Prerequisites
 
 * Bash
 * `docker`
-
 
 ### Procedure
 
@@ -131,7 +129,7 @@ Here are some examples of the UI elements in Visual Studio Code - Open Source th
 
 The following example shows all of the properties that you can customize by using this file:
 
-```
+```json
 {
     "nameShort": "Branded IDE",
     "nameLong": "Branded Instance of Eclipse Che with Branded Microsoft Visual Studio Code - Open Source IDE",
@@ -186,7 +184,7 @@ The following example shows all of the properties that you can customize by usin
 
 *Example. `/branding/workbench-config.json`*
 
-```
+```json
 {
 	"windowIndicator": {
 		"label": "$(eclipse-che) Eclipse Che",
@@ -213,7 +211,7 @@ The following example shows all of the properties that you can customize by usin
 
 *Example. `/branding/css/codicon.css`*
 
-```
+```css
 span.codicon.codicon-eclipse-che  {
 	background-image: url(./che/icon.svg);
 	width: 13px;
@@ -246,7 +244,7 @@ $ docker push <username>/vs-code-open-source:next
 
 *Example. `/che-editor.yaml` for the branded Visual Studio Code - Open Source*
 
-```
+```yaml
 inline:
   schemaVersion: 2.1.0
   metadata:
@@ -322,7 +320,6 @@ inline:
 ```
 
 :grey_exclamation: In this example, `quay.io/username/vs-code-open-source:next` specifies the container image of a branded Visual Studio Code - Open Source that will be pulled at workspace creation.
-
 
 ### Verification
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ The following example shows all of the properties that you can customize by usin
 }
 ```
 
+`eclipse-che` in `"label": "$(eclipse-che) Eclipse Che"` is from `span.codicon.codicon-eclipse-che` in `/branding/css/codicon.css` in the next step.
+
 5\. Create a `/branding/css/codicon.css` file with custom values.
 
 *Example. `/branding/css/codicon.css`*

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Add the `Code-OSS` remote by using for example the following command:
 $ git remote add upstream-code https://github.com/microsoft/vscode
 ```
 
-#### Pull changes from the remote Code
+#### Pulling changes from the remote Code
 
 For a release branch:
 
@@ -68,7 +68,7 @@ For the main branch:
 $ git subtree pull --prefix code upstream-code main
 ```
 
-#### Check the diff between local and remote
+#### Checking the diff between local and remote
 
 For a release branch:
 
@@ -82,7 +82,7 @@ For a main branch:
 $ git diff upstream-code/main main:code
 ```
 
-## How to fix the [`rebase-insiders`](https://github.com/che-incubator/che-code/actions/workflows/rebase-insiders.yml) Workflow?
+## Fixing the [`rebase-insiders`](https://github.com/che-incubator/che-code/actions/workflows/rebase-insiders.yml) Workflow?
 Upstream VS Code changes may bring a breakage to Che-Code. In this case, the [`rebase-insiders`](https://github.com/che-incubator/che-code/actions/workflows/rebase-insiders.yml) Workflow run is failed. To fix it, follow the steps below:
 1. Checkout to a new branch, e.g.`fix-rebase`.
 2. Fetch the latest changes from the upstream:
@@ -94,58 +94,247 @@ git fetch upstream-code main
 4. Fix the conflicts or other errors. **Note**, that`./rebase.sh` script also apllies the patches from the [`.rebase`](https://github.com/che-incubator/che-code/tree/main/.rebase) directory. Sometimes, it also requires some updates there.
 5. Open a PR with your changes.
 
-## Whitelabel/branding
- 
-There is a functionality to apply branding to some UI elements. The original data can be overridden by executing the [branding.sh](https://github.com/che-incubator/che-code/blob/main/branding/branding.sh) script. The script searches for the branding resources in the [branding folder](https://github.com/che-incubator/che-code/tree/main/branding). 
+## Branding the UI
 
-The `branding/product.json` file is crucial. 
-The values defined in the `branding/product.json` file override the [default values](https://github.com/che-incubator/che-code/blob/main/code/product.json). 
-Also the file serves data mapping for provided branding resources.
+   <details>
+          <summary>You can brand some of the UI elements in the Visual Studio Code - Open Source IDE with your corporate or product brand.</summary>
 
-Example of the `branding/product.json` file:
+\
+This means first adding brand-related files to the forked IDE repository, then building a container image of the branded IDE, and finally adding a `che-editor.yaml` file to the project repository.
+
+Here are some examples of the UI elements in Visual Studio Code - Open Source that you can brand:
+
+* Browser tab title and icon
+* The icon for the empty editor area when no editor is open
+* The Status Bar commands
+* The Status Bar icon
+* The Get Started page
+* The tab icon for the Get Started page
+* The application name in the **About** dialog
+
+
+### Prerequisites
+
+* Bash
+* `docker`
+
+
+### Procedure
+
+1\. Fork or download the Git [repository](https://github.com/che-incubator/che-code/tree/main/) of Visual Studio Code - Open Source IDE for Eclipse Che.
+
+2\. In the `/branding/` folder of the repository, create the `product.json` file, which maps custom branding resources.
+
+:bulb: In the `product.json` file, specify all paths relative the `/branding/` folder.
+
+*Example. `/branding/product.json`*
+
+The following example shows all of the properties that you can customize by using this file:
+
 ```
 {
-	"nameShort": "VS Code - Open Source",
-	"nameLong": "Red Hat OpenShift Dev Spaces with Microsoft Visual Studio Code - Open Source IDE",
-	"icons": {
-		"favicon": {
-			"universal": "icons/favicon.ico"
-		},
-		"welcome": {
-			"universal": "icons/dev-spaces.svg"
-		},
-		"statusBarItem": {
-			"universal": "icons/dev-spaces.svg"
-		},
-		"letterpress": {
-			"light": "icons/letterpress-light.svg",
-			"dark": "icons/letterpress-light.svg"
-		}
-	},
-	"remoteIndicatorCommands": {
-		"openDocumentationCommand": "Dev Spaces: Open Documentation",
-		"openDashboardCommand": "Dev Spaces: Open Dashboard",
-		"stopWorkspaceCommand": "Dev Spaces: Stop Workspace"
-	},
-	"workbenchConfigFilePath": "workbench-config.json",
-	"codiconCssFilePath": "css/codicon.css"
+    "nameShort": "Branded IDE",
+    "nameLong": "Branded Instance of Eclipse Che with Branded Microsoft Visual Studio Code - Open Source IDE",
+    "icons": {
+        "favicon": {
+            "universal": "icons/favicon.ico"
+        },
+        "welcome": {
+            "universal": "icons/icon.svg"
+        },
+        "statusBarItem": {
+            "universal": "icons/icon.svg"
+        },
+        "letterpress": {
+            "light": "icons/letterpress-light.svg",
+            "dark": "icons/letterpress-light.svg"
+        }
+    },
+    "remoteIndicatorCommands": {
+        "openDocumentationCommand": "Branded IDE: Open Documentation",
+        "openDashboardCommand": "Branded IDE: Open Dashboard",
+        "stopWorkspaceCommand": "Branded IDE: Stop Workspace"
+    },
+    "workbenchConfigFilePath": "workbench-config.json",
+    "codiconCssFilePath": "css/codicon.css"
 }
 ```
-- `nameShort` - The application name.
-- `nameLong` - This is used for the **Welcome** page, the **About** dialog, and browser tab title.
-- `favicon` - The icon for the browser tab title. It's the same for all themes.
-- `welcome` - The icon for the **Welcome** (**Get Started**) page tab title. It's the same for all themes.
-- `statusBarItem` - The icon for the status bar item. It's the same for all themes and must be defined as `codicon` in the `workbench-config.json` file and the `codicon` CSS styles.
-- `letterpress` - The icon for the main area when all editors are closed. It's possible to provide different icons for `light` and `dark` themes.
-- `remoteIndicatorCommands` - The names of commands provided by the [`Eclipse Che Remote`](https://github.com/che-incubator/che-code/blob/main/code/extensions/che-remote/package.nls.json) extension.
-- `workbenchConfigFilePath` - The config file path. See an [example of the config file](https://github.com/che-incubator/che-code/blob/main/code/src/vs/code/browser/workbench/che/workbench-config.json).
-- `codiconCssFilePath` - The codicon css file path. Must contain CSS styles for `codicon`s. The content of the file is appended to [the coressponding css file](https://github.com/che-incubator/che-code/blob/main/code/src/vs/base/browser/ui/codicons/codicon/codicon.css). See an [example of the content](https://github.com/che-incubator/che-code/blob/803b864e8411bd57d617dabddfd8a132fac6c743/code/src/vs/base/browser/ui/codicons/codicon/codicon.css#L29-L33).
 
-NOTE:
--  All paths in the `branding/product.json` file must be relative to the `branding` folder. 
-For example, the `workbenchConfigFilePath` field might have the `anyFolder/myConfigFiles/workbench-config.json` value. 
-This means that the config file can be found by the path: `che-code/branding/anyFolder/myConfigFiles/workbench-config.json`
-- Currently, the [branding.sh](https://github.com/che-incubator/che-code/blob/main/branding/branding.sh) script is not run automatically when building this project. It needs to be integrated into the build process of the [downstream branded project or product](https://github.com/redhat-developer/devspaces-images/blob/devspaces-3-rhel-8/devspaces-code/build/scripts/sync.sh#L96).
+`nameShort` is the application name for UI elements.
+
+`nameLong` is the application name that is used for the **Welcome** page, **About** dialog, and browser tab title.
+
+`favicon` is the icon for the browser tab title for all themes.
+
+`welcome` is the icon for the tab title of the **Get Started** page for all themes.
+
+`statusBarItem` is the icon for the bottom **Status Bar** for all themes. Define it as `codicon` in the `workbench-config.json` file and the `codicon` CSS styles.
+
+`letterpress` is the icon for the empty editor area when no editor is open. You can provide different icon files for `light` and `dark` themes.
+
+`remoteIndicatorCommands` is the names of commands provided by the [Eclipse Che Remote](https://github.com/che-incubator/che-code/blob/main/code/extensions/che-remote/package.nls.json) extension. Users can run these commands by clicking the **Status Bar**.
+
+`workbenchConfigFilePath` is the relative path to `workbench-config.json`, which is explained in one of the next steps.
+
+`codiconCssFilePath` is the relative path to `css/codicon.css`, which is explained in one of the next steps.
+
+:grey_exclamation: The values defined in the `/branding/product.json` file override the [default values](https://github.com/che-incubator/che-code/blob/main/code/product.json).
+
+3\. Add the icon files, which you specified in the `product.json` file in the previous step, to the repository.
+
+4\. Create a `/branding/workbench-config.json` file with custom values.
+
+*Example. `/branding/workbench-config.json`*
+
+```
+{
+	"windowIndicator": {
+		"label": "$(eclipse-che) Eclipse Che",
+		"tooltip": "Eclipse Che"
+	},
+	"configurationDefaults": {
+		"workbench.colorTheme": "Dark",
+		"workbench.colorCustomizations": {
+			"statusBarItem.remoteBackground": "#FDB940",
+			"statusBarItem.remoteForeground": "#525C86"
+		}
+	},
+	"initialColorTheme": {
+		"themeType": "dark",
+		"colors": {
+			"statusBarItem.remoteBackground": "#FDB940",
+			"statusBarItem.remoteForeground": "#525C86"
+		}
+	}
+}
+```
+
+5\. Create a `/branding/css/codicon.css` file with custom values.
+
+*Example. `/branding/css/codicon.css`*
+
+```
+span.codicon.codicon-eclipse-che  {
+	background-image: url(./che/icon.svg);
+	width: 13px;
+	height: 13px;
+}
+```
+
+6\. Run the `/branding/branding.sh` script. The [branding.sh](https://github.com/che-incubator/che-code/blob/main/branding/branding.sh) script searches for the branding resources in the [branding folder](https://github.com/che-incubator/che-code/tree/main/branding) and applies the changes.
+
+```
+$ ./branding/branding.sh
+```
+<!-- Currently, the [branding.sh](https://github.com/che-incubator/che-code/blob/main/branding/branding.sh) script is not run automatically when building this project. It needs to be integrated into the build process of the [downstream branded project or product](https://github.com/redhat-developer/devspaces-images/blob/devspaces-3-rhel-8/devspaces-code/build/scripts/sync.sh#L96). -->
+
+7\. Build the container image from the `/che-code/` directory and push the image to a container registry:
+
+```
+$ docker build -f build/dockerfiles/linux-musl.Dockerfile -t linux-musl-amd64 .
+
+$ docker build -f build/dockerfiles/linux-libc.Dockerfile -t linux-libc-amd64 .
+
+$ export DOCKER_BUILDKIT=1
+
+$ docker build -f build/dockerfiles/assembly.Dockerfile -t vs-code-open-source .
+
+$ docker push <username>/vs-code-open-source:next
+```
+
+8\. Create a `/.che/che-editor.yaml` file in the remote repository that you intend to clone into workspaces. This file must specify the container image of your customized Visual Studio Code - Open Source that is to be pulled for new workspaces.
+
+*Example. `/che-editor.yaml` for the branded Visual Studio Code - Open Source*
+
+```
+inline:
+  schemaVersion: 2.1.0
+  metadata:
+    name: che-code
+  commands:
+    - id: init-container-command
+      apply:
+        component: che-code-injector
+  events:
+    preStart:
+      - init-container-command
+  components:
+    - name: che-code-runtime-description
+      container:
+        image: quay.io/devfile/universal-developer-image:ubi8-latest
+        command:
+          - /checode/entrypoint-volume.sh
+        volumeMounts:
+          - name: checode
+            path: /checode
+        memoryLimit: 2Gi
+        memoryRequest: 256Mi
+        cpuLimit: 500m
+        cpuRequest: 30m
+        endpoints:
+          - name: che-code
+            attributes:
+              type: main
+              cookiesAuthEnabled: true
+              discoverable: false
+              urlRewriteSupported: true
+            targetPort: 3100
+            exposure: public
+            secure: false
+            protocol: https
+          - name: code-redirect-1
+            attributes:
+              discoverable: false
+              urlRewriteSupported: true
+            targetPort: 13131
+            exposure: public
+            protocol: http
+          - name: code-redirect-2
+            attributes:
+              discoverable: false
+              urlRewriteSupported: true
+            targetPort: 13132
+            exposure: public
+            protocol: http
+          - name: code-redirect-3
+            attributes:
+              discoverable: false
+              urlRewriteSupported: true
+            targetPort: 13133
+            exposure: public
+            protocol: http
+      attributes:
+        app.kubernetes.io/component: che-code-runtime
+        app.kubernetes.io/part-of: che-code.eclipse.org
+    - name: checode
+      volume: {}
+    - name: che-code-injector
+      container:
+        image: quay.io/username/vs-code-open-source:next <1>
+        command: ["/entrypoint-init-container.sh"]
+        volumeMounts:
+          - name: checode
+            path: /checode
+        memoryLimit: 128Mi
+        memoryRequest: 32Mi
+        cpuLimit: 500m
+        cpuRequest: 30m
+```
+
+:grey_exclamation: In this example, `quay.io/username/vs-code-open-source:next` specifies the container image of a branded Visual Studio Code - Open Source that will be pulled at workspace creation.
+
+
+### Verification
+
+1\. [Start a new workspace](https://www.eclipse.org/che/docs/stable/end-user-guide/starting-a-new-workspace-with-a-clone-of-a-git-repository/) with a clone of the project repository that contains the `che-editor.yaml` file.
+
+2\. Check that the configured UI elements are correctly branded in Visual Studio Code - Open Source in the workspace.
+
+---
+
+</details>
+
+<!-- FYI: https://github.com/redhat-developer/devspaces-images/tree/devspaces-3-rhel-8/devspaces-dashboard#branding -->
 
 # Builds
 

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Here are some examples of the UI elements in Visual Studio Code - Open Source th
 
 * Browser tab title and icon
 * The icon for the empty editor area when no editor is open
-* The Status Bar commands
-* The Status Bar icon
-* The Get Started page
-* The tab icon for the Get Started page
+* The **Status Bar** commands
+* The **Status Bar** icon
+* The **Get Started** page
+* The tab icon for the **Get Started** page
 * The application name in the **About** dialog
 
 ### Prerequisites
@@ -235,7 +235,7 @@ $ docker build -f build/dockerfiles/linux-libc.Dockerfile -t linux-libc-amd64 .
 
 $ export DOCKER_BUILDKIT=1
 
-$ docker build -f build/dockerfiles/assembly.Dockerfile -t vs-code-open-source .
+$ docker build -f build/dockerfiles/assembly.Dockerfile -t vs-code-open-source:next .
 
 $ docker push <username>/vs-code-open-source:next
 ```
@@ -308,7 +308,7 @@ inline:
       volume: {}
     - name: che-code-injector
       container:
-        image: quay.io/username/vs-code-open-source:next <1>
+        image: quay.io/username/vs-code-open-source:next
         command: ["/entrypoint-init-container.sh"]
         volumeMounts:
           - name: checode

--- a/README.md
+++ b/README.md
@@ -330,8 +330,6 @@ inline:
 
 2\. Check that the configured UI elements are correctly branded in Visual Studio Code - Open Source in the workspace.
 
----
-
 </details>
 
 <!-- FYI: https://github.com/redhat-developer/devspaces-images/tree/devspaces-3-rhel-8/devspaces-dashboard#branding -->

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ The following example shows all of the properties that you can customize by usin
 ```json
 {
 	"windowIndicator": {
-		"label": "$(eclipse-che) Eclipse Che",
-		"tooltip": "Eclipse Che"
+		"label": "$(eclipse-che) Branded IDE",
+		"tooltip": "Branded IDE"
 	},
 	"configurationDefaults": {
 		"workbench.colorTheme": "Dark",

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ git remote add upstream-code https://github.com/microsoft/vscode
 git fetch upstream-code main
 ```
 3. `./rebase.sh`
-4. Fix the conflicts or other errors. **Note**, that`./rebase.sh` script also apllies the patches from the [`.rebase`](https://github.com/che-incubator/che-code/tree/main/.rebase) directory. Sometimes, it also requires some updates there.
+4. Fix the conflicts or other errors. **Note**, that`./rebase.sh` script also applies the patches from the [`.rebase`](https://github.com/che-incubator/che-code/tree/main/.rebase) directory. Sometimes, it also requires some updates there.
 5. Open a PR with your changes.
 
 ## Branding the UI

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Add the `Code-OSS` remote by using for example the following command:
 $ git remote add upstream-code https://github.com/microsoft/vscode
 ```
 
-#### Pulling changes from the remote Code
+#### Pulling changes from upstream https://github.com/microsoft/vscode
 
 For a release branch:
 
@@ -321,7 +321,7 @@ inline:
         cpuRequest: 30m
 ```
 
-:grey_exclamation: In this example, `quay.io/username/vs-code-open-source:next` specifies the container image of a branded Visual Studio Code - Open Source that will be pulled at workspace creation.
+:grey_exclamation: In this example, `quay.io/branding-organization/vs-code-open-source:next` specifies the container image of a branded Visual Studio Code - Open Source IDE that will be pulled at workspace creation.
 
 ### Verification
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ inline:
       volume: {}
     - name: che-code-injector
       container:
-        image: quay.io/username/vs-code-open-source:next
+        image: quay.io/branding-organization/vs-code-open-source:next
         command: ["/entrypoint-init-container.sh"]
         volumeMounts:
           - name: checode

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ $ export DOCKER_BUILDKIT=1
 
 $ docker build -f build/dockerfiles/assembly.Dockerfile -t vs-code-open-source:next .
 
-$ docker push <username>/vs-code-open-source:next
+$ docker push <branding-organization>/vs-code-open-source:next
 ```
 
 8\. Create a `/.che/che-editor.yaml` file in the remote repository that you intend to clone into workspaces. This file must specify the container image of your customized Visual Studio Code - Open Source that is to be pulled for new workspaces.


### PR DESCRIPTION
…rewritten in Markdown) to the che-code repo's README

### What does this PR do?
This PR moves the content from https://github.com/eclipse-che/che-docs/pull/2467 that has been translated into Markdown into https://github.com/che-incubator/che-code/blob/main/README.md

Preview: https://github.com/che-incubator/che-code/blob/17351072cb44ac84afef0565ea6c5e6d919c0c39/README.md

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->

https://github.com/eclipse/che/issues/21682
https://issues.redhat.com/browse/CRW-3199
https://issues.redhat.com/browse/RHDEVDOCS-4586

### How to test this PR?

