### PR TITLE
feat: Support Devfile exec commands env in VS Code tasks

### DIFF
--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -23,6 +23,7 @@
   },
   "main": "./out/extension.js",
   "scripts": {
+    "prepare": "yarn compile && yarn test",
     "compile": "gulp compile-extension:che-commands",
     "watch": "gulp watch-extension:che-commands",
     "vscode:prepublish": "npm run compile",

--- a/code/extensions/che-commands/src/utils.ts
+++ b/code/extensions/che-commands/src/utils.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+import { V1alpha2DevWorkspaceSpecTemplateCommandsItemsExecEnv } from "@devfile/api";
+
+/*
+ * This function is used to resolve env variables in command line.
+ * It should support both syntaxes: ${VAR} and $VAR
+ * The function returns the original command line if:
+ * - envVariables is undefined or empty
+ * - there are no env variables in the command line
+ * - there are env variables in the command line but they are not defined in the envVariables array
+ */
+export function resolveEnvVariablesForCommand(commandLine: string, envVariables?: Array<V1alpha2DevWorkspaceSpecTemplateCommandsItemsExecEnv>): string {
+	if (!envVariables || envVariables.length === 0) {
+		return commandLine;
+	}
+
+	// it should support both syntaxes: ${VAR} and $VAR
+	const regex = /\$\{?([a-zA-Z_][a-zA-Z0-9_]*)\}?/g;;
+	let match = regex.exec(commandLine);
+	while (match) {
+		const envVariableName = match[1];
+		const envVariableValue = envVariables.find(env => env.name === envVariableName)?.value;
+		if (envVariableValue) {
+			commandLine = commandLine.replace(match[0], envVariableValue);
+		}
+		match = regex.exec(commandLine);
+	}
+	return commandLine;
+}

--- a/code/extensions/che-commands/tests/jsconfig.json
+++ b/code/extensions/che-commands/tests/jsconfig.json
@@ -1,0 +1,7 @@
+{
+	"typeAcquisition": {
+			"include": [
+					"jest"
+			]
+	}
+}

--- a/code/extensions/che-commands/tests/utils.spec.ts
+++ b/code/extensions/che-commands/tests/utils.spec.ts
@@ -1,0 +1,76 @@
+/* eslint-disable header/header */
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { resolveEnvVariablesForCommand } from '../src/utils';
+
+const USER_NAME = 'UserName';
+const testVariables = [
+	{ name: 'USER', value: USER_NAME },
+	{ name: 'PROJECT_DIR', value: '/projects' }
+];
+
+describe('Resolving Env variables for command line', () => {
+	test('should return the original command if there are no env variables in the command line', () => {
+		const testCommand = 'cd /projects && echo "the command line has no env variables"';
+		const result = resolveEnvVariablesForCommand(testCommand, testVariables);
+
+		expect(result).toBe(testCommand);
+	});
+
+	test('should return the original command if envVariables parameter is undefined', () => {
+		const testCommand = 'echo "${USER}"';
+		const result = resolveEnvVariablesForCommand(testCommand);
+
+		expect(result).toBe(testCommand);
+	});
+
+	test('should return the original command if envVariables parameter is empty array', () => {
+		const testCommand = 'echo "${USER}"';
+		const result = resolveEnvVariablesForCommand(testCommand, []);
+
+		expect(result).toBe(testCommand);
+	});
+
+	test('should return the original command if the corresponding Env Variable is not found', () => {
+		const testCommand = 'echo "${UNKNOWN_VAR}"';
+		const result = resolveEnvVariablesForCommand(testCommand, testVariables);
+
+		expect(result).toBe(testCommand);
+	});
+
+	test('should check ${USER} format', () => {
+		const testCommand = 'echo "${USER}"';
+		const result = resolveEnvVariablesForCommand(testCommand, testVariables);
+
+		expect(result).toBe(`echo "${USER_NAME}"`);
+	});
+
+	test('should check $USER format', () => {
+		const testCommand = 'echo "$USER"';
+		const result = resolveEnvVariablesForCommand(testCommand, testVariables);
+
+		expect(result).toBe(`echo "${USER_NAME}"`);
+	});
+
+	test('should check mixed format', () => {
+		const testCommand = 'cd $PROJECT_DIR && echo "${USER}" && echo $USER';
+		const result = resolveEnvVariablesForCommand(testCommand, testVariables);
+
+		expect(result).toBe(`cd /projects && echo "${USER_NAME}" && echo ${USER_NAME}`);
+	});
+
+	test('should check mixed format with unknown variable', () => {
+		const testCommand = 'cd $PROJECT_DIR && echo "${USER}" && echo ${UNKNOWN_VAR} && echo $USER && echo $ANOTHER_UNKNOWN_VAR';
+		const result = resolveEnvVariablesForCommand(testCommand, testVariables);
+
+		expect(result).toBe('cd /projects && echo "UserName" && echo ${UNKNOWN_VAR} && echo UserName && echo $ANOTHER_UNKNOWN_VAR');
+	});
+});


### PR DESCRIPTION
### What does this PR do?
- Support Devfile exec commands env in VS Code tasks:
         resolve env variables for exec commands at `devfile command => VS Code task` transformation step
- Turn On execution `jest` tests for the `che-commands` extension 
 

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21760

### How to test this PR?
- you can use [this link](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/test-env-var-for-commands) to start a workspace
- [it's configured](https://github.com/RomanNikitenko/web-nodejs-sample/blob/5a20412ce02c0b17749db5a48c598f78875cca1f/.che/che-editor.yaml#L33) to use image of current PR
- there are [few commands](https://github.com/RomanNikitenko/web-nodejs-sample/blob/5a20412ce02c0b17749db5a48c598f78875cca1f/devfile.yaml#L26-L61) in the devfile for testing
- go to the `Terminal` => `Run Task` `devfile` and select a task for testing 
