### PR TITLE
docs: Add 'Restart Workspace from Local Devfile' item to the 'Branding' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ The following example shows all of the properties that you can customize by usin
         "openDocumentationCommand": "Branded IDE: Open Documentation",
         "openDashboardCommand": "Branded IDE: Open Dashboard",
         "stopWorkspaceCommand": "Branded IDE: Stop Workspace",
-        "restartWorkspaceCommand": "Branded IDE: Restart Workspace"
+        "restartWorkspaceCommand": "Branded IDE: Restart Workspace",
+        "restartWorkspaceFromLocalDevfileCommand": "Branded IDE: Restart Workspace from Local Devfile"
     },
     "workbenchConfigFilePath": "workbench-config.json",
     "codiconCssFilePath": "css/codicon.css"


### PR DESCRIPTION


### What does this PR do?
Add `Restart Workspace from Local Devfile` item to the `Branding` section.
See https://github.com/che-incubator/che-code/pull/185

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
`Restart Workspace from Local Devfile` action was added within https://github.com/eclipse/che/issues/18670

### How to test this PR?
- The item should be displayed in the `Branding` section.
- `branding.sh` script should rename the item [here](https://github.com/che-incubator/che-code/blob/4d474ba3239ac9dd0825033977893e15dc0d739e/code/extensions/che-remote/package.nls.json#L8)
- see more details [here](https://github.com/che-incubator/che-code#branding-the-ui)

