### PR TITLE
Respect the `NO_PROXY` environment variable

### DIFF
--- a/code/src/vs/platform/request/node/proxy.ts
+++ b/code/src/vs/platform/request/node/proxy.ts
@@ -37,7 +37,6 @@ function getCheSystemProxyURI(requestURL: Url, env: typeof process.env): string 
 	const hostname = requestURL.hostname?.toLowerCase();
 	const port = requestURL.port || (requestURL.protocol === 'https:' ? '443' : '80');
 	if (hostname && filters.some(({ domain, port: filterPort }) => `.${hostname}`.endsWith(domain) && (!filterPort || port === filterPort))) {
-		console.info(`skipping proxy`);
 		return null;
 	}
 
@@ -51,9 +50,7 @@ export interface IOptions {
 
 export async function getProxyAgent(rawRequestURL: string, env: typeof process.env, options: IOptions = {}): Promise<Agent> {
 	const requestURL = parseUrl(rawRequestURL);
-	console.info(`Getting proxy for URL:  ${rawRequestURL}`);
 	const proxyURL = options.proxyUrl || getCheSystemProxyURI(requestURL, env);
-	console.info(`proxyURL:  ${proxyURL}`);
 
 	if (!proxyURL) {
 		return null;

--- a/code/src/vs/platform/request/node/proxy.ts
+++ b/code/src/vs/platform/request/node/proxy.ts
@@ -37,6 +37,7 @@ function getCheSystemProxyURI(requestURL: Url, env: typeof process.env): string 
 	const hostname = requestURL.hostname?.toLowerCase();
 	const port = requestURL.port || (requestURL.protocol === 'https:' ? '443' : '80');
 	if (hostname && filters.some(({ domain, port: filterPort }) => `.${hostname}`.endsWith(domain) && (!filterPort || port === filterPort))) {
+		console.info(`skipping proxy`);
 		return null;
 	}
 
@@ -50,7 +51,9 @@ export interface IOptions {
 
 export async function getProxyAgent(rawRequestURL: string, env: typeof process.env, options: IOptions = {}): Promise<Agent> {
 	const requestURL = parseUrl(rawRequestURL);
+	console.info(`Getting proxy for URL:  ${rawRequestURL}`);
 	const proxyURL = options.proxyUrl || getCheSystemProxyURI(requestURL, env);
+	console.info(`proxyURL:  ${proxyURL}`);
 
 	if (!proxyURL) {
 		return null;


### PR DESCRIPTION
### What does this PR do?
While VS Code doesn't respect the `NO_PROXY` environment variable, this PR allows Che-Code to skip the proxy for the provided URLs list.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
fixes https://github.com/eclipse/che/issues/22078

### How to test this PR?
1. Run a Che instance in a proxied environment.
2. Configure it to communicate with an embedded OpenVSX instance rather than the public one.
3. Make sure that it's possible to install the extensions in VS Code.
