### PR TITLE
fix: Filter out che commands imported by plugins/contributions

### DIFF
--- a/code/extensions/che-commands/src/taskProvider.ts
+++ b/code/extensions/che-commands/src/taskProvider.ts
@@ -37,7 +37,7 @@ export class DevfileTaskProvider implements vscode.TaskProvider {
 
 		const cheTasks: vscode.Task[] = devfileCommands!
 			.filter(command => command.exec?.commandLine)
-			.filter(command => !command.attributes || (command.attributes as any)['controller.devfile.io/imported-by'] !== 'editor')
+			.filter(command => !command.attributes || (command.attributes as any)['controller.devfile.io/imported-by'] === undefined)
 			.map(command => this.createCheTask(command.exec?.label || command.id, command.exec?.commandLine!, command.exec?.workingDir || '${PROJECT_SOURCE}', command.exec?.component!));
 		return cheTasks;
 	}


### PR DESCRIPTION
### What does this PR do?
Filters out che commands imported by plugins/contributions as they are not expected to be run by the user.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/22098
implements the suggestion https://github.com/che-incubator/che-code/pull/192#pullrequestreview-1359995830

### How to test this PR?
1. Start a new workspace from the test project https://github.com/azatsarynnyy/java-spring-petclinic/tree/filter-cmds. The project is configured to use the editor image built from this PR.
2. Verify that there is no `init-che-code-command` command among the `devfile`-type Tasks.
