### PR TITLE
Update `redhat-actions/try-in-web-ide` GH action to the latest version

### DIFF
--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Add DevSandbox link
-        uses: redhat-actions/try-in-web-ide@v1.2
+        uses: redhat-actions/try-in-web-ide@v1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add_comment: true
           add_status: false
       - name: Add Dogfooding link
-        uses: redhat-actions/try-in-web-ide@v1.2
+        uses: redhat-actions/try-in-web-ide@v1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add_comment: true


### PR DESCRIPTION
### What does this PR do?
Updates [`redhat-actions/try-in-web-ide` GH action](https://github.com/redhat-actions/try-in-web-ide) to the latest (1.4) version.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
n/a

### How to test this PR?
n/a
