### PR TITLE
feat: Handle disconnection according to the dev workspace status

### DIFF
--- a/.rebase/replace/code/src/vs/workbench/contrib/remote/browser/remote.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/contrib/remote/browser/remote.ts.json
@@ -1,0 +1,34 @@
+[
+    {
+        "from": "import { getVirtualWorkspaceLocation } from 'vs/platform/workspace/common/virtualWorkspace';",
+        "by": "import { getVirtualWorkspaceLocation } from 'vs/platform/workspace/common/virtualWorkspace';\\\nimport { IRequestService } from 'vs/platform/request/common/request';\\\nimport { CheDisconnectionHandler } from 'vs/workbench/contrib/remote/browser/che/remote';\\\nimport { INotificationService } from 'vs/platform/notification/common/notification';\\\nimport { IEnvironmentVariableService } from 'vs/workbench/contrib/terminal/common/environmentVariable';"
+    },
+    {
+        "from": "private _reloadWindowShown: boolean = false;",
+        "by": "private _reloadWindowShown: boolean = false;\\\n\\\tprivate cheDisconnectionHandler: CheDisconnectionHandler;"
+    },
+    {
+        "from": "\\@IProgressService progressService: IProgressService,",
+        "by": "\\@IProgressService progressService: IProgressService,\\\n\\\t\\\t\\@IRequestService requestService: IRequestService,\\\n\\\t\\\t\\@INotificationService notificationService: INotificationService,\\\n\\\t\\\t\\@IEnvironmentVariableService environmentVariableService: IEnvironmentVariableService,"
+    },
+	{
+		"from": "super();",
+		"by": "super();\\\n\\\t\\\tthis.cheDisconnectionHandler = new CheDisconnectionHandler(commandService, dialogService, notificationService, requestService, environmentVariableService);"
+	},
+	{
+		"from": "case PersistentConnectionEventType.ConnectionLost:",
+		"by": "case PersistentConnectionEventType.ConnectionLost:\\\n\\\t\\\t\\\t\\\t\\\t\\\tif (this.cheDisconnectionHandler.canHandle(e.millisSinceLastIncomingData)) {\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tthis.cheDisconnectionHandler.handle(e.type);\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tbreak;\\\n\\\t\\\t\\\t\\\t\\\t\\\t}"
+	},
+	{
+		"from": "case PersistentConnectionEventType.ReconnectionWait:",
+		"by": "case PersistentConnectionEventType.ReconnectionWait:\\\n\\\t\\\t\\\t\\\t\\\t\\\tif (this.cheDisconnectionHandler.canHandle(e.millisSinceLastIncomingData)) {\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tthis.cheDisconnectionHandler.handle(e.type);\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tbreak;\\\n\\\t\\\t\\\t\\\t\\\t\\\t}"
+	},
+	{
+		"from": "case PersistentConnectionEventType.ReconnectionRunning:",
+		"by": "case PersistentConnectionEventType.ReconnectionRunning:\\\n\\\t\\\t\\\t\\\t\\\t\\\tif (this.cheDisconnectionHandler.canHandle(e.millisSinceLastIncomingData)) {\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tthis.cheDisconnectionHandler.handle(e.type);\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tbreak;\\\n\\\t\\\t\\\t\\\t\\\t\\\t}"
+	},
+	{
+		"from": "case PersistentConnectionEventType.ReconnectionPermanentFailure:",
+		"by": "case PersistentConnectionEventType.ReconnectionPermanentFailure:\\\n\\\t\\\t\\\t\\\t\\\t\\\tif (this.cheDisconnectionHandler.canHandle(e.millisSinceLastIncomingData)) {\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tthis.cheDisconnectionHandler.handle(e.type);\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tbreak;\\\n\\\t\\\t\\\t\\\t\\\t\\\t}"
+	}
+]

--- a/code/extensions/che-api/src/extension.ts
+++ b/code/extensions/che-api/src/extension.ts
@@ -62,5 +62,14 @@ export async function activate(_extensionContext: vscode.ExtensionContext): Prom
         },
     };
 
+	const k8sDevWorkspaceEnvVariables = container.get(K8sDevWorkspaceEnvVariables);
+	const dashboardUrl = k8sDevWorkspaceEnvVariables.getDashboardURL();
+	const workspaceNamespace = k8sDevWorkspaceEnvVariables.getWorkspaceNamespace();
+	const workspaceName = k8sDevWorkspaceEnvVariables.getWorkspaceName();
+	
+	_extensionContext.environmentVariableCollection.append('DASHBOARD_URL', dashboardUrl);
+	_extensionContext.environmentVariableCollection.append('WORKSPACE_NAME', workspaceName);
+	_extensionContext.environmentVariableCollection.append('WORKSPACE_NAMESPACE', workspaceNamespace);
+
     return api;
 }

--- a/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable header/header */
+
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { asJson, IRequestService } from 'vs/platform/request/common/request';
+import { IEnvironmentVariableService } from 'vs/workbench/contrib/terminal/common/environmentVariable';
+
+export enum DevWorkspaceStatus {
+	FAILED = 'Failed',
+	FAILING = 'Failing',
+	STARTING = 'Starting',
+	TERMINATING = 'Terminating',
+	RUNNING = 'Running',
+	STOPPED = 'Stopped',
+	STOPPING = 'Stopping',
+}
+
+export type Status = {
+	phase: string,
+	message: string
+}
+
+export type Metadata = {
+	annotations: { [key: string]: string }
+}
+
+export type DevWorkspaceLike = {
+	status: Status,
+	metadata: Metadata
+}
+
+export class DevWorkspaceAssistant {
+	static STOPPED_BY_ANNOTATION = 'controller.devfile.io/stopped-by';
+	static INACTIVITY_REASON = 'inactivity';
+	static RUN_TIMEOUT_REASON = 'run-timeout';
+
+	private dashboardUrl: string | undefined;
+	private getDevWorkspaceUrl: string | undefined;
+	private restartingDevWorkspaceUrl: string | undefined;
+
+	constructor(private requestService: IRequestService, private environmentVariableService: IEnvironmentVariableService) { }
+
+	async getDevWorkspace(): Promise<DevWorkspaceLike> {
+		const url = this.getWorkspaceUrl();
+		const context = await this.requestService.request({
+			type: 'get',
+			url,
+			timeout: 5000
+		}, CancellationToken.None);
+		const result = await asJson(context);
+		return result as DevWorkspaceLike;
+	}
+
+	getDashboardUrl(): string {
+		if (!this.dashboardUrl) {
+			this.provideWorkspaceUrls();
+		}
+		return this.dashboardUrl!;
+	}
+
+	getWorkspaceUrl(): string {
+		if (!this.getDevWorkspaceUrl) {
+			this.provideWorkspaceUrls();
+		}
+		return this.getDevWorkspaceUrl!;
+	}
+
+	getRestartingWorkspaceUrl(): string {
+		if (!this.restartingDevWorkspaceUrl) {
+			this.provideWorkspaceUrls();
+		}
+		return this.restartingDevWorkspaceUrl!;
+	}
+
+	private provideWorkspaceUrls(): void {
+		const envs = this.environmentVariableService.collections;
+		const apiEnvs = envs.get('eclipse-che.api');
+		if (!apiEnvs) {
+			throw new Error('Che API is not available');
+		}
+
+		const dashboardUrl = apiEnvs?.map.get('DASHBOARD_URL')?.value;
+		if (!dashboardUrl) {
+			throw new Error('Env variable for the Che Dashboard URL is not provided');
+		}
+
+		const workspaceNamespace = apiEnvs?.map.get('WORKSPACE_NAMESPACE')?.value;
+		if (!workspaceNamespace) {
+			throw new Error('Env variable for the Che workspace namespace is not provided');
+		}
+
+		const workspaceName = apiEnvs?.map.get('WORKSPACE_NAME')?.value;
+		if (!workspaceName) {
+			throw new Error('Env variable for the Che workspace name is not provided');
+		}
+
+		this.dashboardUrl = dashboardUrl;
+		this.restartingDevWorkspaceUrl = `${dashboardUrl}/dashboard/#/ide/${workspaceNamespace}/${workspaceName}`;
+		this.getDevWorkspaceUrl = `${dashboardUrl}/dashboard/api/namespace/${workspaceNamespace}/devworkspaces/${workspaceName}`;
+	}
+
+	restartWorkspace(): void {
+		const restartingDevWorkspaceUrl = this.getRestartingWorkspaceUrl();
+		window.location.href = restartingDevWorkspaceUrl;
+	}
+
+	goToDashboard(): void {
+		const dashboardUrl = this.getDashboardUrl();
+		window.location.href = dashboardUrl;
+	}
+}

--- a/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
@@ -1,0 +1,196 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable header/header */
+
+import Severity from 'vs/base/common/severity';
+import * as nls from 'vs/nls';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { INotificationService, IPromptChoice } from 'vs/platform/notification/common/notification';
+import { PersistentConnectionEventType } from 'vs/platform/remote/common/remoteAgentConnection';
+import { IRequestService } from 'vs/platform/request/common/request';
+import { ReloadWindowAction } from 'vs/workbench/browser/actions/windowActions';
+import { DevWorkspaceAssistant, DevWorkspaceLike, DevWorkspaceStatus } from 'vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant';
+import { IEnvironmentVariableService } from 'vs/workbench/contrib/terminal/common/environmentVariable';
+
+const CANCEL_LABEL = nls.localize('cancel', "Cancel");
+const RELOAD_WINDOW_LABEL = nls.localize('reloadWindow', "Reload Window");
+const RESTART_WORKSPACE_LABEL = nls.localize('disconnectionHandler.button.restart', 'Restart your workspace');
+const RETURN_TO_DASHBOARD_LABEL = nls.localize('disconnectionHandler.button.returnToDashboard', 'Return to dashboard');
+
+const WORKSPACE_STOPPED = nls.localize('disconnectionHandler.message.workspaceStopped', 'Your workspace is not running.');
+const WORKSPACE_FAILED = nls.localize('disconnectionHandler.message.workspaceFailed', 'The workspace has failed with the following error');
+const WORKSPACE_STOPPED_BY_INACTIVITY = nls.localize('disconnectionHandler.message.workspaceStoppedByInactivity', 'Your workspace has stopped due to inactivity.');
+const WORKSPACE_STOPPED_BY_TIMEOUT = nls.localize('disconnectionHandler.message.workspaceStoppedByTimeout', 'Your workspace has stopped because it has reached the run timeout.');
+const CAN_NOT_RECONNECT = nls.localize('disconnectionHandler.message.canNotReconnect', 'Cannot reconnect. Please reload the window.');
+
+export enum DisconnectionHandlerStatus {
+	AVAILABLE = 'Available',
+	IN_PROGRESS = 'InProgress',
+	USER_ACTION_WAITING = 'waiting for the user action',
+	FAILED = 'Failed'
+}
+
+/**
+ * Time for the Che disconnection handler to detect (and handle) if a dev workspace was stopped and figure out the reason the workspace was stopped 
+ * The default behaviour should be applied if the Che handler can not detect the state of the workspace during this time.
+ */
+const DISCONNECTION_HANDLING_TIME = 30 * 1000; // 30 seconds
+
+export class CheDisconnectionHandler {
+	private devWorkspaceAssistant: DevWorkspaceAssistant;
+	private status: DisconnectionHandlerStatus = DisconnectionHandlerStatus.AVAILABLE;
+
+	constructor(
+		private commandService: ICommandService,
+		private dialogService: IDialogService,
+		private notificationService: INotificationService,
+		requestService: IRequestService,
+		environmentVariableService: IEnvironmentVariableService
+	) {
+		this.devWorkspaceAssistant = new DevWorkspaceAssistant(requestService, environmentVariableService);
+	}
+
+	canHandle(millisSinceLastIncomingData: number): boolean {
+		// the Che handler is waiting for the user action - so, the default behaviour should NOT be applied
+		if (this.status === DisconnectionHandlerStatus.USER_ACTION_WAITING) {
+			return true;
+		}
+
+		// the handler can not get the dev workspace state
+		if (this.status === DisconnectionHandlerStatus.FAILED) {
+			return false;
+		}
+
+		// the default behaviour should be applied if the Che handler can not detect the state of the workspace during this time
+		if (millisSinceLastIncomingData > DISCONNECTION_HANDLING_TIME) {
+			return false;
+		}
+		return true;
+	}
+
+	async handle(type: PersistentConnectionEventType): Promise<void> {
+		if (this.status !== DisconnectionHandlerStatus.AVAILABLE) {
+			return;
+		}
+
+		this.status = DisconnectionHandlerStatus.IN_PROGRESS;
+		let devWorkspace;
+		try {
+			devWorkspace = await this.devWorkspaceAssistant.getDevWorkspace();
+		} catch (error) {
+			this.status = DisconnectionHandlerStatus.FAILED;
+		}
+
+		if (!devWorkspace || !devWorkspace.status) {
+			return;
+		}
+
+		const workspacePhase = devWorkspace.status.phase;
+		if (workspacePhase === DevWorkspaceStatus.STARTING || workspacePhase === DevWorkspaceStatus.RUNNING) {
+			return this.onDisconnectionRunningWorkspace(type);
+		}
+
+		return this.onDisconnectionStoppedWorkspace(devWorkspace);
+	}
+
+	// handle disconnection when dev workspace is not stopped
+	protected async onDisconnectionRunningWorkspace(type: PersistentConnectionEventType): Promise<void> {
+		if (type !== PersistentConnectionEventType.ReconnectionPermanentFailure) {
+			// continue to track state of the dev workspace to detect if the workspace is stopped
+			this.status = DisconnectionHandlerStatus.AVAILABLE;
+			return;
+		}
+
+		this.status = DisconnectionHandlerStatus.USER_ACTION_WAITING;
+
+		const showResult = await this.dialogService.show(Severity.Error, CAN_NOT_RECONNECT, [RELOAD_WINDOW_LABEL, CANCEL_LABEL], { cancelId: 1, custom: true });
+
+		const choice = showResult.choice;
+		if (choice === 0) {
+			return this.commandService.executeCommand(ReloadWindowAction.ID);
+		}
+
+		if (choice === 1) {
+			const reloadWindowChoice: IPromptChoice = {
+				label: RELOAD_WINDOW_LABEL,
+				isSecondary: false,
+				run: () => {
+					this.commandService.executeCommand(ReloadWindowAction.ID);
+				}
+			};
+			const cancelChoice: IPromptChoice = {
+				label: CANCEL_LABEL,
+				isSecondary: false,
+				run: () => { }
+			};
+			this.notificationService.prompt(Severity.Error, CAN_NOT_RECONNECT, [reloadWindowChoice, cancelChoice], { sticky: true });
+		}
+	}
+
+	// handle disconnection when dev workspace is stopped
+	protected async onDisconnectionStoppedWorkspace(devWorkspace: DevWorkspaceLike): Promise<void> {
+		// the dev workspace is not running, so it should be restarted
+		this.status = DisconnectionHandlerStatus.USER_ACTION_WAITING;
+
+		const workspaceAnnotations = devWorkspace.metadata?.annotations;
+		if (workspaceAnnotations) {
+			if (workspaceAnnotations[DevWorkspaceAssistant.STOPPED_BY_ANNOTATION] === DevWorkspaceAssistant.INACTIVITY_REASON) {
+				return this.displayDialog(WORKSPACE_STOPPED_BY_INACTIVITY, Severity.Warning);
+			}
+
+			if (workspaceAnnotations[DevWorkspaceAssistant.STOPPED_BY_ANNOTATION] === DevWorkspaceAssistant.RUN_TIMEOUT_REASON) {
+				return this.displayDialog(WORKSPACE_STOPPED_BY_TIMEOUT, Severity.Warning);
+			}
+		}
+
+		const workspacePhase = devWorkspace.status.phase;
+		const statusMessage = devWorkspace.status?.message;
+		if (workspacePhase === DevWorkspaceStatus.FAILED && statusMessage) {
+			return this.displayDialog(`${WORKSPACE_FAILED}: ${statusMessage}`, Severity.Error);
+		}
+
+		return this.displayDialog(WORKSPACE_STOPPED, Severity.Warning);
+	}
+
+	protected async displayDialog(message: string, severity: Severity): Promise<void> {
+		const response = await this.dialogService.show(severity, message, [RESTART_WORKSPACE_LABEL, RETURN_TO_DASHBOARD_LABEL], { cancelId: -1 });
+		switch (response.choice) {
+			case 0:
+				this.devWorkspaceAssistant.restartWorkspace();
+				break;
+			case 1:
+				this.devWorkspaceAssistant.goToDashboard();
+				break;
+			case -1:
+				return this.displayNotification(severity, message);
+			default:
+				break;
+		}
+	}
+
+	protected displayNotification(severity: Severity, message: string): void {
+		const restartWorkspaceChoice: IPromptChoice = {
+			label: RESTART_WORKSPACE_LABEL,
+			isSecondary: false,
+			run: () => {
+				this.devWorkspaceAssistant.restartWorkspace();
+			}
+		};
+		const goToDashboardChoice: IPromptChoice = {
+			label: RETURN_TO_DASHBOARD_LABEL,
+			isSecondary: false,
+			run: () => {
+				this.devWorkspaceAssistant.goToDashboard();
+			}
+		};
+		this.notificationService.prompt(severity, message, [restartWorkspaceChoice, goToDashboardChoice], { sticky: true });
+	}
+}

--- a/rebase.sh
+++ b/rebase.sh
@@ -197,7 +197,19 @@ apply_code_vs_server_web_client_server_changes() {
   git add code/src/vs/server/node/webClientServer.ts > /dev/null 2>&1
 }
 
-
+# Apply changes on code/src/vs/workbench/contrib/remote/browser/remote.ts file
+apply_code_vs_workbench_contrib_remote_browser_remote_changes() {
+  
+  echo "  ⚙️ reworking code/src/vs/workbench/contrib/remote/browser/remote.ts..."
+  # reset the file from what is upstream
+  git checkout --theirs code/src/vs/workbench/contrib/remote/browser/remote.ts > /dev/null 2>&1
+  
+  # now apply again the changes
+  apply_replace code/src/vs/workbench/contrib/remote/browser/remote.ts
+  
+  # resolve the change
+  git add code/src/vs/workbench/contrib/remote/browser/remote.ts > /dev/null 2>&1
+}
 
 # Will try to identify the conflicting files and for some of them it's easy to re-apply changes
 resolve_conflicts() {
@@ -220,6 +232,8 @@ resolve_conflicts() {
       apply_code_vs_platform_remote_browser_factory_changes
     elif [[ "$conflictingFile" == "code/src/vs/server/node/webClientServer.ts" ]]; then
       apply_code_vs_server_web_client_server_changes
+	elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/remote/browser/remote.ts" ]]; then
+      apply_code_vs_workbench_contrib_remote_browser_remote_changes
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"
       exit 1


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

### What does this PR do?
Handle disconnection according to the dev workspace status:
- Run timeout
<img width="638" alt="image" src="https://user-images.githubusercontent.com/5676062/212884051-c0861617-527f-4ca7-9c6a-1e50920409a7.png">

- Inactivity timeout
<img width="638" alt="image" src="https://user-images.githubusercontent.com/5676062/212888813-ebc11ee3-b974-4d6e-b58d-23556c523b0b.png">

- An error
<img width="638" alt="image" src="https://user-images.githubusercontent.com/5676062/212887755-fcf0147e-ce3d-4f92-b35d-bfb98484e518.png">

- Workspace is not running
<img width="638" alt="image" src="https://user-images.githubusercontent.com/5676062/212888224-77071266-fd6a-4137-9277-1811ba37fe8c.png">

 Within testing I detected the following unusual use case:
- the disconnection happened
- the API responds that the workspace is running
- dashboard displays the workspace as running
- but the workspace is not usable

I've added some logic to propose reloading the window for such use case - it fixes the disconnection. See the behaviour on the video.

https://user-images.githubusercontent.com/5676062/212892918-088eb7c7-002b-442f-99dd-a427037ab099.mp4

    

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->

https://github.com/eclipse/che/issues/21610

### How to test this PR?
It's possible to change the corresponding properties to test use cases related to timeouts:
<details>
<summary>See screenshot here </summary>
<img width="752" alt="timeouts" src="https://user-images.githubusercontent.com/5676062/212895573-1c220099-657f-47b3-b0ea-83536f849083.png">

</details>


#### Run timeout
1. Set the workspace run timeout (`checluster.spec.devEnvironments.secondsOfRunBeforeIdling`) to 120, for example.
2. Wait about 120 seconds.
3. The corresponding dialog should be displayed.

####  Inactivity timeout
1. Set the workspace inactivity timeout (`checluster.spec.devEnvironments.secondsOfInactivityBeforeIdling`) to 100, for example.
2. Do not interact with the workspace 100 seconds.
3. The corresponding dialog should be displayed.

#### An error
I tested the use case using minikube:
- start a workspace using minikube
- go to your local terminal => `minikube ssh` => `docker ps`
- detect a container with the running `VS Code` and stop it, like: `docker stop d9bd0222b513`
 
<img width="657" alt="docker_ps" src="https://user-images.githubusercontent.com/5676062/212900919-32031a41-91ca-441c-ae14-86caf011d3ce.png">
 

#### Workspace is not running
The use case is related to the any case when 
- a workspace is not running
- we can not detect an error, timeout or any reason of the stopped workspace

You can just stop a workspace using dashboard to test it.
