### PR TITLE
docs: Update info about required version of Node.js

### DIFF
--- a/build/dockerfiles/README.md
+++ b/build/dockerfiles/README.md
@@ -1,5 +1,5 @@
 ## Running Visual Studio Code - Open Source ("Code - OSS") in a UBI9-based container
-`Node.js` version >=16.14.x and <17 [is required](https://github.com/microsoft/vscode/wiki/How-to-Contribute#prerequisites) to run `Code-OSS`.
+`Node.js` is required to run `Code-OSS` (see required version [here](https://github.com/microsoft/vscode/wiki/How-to-Contribute#prerequisites)).
 This project includes [dockefiles](https://github.com/che-incubator/che-code/tree/main/build/dockerfiles) that based on the `ubi8/nodejs-16` image - an assembly contains `Node.js 16` that requires `OpenSSL 1`.
 
 One of the differences between `UBI8` and `UBI9` image is:


### PR DESCRIPTION
### What does this PR do?
Node.js version was changed in the `Prerequisites` section of upstream.
So, we need to update info about it on the `che-code` side.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
no issue

### How to test this PR?
Just check that the corresponding part of the README is rendered correctly
