### PR TITLE
feat: Provide branding for the Welcome page subtitle

### DIFF
--- a/.rebase/replace/code/src/vs/base/common/product.ts.json
+++ b/.rebase/replace/code/src/vs/base/common/product.ts.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "readonly nameLong: string;",
+    "by": "readonly nameLong: string;\\\n\\\treadonly nameLongSubtitle?: string;"
+  }
+]

--- a/.rebase/replace/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, \"Editing evolved\")",
+    "by": "this.productService.nameLongSubtitle \\|\\| localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, \"Editing evolved\")"
+  }
+]

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ The following example shows all of the properties that you can customize by usin
 ```json
 {
     "nameShort": "Branded IDE",
-    "nameLong": "Branded Instance of Eclipse Che with Branded Microsoft Visual Studio Code - Open Source IDE",
+    "nameLong": "Branded Instance of Eclipse Che",
+    "nameLongSubtitle": "with Branded Microsoft Visual Studio Code - Open Source IDE",
     "icons": {
         "favicon": {
             "universal": "icons/favicon.ico"

--- a/code/src/vs/base/common/product.ts
+++ b/code/src/vs/base/common/product.ts
@@ -62,6 +62,7 @@ export interface IProductConfiguration {
 
 	readonly nameShort: string;
 	readonly nameLong: string;
+	readonly nameLongSubtitle?: string;
 
 	readonly win32AppUserModelId?: string;
 	readonly win32MutexName?: string;

--- a/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -793,7 +793,7 @@ export class GettingStartedPage extends EditorPane {
 
 		const header = $('.header', {},
 			$('h1.product-name.caption', {}, this.productService.nameLong),
-			$('p.subtitle.description', {}, localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, "Editing evolved"))
+			$('p.subtitle.description', {}, this.productService.nameLongSubtitle || localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, "Editing evolved"))
 		);
 
 		const leftColumn = $('.categories-column.categories-column-left', {},);

--- a/rebase.sh
+++ b/rebase.sh
@@ -267,6 +267,26 @@ apply_code_vs_workbench_contrib_webview_browser_pre_index_no_csp_html_changes() 
   git add code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html > /dev/null 2>&1
 }
 
+# Apply changes for the given file
+apply_changes() {
+  local filePath="$1"
+  
+  if [ -z "$filePath" ]; then
+     echo "Can not apply changes - the path was not passed"
+     exit 1;
+  fi
+  
+  echo "  ⚙️ reworking $filePath..."
+  # reset the file from what is upstream
+  git checkout --theirs "$filePath" > /dev/null 2>&1
+  
+  # now apply again the changes
+  apply_replace "$filePath"
+  
+  # resolve the change
+  git add "$filePath" > /dev/null 2>&1
+}
+
 # Will try to identify the conflicting files and for some of them it's easy to re-apply changes
 resolve_conflicts() {
   echo "⚠️  There are conflicting files, trying to solve..."
@@ -298,6 +318,10 @@ resolve_conflicts() {
       apply_code_vs_workbench_contrib_webview_browser_pre_index_html_changes
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html" ]]; then
       apply_code_vs_workbench_contrib_webview_browser_pre_index_no_csp_html_changes
+    elif [[ "$conflictingFile" == "code/src/vs/base/common/product.ts" ]]; then
+      apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts" ]]; then
+      apply_changes "$conflictingFile"
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"
       exit 1


### PR DESCRIPTION
### What does this PR do?
Provide branding for the Welcome page subtitle, so it's possible to provide a subtitle using `product.json` file.
Downstream change: https://github.com/redhat-developer/devspaces-images/pull/432

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-4114

### How to test this PR?
1. Provide the corresponding changes to the `product.json` file:
<img width="631" alt="image" src="https://user-images.githubusercontent.com/5676062/234275969-c9bb4c92-6e0e-466e-aa41-e6b762eca14d.png">

2. Build the assembly and check the result:

<img width="1572" alt="image" src="https://user-images.githubusercontent.com/5676062/234276288-ba3d3251-d463-4c3e-8827-3d0b75ceda51.png">

