### PR TITLE
fix: Fix automatic rebasing for the vscode/l10n-dev dependency

### DIFF
--- a/.rebase/override/code/package.json
+++ b/.rebase/override/code/package.json
@@ -1,4 +1,7 @@
 {
     "name": "che-code",
-    "bin": "out/vs/server/main.js"
+    "bin": "out/vs/server/main.js",
+    "devDependencies": {
+      "@vscode/l10n-dev": "0.0.18"
+    }
 }

--- a/code/package.json
+++ b/code/package.json
@@ -131,7 +131,7 @@
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/experimental-utils": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
-    "@vscode/l10n-dev": "0.0.21",
+    "@vscode/l10n-dev": "0.0.18",
     "@vscode/telemetry-extractor": "^1.9.8",
     "@vscode/test-web": "^0.0.34",
     "@vscode/vscode-perf": "^0.0.6",


### PR DESCRIPTION
### What does this PR do?
- Pin `0.0.18` version of `vscode/l10n-dev` dependency
- do not allow to overwrite it by upstream changes

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-4053

### How to test this PR?
We should check that `@vscode/l10n-dev` dependency still has `0.0.18` version after automatic rebasing, so the version is not overwritten by the upstream value.
