### PR TITLE
chore: Update `actions/checkout` to node 16 version

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -53,7 +53,7 @@ jobs:
           BRANCH_NAME=${{ github.ref }}
           echo "BRANCH_NAME=${BRANCH_NAME##*/}" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download linux-libc-amd64 image
         uses: ishworkh/docker-image-artifact-download@v1
         with:


### PR DESCRIPTION
### What does this PR do?
Updates `actions/checkout` to the latest version using node 16. In addition to the previous PR https://github.com/che-incubator/che-code/pull/162



### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21763

### How to test this PR?
On the [`image-publish` Workflow page](https://github.com/che-incubator/che-code/actions/runs/4120145113) there should be no warnings like:
![image](https://user-images.githubusercontent.com/1636395/217486324-8d9d326c-662e-4400-b049-f5f0a3d7c0fb.png)

