### PR TITLE
More automation when the auto-rebase has failed

### DIFF
--- a/.github/fix_auto-rebase_issue_template.md
+++ b/.github/fix_auto-rebase_issue_template.md
@@ -1,0 +1,15 @@
+---
+title: Che-Code automatic rebase against upstream VS Code is failed
+assignees: azatsarynnyy
+labels: area/editor/che-code, kind/task, severity/P1, sprint/current, team/editors
+
+---
+
+### Is your task related to a problem? Please describe
+The GitHub Workflow has been unable to update Che-Code with the latest VS Code patches and needs human attention.
+The Workflow has been disabled.
+
+### Describe the solution you'd like
+1. See the output of [the failed job](https://github.com/che-incubator/che-code/actions/workflows/rebase-insiders.yml).
+2. Perform the rebase manually (fixing the detected merge conflicts). For the detailed steps, see [the instructions](https://github.com/che-incubator/che-code#how-to-fix-the-rebase-insiders-workflow).
+3. Enable the [GitHub Workflow](https://github.com/che-incubator/che-code/actions/workflows/rebase-insiders.yml).

--- a/.github/workflows/rebase-insiders.yml
+++ b/.github/workflows/rebase-insiders.yml
@@ -41,6 +41,22 @@ jobs:
       - name: rebase
         run: |
           ./rebase.sh
+      - name: Create an issue
+        if: failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/fix_auto-rebase_issue_template.md
+      - name: Disable the Workflow
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            /repos/azatsarynnyy/che-editor-test/actions/workflows/test.yaml/disable
       - name: Validate tests on libc image
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/amd64 -f build/dockerfiles/linux-libc.Dockerfile .
@@ -48,5 +64,4 @@ jobs:
         run: |
           set -e
           git push origin main
-
 

--- a/.github/workflows/rebase-insiders.yml
+++ b/.github/workflows/rebase-insiders.yml
@@ -56,7 +56,7 @@ jobs:
           gh api \
             --method PUT \
             -H "Accept: application/vnd.github+json" \
-            /repos/azatsarynnyy/che-editor-test/actions/workflows/test.yaml/disable
+            /repos/che-incubator/che-code/actions/workflows/rebase-insiders.yml/disable
       - name: Validate tests on libc image
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/amd64 -f build/dockerfiles/linux-libc.Dockerfile .
@@ -64,4 +64,5 @@ jobs:
         run: |
           set -e
           git push origin main
+
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
Automates one more repetitive step that I'm usually doing manually when auto-rebase Workflow is failed.
Now, it should create an issue assigned to me so I get notified by GitHub. Also, it disables the Workflow to prevent redundant runs until the probelm is fixed.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
One step for https://github.com/eclipse/che/issues/21788

### How to test this PR?

