### PR TITLE
Update the dependency declaration to make it work for Cachito

### DIFF
--- a/code/extensions/emmet/package.json
+++ b/code/extensions/emmet/package.json
@@ -483,7 +483,7 @@
   },
   "dependencies": {
     "@emmetio/abbreviation": "^2.2.0",
-    "@emmetio/css-parser": "ramya-rao-a/css-parser#vscode",
+    "@emmetio/css-parser": "git+https://github.com/ramya-rao-a/css-parser#vscode",
     "@emmetio/html-matcher": "^0.3.3",
     "@emmetio/math-expression": "^1.0.4",
     "@vscode/emmet-helper": "^2.3.0",

--- a/code/extensions/emmet/yarn.lock
+++ b/code/extensions/emmet/yarn.lock
@@ -23,9 +23,9 @@
   dependencies:
     "@emmetio/scanner" "^1.0.0"
 
-"@emmetio/css-parser@ramya-rao-a/css-parser#vscode":
+"@emmetio/css-parser@git+https://github.com/ramya-rao-a/css-parser#vscode":
   version "0.4.0"
-  resolved "https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660"
+  resolved "git+https://github.com/ramya-rao-a/css-parser#370c480ac103bd17c7bcfb34bf5d577dc40d3660"
   dependencies:
     "@emmetio/stream-reader" "^2.2.0"
     "@emmetio/stream-reader-utils" "^0.1.0"


### PR DESCRIPTION
### What does this PR do?
Downstream, when Cachito processes the dependencies it doesn't recognize those that point to the GitHub project in the following format:
`"@emmetio/css-parser": "ramya-rao-a/css-parser#vscode"`

Cachito recognizes such dependencies [only when they are prefixed explicitly](https://github.com/containerbuildsystem/cachito/blob/7139ce0eae593598a69feb062ac63de745691464/cachito/workers/pkg_managers/general_js.py#L695-L703):
`"@emmetio/css-parser": "git+https://github.com/ramya-rao-a/css-parser#vscode"`

Note, we can't send this patch upstream as there was [an opposite problem](https://github.com/microsoft/vscode/issues/149291) for them which is usually [fixed like this](https://github.com/microsoft/vscode/pull/149962/files).

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
It's needed for migrating downstream build to Cachito https://issues.redhat.com/browse/CRW-3160

### How to test this PR?

