### PR TITLE
chore: Remove unused env variable

### DIFF
--- a/code/extensions/che-api/src/impl/k8s-devworkspace-env-variables.ts
+++ b/code/extensions/che-api/src/impl/k8s-devworkspace-env-variables.ts
@@ -55,13 +55,6 @@ export class K8sDevWorkspaceEnvVariables {
   private readonly pluginRegistryURL!: string;
 
   /**
-   * pluginRegistryInternalURL - Plugin registry internal URL
-   */
-
-  private readonly pluginRegistryInternalURL!: string;
-
-
-  /**
    * dashboardURL - Dashboard URL
    */
 
@@ -104,12 +97,6 @@ export class K8sDevWorkspaceEnvVariables {
       this.pluginRegistryURL = process.env.CHE_PLUGIN_REGISTRY_URL;
     }
 
-    if (process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL === undefined) {
-      console.error('Environment variable CHE_PLUGIN_REGISTRY_INTERNAL_URL is not set');
-    } else {
-      this.pluginRegistryInternalURL = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
-    }
-
     if (process.env.CHE_DASHBOARD_URL === undefined) {
       console.error('Environment variable CHE_DASHBOARD_URL is not set');
     } else {
@@ -139,10 +126,6 @@ export class K8sDevWorkspaceEnvVariables {
 
   getPluginRegistryURL(): string {
     return this.pluginRegistryURL;
-  }
-
-  getPluginRegistryInternalURL(): string {
-    return this.pluginRegistryInternalURL;
   }
 
   getDashboardURL(): string {

--- a/code/extensions/che-api/tests/_data/flattened-devfile.yaml
+++ b/code/extensions/che-api/tests/_data/flattened-devfile.yaml
@@ -69,8 +69,6 @@ components:
       value: https://che-eclipse-che.apps.cluster-c9b7.c9b7.sandbox909.opentlc.com
     - name: CHE_PLUGIN_REGISTRY_URL
       value: https://che-eclipse-che.apps.cluster-c9b7.c9b7.sandbox909.opentlc.com/plugin-registry/v3
-    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
-      value: http://plugin-registry.eclipse-che.svc:8080/v3
     image: quay.io/che-incubator/che-code:insiders
     memoryLimit: 128Mi
     memoryRequest: 32Mi

--- a/code/extensions/che-port/tests/devfile-handler/devworkspace-flattened.yaml
+++ b/code/extensions/che-port/tests/devfile-handler/devworkspace-flattened.yaml
@@ -69,8 +69,6 @@ components:
       value: https://che-eclipse-che.apps.cluster-c9b7.c9b7.sandbox909.opentlc.com
     - name: CHE_PLUGIN_REGISTRY_URL
       value: https://che-eclipse-che.apps.cluster-c9b7.c9b7.sandbox909.opentlc.com/plugin-registry/v3
-    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
-      value: http://plugin-registry.eclipse-che.svc:8080/v3
     image: quay.io/che-incubator/che-code:insiders
     memoryLimit: 128Mi
     memoryRequest: 32Mi

--- a/code/extensions/che-port/tests/endpoints-tree-data-provider/devworkspace-flattened.yaml
+++ b/code/extensions/che-port/tests/endpoints-tree-data-provider/devworkspace-flattened.yaml
@@ -69,8 +69,6 @@ components:
       value: https://che-eclipse-che.apps.cluster-c9b7.c9b7.sandbox909.opentlc.com
     - name: CHE_PLUGIN_REGISTRY_URL
       value: https://che-eclipse-che.apps.cluster-c9b7.c9b7.sandbox909.opentlc.com/plugin-registry/v3
-    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
-      value: http://plugin-registry.eclipse-che.svc:8080/v3
     image: quay.io/che-incubator/che-code:insiders
     memoryLimit: 128Mi
     memoryRequest: 32Mi


### PR DESCRIPTION
### What does this PR do?
Removes code related to the `CHE_PLUGIN_REGISTRY_INTERNAL_URL` env variable.
I don't see why we need it on the `che-code` side. 

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
no issue - just clean up

### How to test this PR?
Tests should be happy.
