### PR TITLE
fix: Filter out the editor-provided commands

### DIFF
--- a/code/extensions/che-commands/src/taskProvider.ts
+++ b/code/extensions/che-commands/src/taskProvider.ts
@@ -37,6 +37,7 @@ export class DevfileTaskProvider implements vscode.TaskProvider {
 
 		const cheTasks: vscode.Task[] = devfileCommands!
 			.filter(command => command.exec?.commandLine)
+			.filter(command => !command.attributes || (command.attributes as any)['controller.devfile.io/imported-by'] !== 'editor')
 			.map(command => this.createCheTask(command.exec?.label || command.id, command.exec?.commandLine!, command.exec?.workingDir || '${PROJECT_SOURCE}', command.exec?.component!));
 		return cheTasks;
 	}


### PR DESCRIPTION
### What does this PR do?
Filters out the editor-provided Devfile commands as they are not expected to be run by the user.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
Closes https://github.com/eclipse/che/issues/22098

### How to test this PR?
1. Start a new workspace from the test project https://github.com/azatsarynnyy/java-spring-petclinic/tree/hide-editor-exec-cmds. Its `.che/che-editor.yaml` contains the `init-che-code-command` exec command.
2. Verify that there is no editor-specific command among the `devfile`-type Tasks.
