### PR TITLE
docs: Add 'Restart Workspace' item to the 'Branding' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ The following example shows all of the properties that you can customize by usin
     "remoteIndicatorCommands": {
         "openDocumentationCommand": "Branded IDE: Open Documentation",
         "openDashboardCommand": "Branded IDE: Open Dashboard",
-        "stopWorkspaceCommand": "Branded IDE: Stop Workspace"
+        "stopWorkspaceCommand": "Branded IDE: Stop Workspace",
+        "restartWorkspaceCommand": "Branded IDE: Restart Workspace"
     },
     "workbenchConfigFilePath": "workbench-config.json",
     "codiconCssFilePath": "css/codicon.css"


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

### What does this PR do?
Add `Restart Workspace` item to the `Branding` section.
See https://github.com/che-incubator/che-code/pull/172.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
We need `Restart Workspace` action for the https://github.com/eclipse/che/issues/18670.

### How to test this PR?
- The item should be displayed in the `Branding` section.
- `branding.sh` script should rename the item [here](https://github.com/RomanNikitenko/che-code/blob/fa64b7b2ffcc93e7e0718cb317384ce123e8dd79/code/extensions/che-remote/package.nls.json#L7)
- see more details [here](https://github.com/che-incubator/che-code#procedure)
