### PR TITLE
Don't run the tests before the dependencies are actually installed

### DIFF
--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -23,7 +23,6 @@
   },
   "main": "./out/extension.js",
   "scripts": {
-    "prepare": "yarn compile && yarn test",
     "compile": "gulp compile-extension:che-commands",
     "watch": "gulp watch-extension:che-commands",
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
### What does this PR do?
Recently, running the test for the `che-commands` extensions [was bound](https://github.com/che-incubator/che-code/commit/319c20aa848e32c2c5e49b1ccbac2acd1b4c128d) before the dependencies installation phase.
While it works well when building Che-Code assembly from the root of the project, running the dependencies installation solely for the `che-commands` extension fails. It's because the script depends on the `gulp` binary which isn't installed yet.
It affects the downstream build.

After merging this PR, the tests for `che-commands` extensions can be run the same way as for other extensions - by calling `yarn test` command, e.g: https://github.com/che-incubator/che-code/blob/8cf7bbc8a81ac46e6162b81900906e89babe1480/code/extensions/html-language-features/server/package.json#L30

### What issues does this PR fix?
It's needed for https://issues.redhat.com/browse/CRW-3160

### How to test this PR?
After running `cd code/extensions/che-commands && yarn`
the extension's dependencies should be installed successfully, without the error:
```
$ gulp compile-extension:che-commands
/bin/sh: line 1: gulp: command not found
error Command failed with exit code 127.
```
