### PR TITLE
fix: load webview static resources from local host instead of CDN

### DIFF
--- a/.rebase/replace/code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html.json
+++ b/.rebase/replace/code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html.json
@@ -1,0 +1,6 @@
+[
+	{
+		"from": "const hostname = location.hostname;",
+		"by": "const hostname = location.hostname;\\\n\\\n\\\t\\\t\\\t\\\t// Run if we are on the same host.\\\n\\\t\\\t\\\t\\\tconst parent = new URL(parentOrigin);\\\n\\\t\\\t\\\t\\\tif (parent.hostname === hostname) {\\\n\\\t\\\t\\\t\\\t\\\treturn start(parentOrigin);\\\n\\\t\\\t\\\t\\\t}"
+	}
+]

--- a/.rebase/replace/code/src/vs/workbench/contrib/webview/browser/pre/index.html.json
+++ b/.rebase/replace/code/src/vs/workbench/contrib/webview/browser/pre/index.html.json
@@ -1,0 +1,10 @@
+[
+	{
+		"from": "content=\\\"default-src 'none'; script-src 'sha256-............................................' 'self'; frame-src 'self'; style-src 'unsafe-inline';\\\"",
+		"by": "content=\\\"default-src 'none'; script-src 'unsafe-inline' 'self'; frame-src 'self'; style-src 'unsafe-inline';\\\""
+	},
+	{
+		"from": "const hostname = location.hostname;",
+		"by": "const hostname = location.hostname;\\\n\\\n\\\t\\\t\\\t\\\t// Run if we are on the same host.\\\n\\\t\\\t\\\t\\\tconst parent = new URL(parentOrigin);\\\n\\\t\\\t\\\t\\\tif (parent.hostname === hostname) {\\\n\\\t\\\t\\\t\\\t\\\treturn start(parentOrigin);\\\n\\\t\\\t\\\t\\\t}"
+	}
+]

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -66,6 +66,51 @@ if [ -n "${OPENVSX_REGISTRY_URL+x}" ]; then
   sed -i -e "s|serviceUrl:\".*\",itemUrl:\".*\"},version|serviceUrl:\"${OPENVSX_URL}/gallery\",itemUrl:\"${OPENVSX_URL}/item\"},version|" out/vs/workbench/workbench.web.main.js
 fi
 
+
+# To switch the webview content being loaded from local workspace we need to check for 'WEBVIEW_LOCAL_RESOURCES' environment variable.
+if [ -n "${WEBVIEW_LOCAL_RESOURCES+x}" ]; then
+
+  # If the variable is set to 'true', then:
+  if [[ "${WEBVIEW_LOCAL_RESOURCES}" == "true" ]]; then
+
+    # fetch che-code endpoint value from /devworkspace-metadata/flattened.devworkspace.yaml
+    CHE_CODE_ENDPOINT=$(yq -r '
+      .components
+      | to_entries[]
+      | select(.value.container.command[0] == "/checode/entrypoint-volume.sh")
+      | .value.container.endpoints
+      | to_entries[]
+      | select(.value.name == "che-code")
+      | .value.attributes
+      | to_entries[]
+      | select(.key == "controller.devfile.io/endpoint-url")
+      | .value
+    ' /devworkspace-metadata/flattened.devworkspace.yaml)
+
+    # make a valid base URI for webview static resources
+    WEBVIEW_CONTENT_BASE_URL=$CHE_CODE_ENDPOINT"oss-dev/static/out/vs/workbench/contrib/webview/browser/pre/"
+    echo "WEBVIEW_CONTENT_BASE_URL: $WEBVIEW_CONTENT_BASE_URL"
+
+    # fetch the existing base URI from product.json
+    WEBVIEW_CONTENT_BASE_URL_TEMPLATE=$(jq -r '.webviewContentExternalBaseUrlTemplate' product.json)
+    echo "WEBVIEW_CONTENT_BASE_URL_TEMPLATE: $WEBVIEW_CONTENT_BASE_URL_TEMPLATE"
+
+    # escape special characters
+    WORK_TEMPLATE=$WEBVIEW_CONTENT_BASE_URL_TEMPLATE
+    WORK_TEMPLATE=${WORK_TEMPLATE//[\{]/\\{}
+    WORK_TEMPLATE=${WORK_TEMPLATE//[\}]/\\\}}
+
+    # apply new base URI to the following files
+    sed -i -r -e "s|${WORK_TEMPLATE}|${WEBVIEW_CONTENT_BASE_URL}|" out/vs/workbench/workbench.web.main.js
+    sed -i -r -e "s|${WORK_TEMPLATE}|${WEBVIEW_CONTENT_BASE_URL}|" out/vs/workbench/api/node/extensionHostProcess.js
+
+    # actual value of webviewContentExternalBaseUrlTemplate in the product.json has no effect at runtime
+    # it serves as a marker for easily verifying the source of the webview static resources
+    sed -i -r -e "s|${WORK_TEMPLATE}|${WEBVIEW_CONTENT_BASE_URL}|" product.json
+  fi
+fi
+
+
 # Check if we have a custom CA certificate
 if [ -f /tmp/che/secret/ca.crt ]; then
   echo "Adding custom CA certificate"

--- a/code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -333,6 +333,12 @@
 
 				const hostname = location.hostname;
 
+				// Run if we are on the same host.
+				const parent = new URL(parentOrigin);
+				if (parent.hostname === hostname) {
+					return start(parentOrigin);
+				}
+
 				if (!crypto.subtle) {
 					// cannot validate, not running in a secure context
 					throw new Error(`'crypto.subtle' is not available so webviews will not work. This is likely because the editor is not running in a secure context (https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).`);

--- a/code/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/code/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-7T0Xm7l4AYKDwm8oYNQ65wcQX7K/ndvxH/2ZgHWUE3w=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'unsafe-inline' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -333,6 +333,12 @@
 				const parentOrigin = searchParams.get('parentOrigin');
 
 				const hostname = location.hostname;
+
+				// Run if we are on the same host.
+				const parent = new URL(parentOrigin);
+				if (parent.hostname === hostname) {
+					return start(parentOrigin);
+				}
 
 				if (!crypto.subtle) {
 					// cannot validate, not running in a secure context

--- a/rebase.sh
+++ b/rebase.sh
@@ -75,7 +75,7 @@ apply_replace() {
     sed -i.bak -e "s|${escape_from}|${escape_by}|" "${filename}"
     if diff "$filename" "$filename.bak" &> /dev/null; then
       echo "Unable to perform the replace. Value is not present in the resulting file"
-      echo "Wanted to check ${by}"
+      echo "Wanted to check ${from}"
       echo "File content is"
       cat "${filename}"
       exit 1
@@ -239,6 +239,34 @@ apply_code_vs_workbench_contrib_remote_browser_remote_changes() {
   git add code/src/vs/workbench/contrib/remote/browser/remote.ts > /dev/null 2>&1
 }
 
+# Apply changes on code/src/vs/workbench/contrib/webview/browser/pre/index.html file
+apply_code_vs_workbench_contrib_webview_browser_pre_index_html_changes() {
+  
+  echo "  ⚙️ reworking code/src/vs/workbench/contrib/webview/browser/pre/index.html..."
+  # reset the file from what is upstream
+  git checkout --theirs code/src/vs/workbench/contrib/webview/browser/pre/index.html > /dev/null 2>&1
+  
+  # now apply again the changes
+  apply_replace code/src/vs/workbench/contrib/webview/browser/pre/index.html
+  
+  # resolve the change
+  git add code/src/vs/workbench/contrib/webview/browser/pre/index.html > /dev/null 2>&1
+}
+
+# Apply changes on code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html file
+apply_code_vs_workbench_contrib_webview_browser_pre_index_no_csp_html_changes() {
+  
+  echo "  ⚙️ reworking code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html..."
+  # reset the file from what is upstream
+  git checkout --theirs code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html > /dev/null 2>&1
+  
+  # now apply again the changes
+  apply_replace code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+  
+  # resolve the change
+  git add code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html > /dev/null 2>&1
+}
+
 # Will try to identify the conflicting files and for some of them it's easy to re-apply changes
 resolve_conflicts() {
   echo "⚠️  There are conflicting files, trying to solve..."
@@ -266,12 +294,15 @@ resolve_conflicts() {
       apply_code_vs_server_node_remoteExtensionHostAgentServer_changes
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/remote/browser/remote.ts" ]]; then
       apply_code_vs_workbench_contrib_remote_browser_remote_changes
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/webview/browser/pre/index.html" ]]; then
+      apply_code_vs_workbench_contrib_webview_browser_pre_index_html_changes
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html" ]]; then
+      apply_code_vs_workbench_contrib_webview_browser_pre_index_no_csp_html_changes
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"
       exit 1
     fi
   done
-  
 }
 
 # $1 is the upstream sha1 on which we're rebasing


### PR DESCRIPTION
### What does this PR do?

If configured, replaces the base URL of the webview static resources to be able to load them from the same host as VS Code instead of getting them from CDN.
It makes the webviews working when the browser is behind a proxy.

To turn the redirection on, it needs to edit the devfile and defile `WEBVIEW_LOCAL_RESOURCES` environment variable for `tools` container. Defining the variable into the editor devfile temporary does not work as the environment variable is not transferred into the DevWorkspace object (needs to be double checked)
```
      env:
        - name: WEBVIEW_LOCAL_RESOURCES
          value: 'true'
```

When it configured to get resources from CDN, the browser console looks like following
![Screenshot from 2023-04-17 19-34-41](https://user-images.githubusercontent.com/1655894/232553516-c9caf4c4-b614-49f9-ba48-d5b87d9f00c8.png)

When `WEBVIEW_LOCAL_RESOURCES` is set, `index.html`, `fake.html` and `service-worker.js` were taken from the same domain as main VS Code frame

![Screenshot from 2023-04-17 19-29-43](https://user-images.githubusercontent.com/1655894/232554458-2700938d-aa5e-4e73-89cd-ae0833045b82.png)


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-3885
https://issues.redhat.com/browse/CRW-4178


### How to test this PR?

#### Webview resources are local-workspace based:

1. Create a workspace from the repository https://github.com/vitaliy-guliy/web-nodejs-sample/tree/test-webviews-local-resources ( it will use prebuilt [quay.io/vgulyy/che-code:webviews-behind-a-proxy-stable](https://quay.io/vgulyy/che-code:webviews-behind-a-proxy-stable) editor image )

Before 2 and 3 steps, open the browser console, navigate to Network.

2. Open README.md at the project root, click Open Preview at the right top. Check that `index.html`, `fake.html` and `service-worker.js` files were loaded from the current domain.

Pay attention on other files with URI like this
```
https://vscode-remote+devspaces-002eapps-002esandbox-002dm3-002e1530-002ep1-002eopenshiftapps-002ecom.vscode-resource.vscode-cdn.net/checode/checode-linux-libc/extensions/github/markdown.css
```
Despite they have `vscode-cdn.net` in the URI, they are loaded from the local domain. Browser do not send any request to `vscode-cdn.net` for that files because of service worker catches the requests for those files and forwards them to the local domain.

3. Install Jira and Bitbucket extension, open Atlassian Settings tab ( webview based ), check that it works.

#### Webview resources are CDN-based:

The same as above, but create a workspace from https://github.com/vitaliy-guliy/web-nodejs-sample/tree/test-webviews-resources-on-cdn
Check the browser console, `index.html`, `fake.html` and `service-worker.js` files must be loaded from [vscode-cdn.net](vscode-cdn.net)


