### PR TITLE
Support vscode `--default-workspace` option

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -129,5 +129,23 @@ fi
 
 echo "Node.js dir for running VS Code: $VSCODE_NODEJS_RUNTIME_DIR"
 
-# Launch che without connection-token, security is managed by Che
-"$VSCODE_NODEJS_RUNTIME_DIR/node" out/server-main.js --host "${CODE_HOST}" --port 3100 --without-connection-token --default-folder ${PROJECT_SOURCE}
+# Set the default workspace if the VSCODE_DEFAULT_WORKSPACE env variable exist``
+if [[ -v VSCODE_DEFAULT_WORKSPACE ]]; then
+  if [[ -f "${VSCODE_DEFAULT_WORKSPACE}" ]]; then
+    echo "Found VSCODE_DEFAULT_WORKSPACE environment variable set to: \"${VSCODE_DEFAULT_WORKSPACE}\""
+    FOLDER_OR_WORKSPACE_OPTION="--default-workspace ${VSCODE_DEFAULT_WORKSPACE}"
+  else
+    echo "WARNING: VS Code default workspace file ${VSCODE_DEFAULT_WORKSPACE} doesn't exist."
+    FOLDER_OR_WORKSPACE_OPTION="--default-folder ${PROJECT_SOURCE}"
+  fi
+else
+  FOLDER_OR_WORKSPACE_OPTION="--default-folder ${PROJECT_SOURCE}"
+fi
+
+# Launch VS Code without connection-token, security is managed by Che
+"$VSCODE_NODEJS_RUNTIME_DIR/node" out/server-main.js \
+                --host "${CODE_HOST}" \
+                --port 3100 \
+                --without-connection-token \
+                ${FOLDER_OR_WORKSPACE_OPTION}
+

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -129,7 +129,7 @@ fi
 
 echo "Node.js dir for running VS Code: $VSCODE_NODEJS_RUNTIME_DIR"
 
-# Set the default workspace if the VSCODE_DEFAULT_WORKSPACE env variable exist``
+# Set the default workspace if the VSCODE_DEFAULT_WORKSPACE env variable exists
 if [[ -v VSCODE_DEFAULT_WORKSPACE ]]; then
   if [[ -f "${VSCODE_DEFAULT_WORKSPACE}" ]]; then
     echo "Found VSCODE_DEFAULT_WORKSPACE environment variable set to: \"${VSCODE_DEFAULT_WORKSPACE}\""


### PR DESCRIPTION
### What does this PR do?

It allows to specify a VS Code workspace file through the env variable `VSCODE_DEFAULT_WORKSPACE`

### What issues does this PR fix?

https://github.com/eclipse/che/issues/22218

### How to test this PR?

For Che 7.64 or higher and Dev Spaces 3.6 or higher I have created [the following gist](https://gist.githubusercontent.com/l0rd/d970c5ac4fc66aa3b7162360d3efee85/raw/che-code.yaml) with a VS Code spec that uses image `quay.io/mloriedo/che-code:insiders` and that can be tested using the following URL:  
`<che-host>/#<repo-url>?che-editor=https://gist.githubusercontent.com/l0rd/d970c5ac4fc66aa3b7162360d3efee85/raw/7f0a93164896a4c2b28971ba7cccc3238b8857b5/che-code.yaml`

[This link](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/l0rd/che-demo-app?che-editor=https://gist.githubusercontent.com/l0rd/d970c5ac4fc66aa3b7162360d3efee85/raw/7f0a93164896a4c2b28971ba7cccc3238b8857b5/che-code.yaml) allows testing on dogfooding instance.
