### PR TITLE
feat: Add 'Restart Workspace' action

### DIFF
--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -51,6 +51,11 @@
         "title": "%stopWorkspaceCommand%",
         "enablement": "che-remote.workspace-enabled"
       },
+	  {
+        "command": "che-remote.command.restartWorkspace",
+        "title": "%restartWorkspaceCommand%",
+        "enablement": "che-remote.workspace-enabled"
+      },
       {
         "command": "che-remote.command.openDocumentation",
         "title": "%openDocumentationCommand%"
@@ -68,6 +73,11 @@
           "group": "remote_40_che_navigation@10",
           "when": "che-remote.workspace-enabled"
         },
+		{
+			"command": "che-remote.command.restartWorkspace",
+			"group": "remote_40_che_navigation@15",
+			"when": "che-remote.workspace-enabled"
+		  },
         {
           "command": "che-remote.command.openDashboard",
           "group": "remote_40_che_navigation@20",

--- a/code/extensions/che-remote/package.nls.json
+++ b/code/extensions/che-remote/package.nls.json
@@ -3,5 +3,6 @@
 	"description": "Provides remoteIndicator commands",
 	"openDocumentationCommand": "Eclipse Che: Open Documentation",
 	"openDashboardCommand": "Eclipse Che: Open Dashboard",
-	"stopWorkspaceCommand": "Eclipse Che: Stop Workspace"
+	"stopWorkspaceCommand": "Eclipse Che: Stop Workspace",
+	"restartWorkspaceCommand": "Eclipse Che: Restart Workspace"
 }

--- a/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
@@ -53,7 +53,7 @@ export class CheDisconnectionHandler {
 	}
 
 	private restartWorkspaceHandler = () => {
-		this.devWorkspaceAssistant.restartWorkspace();
+		this.devWorkspaceAssistant.startWorkspace();
 	}
 
 	private goToDashboardHandler = () => {
@@ -67,7 +67,7 @@ export class CheDisconnectionHandler {
 		requestService: IRequestService,
 		environmentVariableService: IEnvironmentVariableService
 	) {
-		this.devWorkspaceAssistant = new DevWorkspaceAssistant(requestService, environmentVariableService);
+		this.devWorkspaceAssistant = new DevWorkspaceAssistant(commandService, requestService, environmentVariableService);
 	}
 
 	canHandle(millisSinceLastIncomingData: number): boolean {

--- a/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
@@ -52,7 +52,7 @@ export class CheDisconnectionHandler {
 		this.commandService.executeCommand(ReloadWindowAction.ID);
 	}
 
-	private restartWorkspaceHandler = () => {
+	private startWorkspaceHandler = () => {
 		this.devWorkspaceAssistant.startWorkspace();
 	}
 
@@ -181,7 +181,7 @@ export class CheDisconnectionHandler {
 	protected async displayDialog(message: string, severity: Severity): Promise<void> {
 		const restartWorkspaceButton: IPromptButton<void> = {
 			label: RESTART_WORKSPACE_LABEL,
-			run: this.restartWorkspaceHandler
+			run: this.startWorkspaceHandler
 		}
 
 		const goToDashboardButton: IPromptButton<void> = {
@@ -208,7 +208,7 @@ export class CheDisconnectionHandler {
 		const restartWorkspaceChoice: IPromptChoice = {
 			label: RESTART_WORKSPACE_LABEL,
 			isSecondary: false,
-			run: this.restartWorkspaceHandler
+			run: this.startWorkspaceHandler
 		};
 		const goToDashboardChoice: IPromptChoice = {
 			label: RETURN_TO_DASHBOARD_LABEL,


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

### What does this PR do?
Adds an ability to restart a workspace directly from the IDE (no need to go to the dashboard).

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
We need `Restart Workspace` action for the https://github.com/eclipse/che/issues/18670

### How to test this PR?
1. Start a workspace
2. Click on the `Eclipse Che` status bar item.
3. Select `Restart Workspace` action.

Another way is:
1. Press `F1`
2. Type `Restart Workspace`
3. Select `Restart Workspace` command.


https://user-images.githubusercontent.com/5676062/216954371-e78210c0-d465-49e4-b522-b1e03c6caefa.mp4

