### PR TITLE
feat: Add 'Open Cluster Console' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The following example shows all of the properties that you can customize by usin
     "remoteIndicatorCommands": {
         "openDocumentationCommand": "Branded IDE: Open Documentation",
         "openDashboardCommand": "Branded IDE: Open Dashboard",
+        "openOpenShiftConsoleCommand": "Branded IDE: Open OpenShift Console",
         "stopWorkspaceCommand": "Branded IDE: Stop Workspace",
         "restartWorkspaceCommand": "Branded IDE: Restart Workspace",
         "restartWorkspaceFromLocalDevfileCommand": "Branded IDE: Restart Workspace from Local Devfile"

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -71,6 +71,11 @@
         "command": "che-remote.command.openDashboard",
         "title": "%openDashboardCommand%",
         "enablement": "che-remote.dashboard-enabled"
+      },
+      {
+        "command": "che-remote.command.openClusterConsole",
+        "title": "%openClusterConsoleCommand%",
+        "enablement": "che-remote.cluster-console-enabled"
       }
     ],
     "menus": {
@@ -94,6 +99,11 @@
           "command": "che-remote.command.openDashboard",
           "group": "remote_40_che_navigation@20",
           "when": "che-remote.dashboard-enabled"
+        },
+        {
+          "command": "che-remote.command.openClusterConsole",
+          "group": "remote_40_che_navigation@21",
+          "when": "che-remote.cluster-console-enabled"
         },
         {
           "command": "che-remote.command.openDocumentation",

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -73,9 +73,9 @@
         "enablement": "che-remote.dashboard-enabled"
       },
       {
-        "command": "che-remote.command.openClusterConsole",
-        "title": "%openClusterConsoleCommand%",
-        "enablement": "che-remote.cluster-console-enabled"
+        "command": "che-remote.command.openOpenShiftConsole",
+        "title": "%openOpenShiftConsoleCommand%",
+        "enablement": "che-remote.openshift-console-enabled"
       }
     ],
     "menus": {
@@ -101,9 +101,9 @@
           "when": "che-remote.dashboard-enabled"
         },
         {
-          "command": "che-remote.command.openClusterConsole",
+          "command": "che-remote.command.openOpenShiftConsole",
           "group": "remote_40_che_navigation@21",
-          "when": "che-remote.cluster-console-enabled"
+          "when": "che-remote.openshift-console-enabled"
         },
         {
           "command": "che-remote.command.openDocumentation",

--- a/code/extensions/che-remote/package.nls.json
+++ b/code/extensions/che-remote/package.nls.json
@@ -3,7 +3,7 @@
 	"description": "Provides remoteIndicator commands",
 	"openDocumentationCommand": "Eclipse Che: Open Documentation",
 	"openDashboardCommand": "Eclipse Che: Open Dashboard",
-	"openClusterConsoleCommand": "Eclipse Che: Open Cluster Console",
+	"openClusterConsoleCommand": "Eclipse Che: Open OpenShift Console",
 	"stopWorkspaceCommand": "Eclipse Che: Stop Workspace",
 	"restartWorkspaceCommand": "Eclipse Che: Restart Workspace",
 	"restartWorkspaceFromLocalDevfileCommand": "Eclipse Che: Restart Workspace from Local Devfile"

--- a/code/extensions/che-remote/package.nls.json
+++ b/code/extensions/che-remote/package.nls.json
@@ -3,6 +3,7 @@
 	"description": "Provides remoteIndicator commands",
 	"openDocumentationCommand": "Eclipse Che: Open Documentation",
 	"openDashboardCommand": "Eclipse Che: Open Dashboard",
+	"openClusterConsoleCommand": "Eclipse Che: Open Cluster Console",
 	"stopWorkspaceCommand": "Eclipse Che: Stop Workspace",
 	"restartWorkspaceCommand": "Eclipse Che: Restart Workspace",
 	"restartWorkspaceFromLocalDevfileCommand": "Eclipse Che: Restart Workspace from Local Devfile"

--- a/code/extensions/che-remote/package.nls.json
+++ b/code/extensions/che-remote/package.nls.json
@@ -3,7 +3,7 @@
 	"description": "Provides remoteIndicator commands",
 	"openDocumentationCommand": "Eclipse Che: Open Documentation",
 	"openDashboardCommand": "Eclipse Che: Open Dashboard",
-	"openClusterConsoleCommand": "Eclipse Che: Open OpenShift Console",
+	"openOpenShiftConsoleCommand": "Eclipse Che: Open OpenShift Console",
 	"stopWorkspaceCommand": "Eclipse Che: Stop Workspace",
 	"restartWorkspaceCommand": "Eclipse Che: Restart Workspace",
 	"restartWorkspaceFromLocalDevfileCommand": "Eclipse Che: Restart Workspace from Local Devfile"

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -41,6 +41,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     );
   }
 
+  // add command only if env variable is set
+  const clusterConsoleUrl = process.env.CLUSTER_CONSOLE_URL;
+  if (clusterConsoleUrl) {
+    // enable command
+    vscode.commands.executeCommand('setContext', 'che-remote.cluster-console-enabled', true);
+    context.subscriptions.push(
+      vscode.commands.registerCommand('che-remote.command.openClusterConsole', () => {
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(clusterConsoleUrl));
+      })
+    );
+  }
+
   const extensionApi = vscode.extensions.getExtension('eclipse-che.api');
   if (extensionApi) {
     await extensionApi.activate();

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -41,13 +41,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     );
   }
 
-  // add command only if env variable is set
+  // add command only if Che Code is running on OpenShift
   const clusterConsoleUrl = process.env.CLUSTER_CONSOLE_URL;
-  if (clusterConsoleUrl) {
+  const clusterConsoleTitle = process.env.CLUSTER_CONSOLE_TITLE || '';
+  if (clusterConsoleUrl && clusterConsoleTitle.includes('OpenShift')) {
     // enable command
-    vscode.commands.executeCommand('setContext', 'che-remote.cluster-console-enabled', true);
+    vscode.commands.executeCommand('setContext', 'che-remote.openshift-console-enabled', true);
     context.subscriptions.push(
-      vscode.commands.registerCommand('che-remote.command.openClusterConsole', () => {
+      vscode.commands.registerCommand('che-remote.command.openOpenShiftConsole', () => {
         vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(clusterConsoleUrl));
       })
     );


### PR DESCRIPTION
depends on https://github.com/eclipse-che/che-dashboard/pull/758

### What does this PR do?
- adds `Open OpenShift Console` command to the Command Palette
- adds `Open OpenShift Console` action to the `Eclipse Che` status bar actions

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21822

### How to test this PR?
Please see a short video:

https://user-images.githubusercontent.com/5676062/226611639-b3b971b1-f8c8-439d-80c5-1f7dfd52667c.mp4


