### PR TITLE
Rename the Task Group: `che` > `devfile`

### DIFF
--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -76,7 +76,7 @@
   "contributes": {
     "taskDefinitions": [
       {
-        "type": "che",
+        "type": "devfile",
         "required": [
           "command"
         ],

--- a/code/extensions/che-commands/src/extension.ts
+++ b/code/extensions/che-commands/src/extension.ts
@@ -11,16 +11,16 @@
 /* eslint-disable header/header */
 
 import * as vscode from 'vscode';
-import { CheTaskProvider } from './taskProvider';
+import { DevfileTaskProvider } from './taskProvider';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-	const channel: vscode.OutputChannel = vscode.window.createOutputChannel('Che Commands');
+	const channel: vscode.OutputChannel = vscode.window.createOutputChannel('Devfile Commands');
 
 	const cheAPI = await getExtensionAPI('eclipse-che.api');
 	const terminalExtAPI = await getExtensionAPI('eclipse-che.terminal');
 
-	const taskProvider = new CheTaskProvider(channel, cheAPI, terminalExtAPI);
-	const disposable = vscode.tasks.registerTaskProvider('che', taskProvider);
+	const taskProvider = new DevfileTaskProvider(channel, cheAPI, terminalExtAPI);
+	const disposable = vscode.tasks.registerTaskProvider('devfile', taskProvider);
 
 	context.subscriptions.push(disposable);
 }

--- a/code/extensions/che-commands/src/taskProvider.ts
+++ b/code/extensions/che-commands/src/taskProvider.ts
@@ -13,13 +13,13 @@
 import { V1alpha2DevWorkspaceSpecTemplate, V1alpha2DevWorkspaceSpecTemplateCommands } from '@devfile/api';
 import * as vscode from 'vscode';
 
-interface CheTaskDefinition extends vscode.TaskDefinition {
+interface DevfileTaskDefinition extends vscode.TaskDefinition {
 	command: string;
 	workdir?: string;
 	component?: string;
 }
 
-export class CheTaskProvider implements vscode.TaskProvider {
+export class DevfileTaskProvider implements vscode.TaskProvider {
 
 	constructor(private channel: vscode.OutputChannel, private cheAPI: any, private terminalExtAPI: any) {
 	}
@@ -66,8 +66,8 @@ export class CheTaskProvider implements vscode.TaskProvider {
 			return line;
 		}
 
-		const kind: CheTaskDefinition = {
-			type: 'che',
+		const kind: DevfileTaskDefinition = {
+			type: 'devfile',
 			command,
 			workdir,
 			component
@@ -76,7 +76,7 @@ export class CheTaskProvider implements vscode.TaskProvider {
 		const execution = new vscode.CustomExecution(async (): Promise<vscode.Pseudoterminal> => {
 			return this.terminalExtAPI.getMachineExecPTY(component, command, expandEnvVariables(workdir));
 		});
-		const task = new vscode.Task(kind, vscode.TaskScope.Workspace, name, 'che', execution, []);
+		const task = new vscode.Task(kind, vscode.TaskScope.Workspace, name, 'devfile', execution, []);
 		return task;
 	}
 }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
Renames the Task Group `che` to `devfile` to better reflect the source of the contributed VS Code Tasks.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
closes https://github.com/eclipse/che/issues/21840, [CRW-3333](https://issues.redhat.com/browse/CRW-3333)

### How to test this PR?
1. Spin up a workspace from the test project https://github.com/azatsarynnyy/java-spring-petclinic/tree/task-type. It includes the PR changes.
2. In the Command Palette, open the task list and verify that there's no `che` Task Group, but `devfile` instead:
![image](https://user-images.githubusercontent.com/1636395/214314105-cb91df2e-42ca-439f-8355-c3b7a0c29752.png)

