### PR TITLE
fix: Fix pattern for replacing OPENVSX_URL variable

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -62,7 +62,7 @@ if [ -n "${OPENVSX_REGISTRY_URL+x}" ]; then
   echo "using OPENVSX_URL=$OPENVSX_URL"
   sed -i -r -e "s|\"serviceUrl\": \"..*\"|\"serviceUrl\": \"${OPENVSX_URL}/gallery\"|" product.json
   sed -i -r -e "s|\"itemUrl\": \"..*\"|\"itemUrl\": \"${OPENVSX_URL}/item\"|" product.json
-  sed -i -e "s|serviceUrl:\".*\",itemUrl:\".*\"},version|serviceUrl:\"${OPENVSX_URL}/gallery\",itemUrl:\"${OPENVSX_URL}/item\"},version|" out/vs/workbench/workbench.web.main.js
+  sed -i -e "s|extensionsGallery:{serviceUrl:\"[^\"]*\",itemUrl:\"[^\"]*\"|extensionsGallery:{serviceUrl:\"${OPENVSX_URL}/gallery\",itemUrl:\"${OPENVSX_URL}/item\"|" out/vs/workbench/workbench.web.main.js
 fi
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes pattern for replacing `OPENVSX_URL` variable in the `/checode/checode-linux-libc/out/vs/workbench/workbench.web.main.js` file.
The pattern is used in the entrypoint, see [here](https://github.com/che-incubator/che-code/blob/4cc3fd0d4338e52ed88cdb8364b93fe7ccd32392/build/scripts/entrypoint-volume.sh#L65).

Before this change the pattern broke the corresponding product configuration - it [cut all values of the product.json file](https://github.com/redhat-developer/devspaces-images/blob/9b48e7a56904dfd60de0c96b32b3131511cfc9b9/devspaces-code/code/product.json#L101-L125) which were placed after the `serviceUrl` and `itemUrl` fields. 

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21962
https://issues.redhat.com/browse/CRW-4114


### How to test this PR?
I tested it in the downstream:
- start a workspace
- open `/checode/checode-linux-libc/out/vs/workbench/workbench.web.main.js` file
- search `extensionsGallery:`
- check that [all fields of the product.json file](https://github.com/redhat-developer/devspaces-images/blob/9b48e7a56904dfd60de0c96b32b3131511cfc9b9/devspaces-code/code/product.json#L101-L125) are present in the file

<img width="1654" alt="Screenshot 2023-05-05 at 20 08 54" src="https://user-images.githubusercontent.com/5676062/236522938-fe9b6a0d-064c-4d7f-b8f7-5810d8b350b0.png">

The pattern should also handle correctly extra fields in the `extensionGalary`, for example:
```
"extensionsGallery": {
    "serviceUrl": "https://open-vsx.org/vscode/gallery",
    "itemUrl": "https://open-vsx.org/vscode/item",
    "resourceUrlTemplate": "someResourceUrlTemplate"
  },
```