### PR TITLE
feat: Handle health check requests

### DIFF
--- a/.rebase/replace/code/src/server-main.js.json
+++ b/.rebase/replace/code/src/server-main.js.json
@@ -1,0 +1,14 @@
+[
+    {
+        "from": "const product = require('../product.json');",
+        "by": "const product = require('../product.json');\\\nconst url = require('url');"
+    },
+    {
+        "from": "perf.mark('code/server/firstRequest');",
+        "by": "perf.mark('code/server/firstRequest');\\\n\\\t\\\t}\\\n\\\t\\\tif (!_remoteExtensionHostAgentServer \\&\\& req.url \\&\\& url.parse(req.url, true).pathname === '/healthz') {\\\n\\\t\\\t\\\tres.writeHead(503, { 'Content-Type': 'text/plain' });\\\n\\\t\\\t\\\tres.end('Service Unavailable');\\\n\\\t\\\t\\\treturn;"
+    },
+    {
+        "from": "_remoteExtensionHostAgentServer.dispose();",
+        "by": "_remoteExtensionHostAgentServer.dispose();\\\n\\\t\\\t\\\t_remoteExtensionHostAgentServer = null;"
+    }
+]

--- a/.rebase/replace/code/src/vs/server/node/remoteExtensionHostAgentServer.ts.json
+++ b/.rebase/replace/code/src/vs/server/node/remoteExtensionHostAgentServer.ts.json
@@ -1,0 +1,6 @@
+[
+    {
+        "from": "// Version",
+        "by": "// healthz\\\n\\\t\\\tif (pathname === '/healthz') {\\\n\\\t\\\t\\\tres.writeHead(200, { 'Content-Type': 'text/plain' });\\\n\\\t\\\t\\\treturn void res.end('OK');\\\n\\\t\\\t}"
+    }
+]

--- a/code/src/server-main.js
+++ b/code/src/server-main.js
@@ -8,6 +8,7 @@
 const perf = require('./vs/base/common/performance');
 const performance = require('perf_hooks').performance;
 const product = require('../product.json');
+const url = require('url');
 const readline = require('readline');
 const http = require('http');
 
@@ -102,6 +103,12 @@ async function start() {
 			firstRequest = false;
 			perf.mark('code/server/firstRequest');
 		}
+		if (!_remoteExtensionHostAgentServer && req.url && url.parse(req.url, true).pathname === '/healthz') {
+			res.writeHead(503, { 'Content-Type': 'text/plain' });
+			res.end('Service Unavailable');
+			return;
+		}
+		
 		const remoteExtensionHostAgentServer = await getRemoteExtensionHostAgentServer();
 		return remoteExtensionHostAgentServer.handleRequest(req, res);
 	});
@@ -160,6 +167,7 @@ async function start() {
 		server.close();
 		if (_remoteExtensionHostAgentServer) {
 			_remoteExtensionHostAgentServer.dispose();
+			_remoteExtensionHostAgentServer = null;
 		}
 	});
 }

--- a/code/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/code/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -121,6 +121,11 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			return void res.end(this._productService.commit || '');
 		}
 
+		if (pathname === '/healthz') {
+			res.writeHead(200, { 'Content-Type': 'text/plain' });
+			return void res.end('OK');
+		}
+
 		// Delay shutdown
 		if (pathname === '/delay-shutdown') {
 			this._delayShutdown();

--- a/rebase.sh
+++ b/rebase.sh
@@ -183,6 +183,34 @@ apply_code_vs_platform_remote_browser_factory_changes() {
   git add code/src/vs/platform/remote/browser/browserSocketFactory.ts > /dev/null 2>&1
 }
 
+# Apply changes on code/src/server-main.js file
+apply_code_server-main_changes() {
+  
+  echo "  ⚙️ reworking code/src/server-main.js..."
+  # reset the file from what is upstream
+  git checkout --theirs code/src/server-main.js > /dev/null 2>&1
+  
+  # now apply again the changes
+  apply_replace code/src/server-main.js
+  
+  # resolve the change
+  git add code/src/server-main.js > /dev/null 2>&1
+}
+
+# Apply changes on code/src/vs/server/node/remoteExtensionHostAgentServer.ts file
+apply_code_vs_server_node_remoteExtensionHostAgentServer_changes() {
+  
+  echo "  ⚙️ reworking code/src/vs/server/node/remoteExtensionHostAgentServer.ts..."
+  # reset the file from what is upstream
+  git checkout --theirs code/src/vs/server/node/remoteExtensionHostAgentServer.ts > /dev/null 2>&1
+  
+  # now apply again the changes
+  apply_replace code/src/vs/server/node/remoteExtensionHostAgentServer.ts
+  
+  # resolve the change
+  git add code/src/vs/server/node/remoteExtensionHostAgentServer.ts > /dev/null 2>&1
+}
+
 # Apply changes on code/src/vs/server/node/webClientServer.ts file
 apply_code_vs_server_web_client_server_changes() {
   
@@ -232,7 +260,11 @@ resolve_conflicts() {
       apply_code_vs_platform_remote_browser_factory_changes
     elif [[ "$conflictingFile" == "code/src/vs/server/node/webClientServer.ts" ]]; then
       apply_code_vs_server_web_client_server_changes
-	elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/remote/browser/remote.ts" ]]; then
+    elif [[ "$conflictingFile" == "code/src/server-main.js" ]]; then
+      apply_code_server-main_changes
+    elif [[ "$conflictingFile" == "code/src/vs/server/node/remoteExtensionHostAgentServer.ts" ]]; then
+      apply_code_vs_server_node_remoteExtensionHostAgentServer_changes
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/remote/browser/remote.ts" ]]; then
       apply_code_vs_workbench_contrib_remote_browser_remote_changes
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"


### PR DESCRIPTION
### What does this PR do?
Handle health check requests:
- return `503` response code while `remoteExtensionHostAgentServer` is NOT available
- return `200` response code when `remoteExtensionHostAgentServer` is ready to serve requests 

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/22008

### How to test this PR?
I tested my changes by adding the corresponding logs to see that:
- `503` response code is returned while `remoteExtensionHostAgentServer` is NOT available
- `200` response code is returned when `remoteExtensionHostAgentServer` is ready to serve requests 
