### PR TITLE
Increase GH API rate limit when downloading `vscode-ripgrep`

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Docker Build
+        env:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/${{matrix.arch}} -f build/dockerfiles/linux-${{matrix.dist}}.Dockerfile --load -t linux-${{matrix.dist}}-${{matrix.arch}} .
       - name: Upload image

--- a/.github/workflows/rebase-insiders.yml
+++ b/.github/workflows/rebase-insiders.yml
@@ -58,6 +58,9 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             /repos/che-incubator/che-code/actions/workflows/rebase-insiders.yml/disable
       - name: Validate tests on libc image
+        env:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/amd64 -f build/dockerfiles/linux-libc.Dockerfile .
       - name: push changes

--- a/.github/workflows/rebase-release-branch.yml
+++ b/.github/workflows/rebase-release-branch.yml
@@ -49,6 +49,9 @@ jobs:
         run: |
           ./rebase.sh
       - name: Validate tests on libc image
+        env:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/amd64 -f build/dockerfiles/linux-libc.Dockerfile .
       - name: push changes


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
Increases GitHub API rate limit for the Actions when VS Code is built. It's needed for downloading `vscode-ripgrep` dependency.

In addition to https://github.com/che-incubator/che-code/pull/170, this PR makes a couple of more image build calls more stable: `pr-check` and `rebase` jobs.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
addresses the https://github.com/eclipse/che/issues/21982#issuecomment-1418902155

### How to test this PR?
With this PR merged, [`rebase-insiders`](https://github.com/che-incubator/che-code/actions/workflows/rebase-insiders.yml) and [`pr-check`](https://github.com/che-incubator/che-code/actions/workflows/pr-check.yml) workflows should not be failed with the errors like `Downloading ripgrep failed: Error: Request failed: 403`.
