### PR TITLE
Increase GH API rate limit when downloading `vscode-ripgrep`

### DIFF
--- a/.github/workflows/image-publish-stable.yml
+++ b/.github/workflows/image-publish-stable.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Docker Build
+        env:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/${{matrix.arch}} -f build/dockerfiles/linux-${{matrix.dist}}.Dockerfile --load -t linux-${{matrix.dist}}-${{matrix.arch}} .
       - name: Upload image
@@ -84,6 +87,9 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}        
       - name: Docker Build and Push
+        env:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHORT_SHA1=$(git rev-parse --short=7 HEAD)
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Docker Build
+        env:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/${{matrix.arch}} -f build/dockerfiles/linux-${{matrix.dist}}.Dockerfile --load -t linux-${{matrix.dist}}-${{matrix.arch}} .
       - name: Upload image
@@ -116,6 +119,9 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}        
       - name: Docker Build and Push
+        env:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHORT_SHA1=$(git rev-parse --short=7 HEAD)
           docker buildx build --platform linux/amd64 -f build/dockerfiles/dev.Dockerfile --push -t quay.io/che-incubator/che-code-dev:insiders -t quay.io/che-incubator/che-code-dev:next -t quay.io/che-incubator/che-code-dev:insiders-${SHORT_SHA1} .


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
Increases GitHub API rate limit for the Actions when VS Code is built.
It's needed for downloading `vscode-ripgrep` dependency.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
closes https://github.com/eclipse/che/issues/21982

### How to test this PR?
With this PR merged, [there](https://github.com/che-incubator/che-code/actions/workflows/image-publish.yml) should be no failures like `Downloading ripgrep failed: Error: Request failed: 403`.
