### PR TITLE
Upgrade node.js to minimally required version

### DIFF
--- a/build/dockerfiles/dev.Dockerfile
+++ b/build/dockerfiles/dev.Dockerfile
@@ -28,7 +28,7 @@ RUN cd /mnt/rootfs && ln -s /usr/bin/python3 ./usr/bin/python
 RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 
 # Download nodejs required by VS Code
-RUN mkdir -p /mnt/rootfs/opt/nodejs && curl -sL https://nodejs.org/download/release/v16.14.0/node-v16.14.0-linux-x64.tar.gz | tar xzf - -C /mnt/rootfs/opt/nodejs --strip-components=1
+RUN mkdir -p /mnt/rootfs/opt/nodejs && curl -sL https://nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-x64.tar.gz | tar xzf - -C /mnt/rootfs/opt/nodejs --strip-components=1
 
 # Download kubectl
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # Make an assembly including both musl and libc variant to be able to run on all linux systems
-FROM docker.io/node:16.17.0-alpine3.15 as linux-musl-builder
+FROM docker.io/node:16.17.1-alpine3.15 as linux-musl-builder
 RUN apk add --update --no-cache \
     # Download some files
     curl \

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # Make an assembly including both musl and libc variant to be able to run on all linux systems
-FROM docker.io/node:16.14.0-alpine3.15 as linux-musl-builder
+FROM docker.io/node:16.17.0-alpine3.15 as linux-musl-builder
 RUN apk add --update --no-cache \
     # Download some files
     curl \


### PR DESCRIPTION
### What does this PR do?
Updates the Node.js runtime for Che-Code according to the [new upstream requirements](https://github.com/microsoft/vscode/pull/175663/files).

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
closes https://github.com/eclipse/che/issues/22024

### How to test this PR?
All PR status checks must pass successfully.
