### PR TITLE
feat: Add 'New Terminal (Select a Container)' action to Terminal and terminal's context menus

### DIFF
--- a/code/extensions/che-terminal/package.nls.json
+++ b/code/extensions/che-terminal/package.nls.json
@@ -2,6 +2,6 @@
 	"displayName": "Eclipse Che Terminal",
 	"description": "Provides the remote terminals support",
 	"category": "Terminal",
-	"new.title": "Create New Terminal to DevWorkspace Container",
+	"new.title": "Create New Terminal (Select a Container)",
 	"new.shortTitle": "New Terminal to Container"
 }

--- a/code/src/vs/workbench/contrib/terminal/browser/che/terminalMenus.ts
+++ b/code/src/vs/workbench/contrib/terminal/browser/che/terminalMenus.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable header/header */
+
+import { localize } from 'vs/nls';
+import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
+import { TerminalMenuBarGroup } from 'vs/workbench/contrib/terminal/browser/terminalMenus';
+
+// see enum ContextMenuGroup in the terminalMenus
+const CONTEXT_MENU_GROUP_CREATE = '1_create';
+const NEW_TERMINAL_IN_CONTAINER_COMMAND_ID = 'che-terminal.new';
+const NEW_TERMINAL_IN_CONTAINER_TITLE = localize('newTerminal.selectContainer.title', 'New Terminal (Select a Container)');
+
+export function setupCheTerminalMenus(): void {
+  MenuRegistry.appendMenuItems(
+    [
+      {
+        id: MenuId.MenubarTerminalMenu,
+        item: {
+          group: TerminalMenuBarGroup.Create,
+          command: {
+            id: NEW_TERMINAL_IN_CONTAINER_COMMAND_ID,
+            title: NEW_TERMINAL_IN_CONTAINER_TITLE
+          },
+          order: 1.5
+        }
+      }
+    ]
+  );
+
+  MenuRegistry.appendMenuItems(
+    [
+      {
+        id: MenuId.TerminalInstanceContext,
+        item: {
+          command: {
+            id: NEW_TERMINAL_IN_CONTAINER_COMMAND_ID,
+            title: NEW_TERMINAL_IN_CONTAINER_TITLE
+          },
+          group: CONTEXT_MENU_GROUP_CREATE
+        }
+      }
+    ]
+  );
+}

--- a/code/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/code/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -52,6 +52,7 @@ import { RemoteTerminalBackendContribution } from 'vs/workbench/contrib/terminal
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { TerminalMainContribution } from 'vs/workbench/contrib/terminal/browser/terminalMainContribution';
 import { Schemas } from 'vs/base/common/network';
+import { setupCheTerminalMenus } from 'vs/workbench/contrib/terminal/browser/che/terminalMenus';
 
 // Register services
 registerSingleton(ITerminalService, TerminalService, InstantiationType.Delayed);
@@ -282,5 +283,6 @@ registerSendSequenceKeybinding('\u001f', {
 setupTerminalCommands();
 
 setupTerminalMenus();
+setupCheTerminalMenus();
 
 registerColors();


### PR DESCRIPTION
### What does this PR do?
- command `Create New Terminal to DevWorkspace Container` is renamed to `Create New Terminal (Select a Container)` 
- command is added to the `Terminal` menu
- command is added to the terminal's context menu


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/22086

### How to test this PR?
- create a workspace using [this reference](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/testDevfile). It uses [current PR image](https://github.com/RomanNikitenko/web-nodejs-sample/blob/testDevfile/.che/che-editor.yaml#L27) to create an editor.
- check that command `Create New Terminal to DevWorkspace Container` has new title `Create New Terminal (Select a Container)` 
- check that the command is available for running from `Terminal` menu
- check that the command is available for running from terminal's context menu


https://user-images.githubusercontent.com/5676062/229514764-f0c261b0-2acb-4873-a397-9bcb627e24a8.mp4

