### PR TITLE
feat: Provide branding for the Welcome page

### DIFF
--- a/.rebase/replace/code/src/vs/base/common/product.ts.json
+++ b/.rebase/replace/code/src/vs/base/common/product.ts.json
@@ -1,6 +1,6 @@
 [
   {
     "from": "readonly nameLong: string;",
-    "by": "readonly nameLong: string;\\\n\\\treadonly nameLongSubtitle?: string;"
+    "by": "readonly nameLong: string;\\\n\\\treadonly welcomePageTitle?: string;\\\n\\\treadonly welcomePageSubtitle?: string;"
   }
 ]

--- a/.rebase/replace/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts.json
@@ -1,6 +1,10 @@
 [
   {
-    "from": "localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, \"Editing evolved\")",
-    "by": "this.productService.nameLongSubtitle \\|\\| localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, \"Editing evolved\")"
+    "from": "'h1.product-name.caption', {}, this.productService.nameLong",
+    "by": "'h1.product-name.caption', {}, this.productService.welcomePageTitle \\|\\| this.productService.nameLong"
+  },
+  {
+    "from": "'p.subtitle.description', {},",
+    "by": "'p.subtitle.description', {}, this.productService.welcomePageSubtitle \\|\\|"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ The following example shows all of the properties that you can customize by usin
 ```json
 {
     "nameShort": "Branded IDE",
-    "nameLong": "Branded Instance of Eclipse Che",
-    "nameLongSubtitle": "with Branded Microsoft Visual Studio Code - Open Source IDE",
+    "nameLong": "Branded Instance of Eclipse Che with Branded Microsoft Visual Studio Code - Open Source IDE",
+    "welcomePageTitle": "Branded Instance of Eclipse Che",
+    "welcomePageSubtitle": "with Branded Microsoft Visual Studio Code - Open Source IDE",
     "icons": {
         "favicon": {
             "universal": "icons/favicon.ico"
@@ -165,6 +166,10 @@ The following example shows all of the properties that you can customize by usin
 `nameShort` is the application name for UI elements.
 
 `nameLong` is the application name that is used for the **Welcome** page, **About** dialog, and browser tab title.
+
+`welcomePageTitle` is the **Welcome** page title. The field is optional, the default is `nameLong` as the title.
+
+`welcomePageSubtitle` - is the **Welcome** page subtitle. The field is optional, the default value comes from the upstream.
 
 `favicon` is the icon for the browser tab title for all themes.
 

--- a/code/src/vs/base/common/product.ts
+++ b/code/src/vs/base/common/product.ts
@@ -62,7 +62,8 @@ export interface IProductConfiguration {
 
 	readonly nameShort: string;
 	readonly nameLong: string;
-	readonly nameLongSubtitle?: string;
+	readonly welcomePageTitle?: string;
+	readonly welcomePageSubtitle?: string;
 
 	readonly win32AppUserModelId?: string;
 	readonly win32MutexName?: string;

--- a/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -813,8 +813,8 @@ export class GettingStartedPage extends EditorPane {
 		}));
 
 		const header = $('.header', {},
-			$('h1.product-name.caption', {}, this.productService.nameLong),
-			$('p.subtitle.description', {}, this.productService.nameLongSubtitle || localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, "Editing evolved"))
+			$('h1.product-name.caption', {}, this.productService.welcomePageTitle || this.productService.nameLong),
+			$('p.subtitle.description', {}, this.productService.welcomePageSubtitle || localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, "Editing evolved"))
 		);
 
 		const leftColumn = $('.categories-column.categories-column-left', {},);


### PR DESCRIPTION
depends on https://github.com/che-incubator/che-code/pull/219

### What does this PR do?
Provides branding for the Welcome page:
- value of the `welcomePageTitle` field is used as the `Welcome` page title
- value of the `nameLong` filed is used as the `Welcome` page title if the `welcomePageTitle` field is not provided  
- value of the `welcomePageSubtitle` field is used as the `Welcome` page subtitle
- [default value from the upstream](https://github.com/microsoft/vscode/blob/3f7bc08865b413eb688fcd87b06458f2f5c3efe9/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts#L817) is used as the `Welcome` page subtitle if the `welcomePageSubtitle` field is not provided
- `nameLong` is still used for the `About` dialog and browser tab title


https://github.com/che-incubator/che-code/assets/5676062/dd622ea3-acda-44d1-8f19-41e6f796cb4b

  
### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-4114

### How to test this PR?
- provide the corresponding fields to the `product.json` file
- build an assembly
- check that the corresponding changes are applied for the `Welcome` page

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/5676062/236813549-d283286c-2090-445c-88d8-a85322f0ca80.png">

