### PR TITLE
fix: Allow `redhat.java` extension to use `documentPaste` proposed API

### DIFF
--- a/code/product.json
+++ b/code/product.json
@@ -85,6 +85,9 @@
 			"terminalNameChangeEvent",
 			"testObserver",
 			"textSearchProvider"
+		],
+		"redhat.java": [
+			"documentPaste"
 		]
 	},
 	"sendASmile": {


### PR DESCRIPTION
### What does this PR do?
Allows [the `redhat.java` extension](https://open-vsx.org/extension/redhat/java) to use the [`documentPaste` proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.documentPaste.d.ts).
This fixes the problem of never closing the `Opening Java Projects` notification.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/22125

### How to test this PR?
1. Click [this link](https://devspaces.apps.sandbox-m2.ll9k.p1.openshiftapps.com/#https://github.com/azatsarynnyy/java-spring-petclinic/tree/documentPaste) to create a new workspace on DevSandbox with the test project imported. The test project is configured to use the editor which is built with this PR's changes.
2. Check that the Java extension is auto-installed.
3. Open any java file and wait for the following notification to pop up:
![image](https://user-images.githubusercontent.com/1636395/228541251-18b796e2-92f8-4a6d-82d3-4d3782f72668.png)
4. Once the Java extension finishes the project initialization, the popup ^^ should be hidden. For me, it took 9 minutes.
