### PR TITLE
chore: Remove delay at starting Machine-Exec step

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -25,7 +25,6 @@ ls -la /checode/
 # Start the machine-exec component in background
 export MACHINE_EXEC_PORT=3333
 nohup /checode/bin/machine-exec --url "0.0.0.0:${MACHINE_EXEC_PORT}" &
-sleep 5
 
 # Start the checode component based on musl or libc
 


### PR DESCRIPTION
### What does this PR do?
Remove a delay at starting Machine-Exec step, it should reduce starting VS Code process by 5 seconds.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-4342

### How to test this PR?
- create a terminal in a container directly after starting VS Code 
- check that the terminal works as expected
