### PR TITLE
Define the 'dev' container as a target for merging a 'container contribution'

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -22,6 +22,8 @@ components:
           secure: true
           protocol: http
           targetPort: 8000
+    attributes:
+      controller.devfile.io/merge-contribution: true
   - name: projects
     volume:
       size: 3Gi


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

### What does this PR do?
Define the 'dev' container as a target for merging a 'container contribution'.
See description of [the issue](https://github.com/eclipse/che/issues/21738).

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21738

### How to test this PR?
After resolving https://github.com/eclipse/che/issues/21738 we should check that a workspace starts successfully for the `che-code` repo.
