### PR TITLE
fix: Restart From Local Devfile action

### DIFF
--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -18,7 +18,11 @@ import * as vscode from 'vscode';
 
 const DEVFILE_NAME = 'devfile.yaml';
 const DOT_DEVFILE_NAME = '.devfile.yaml';
-const DEFAULT_EDITOR_ENTRY = 'che-incubator/che-code/insiders';
+const EDITOR_CONTENT_STUB: string = `
+schemaVersion: 2.2.0
+metadata:
+  name: che-code
+  `;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 
@@ -111,10 +115,9 @@ async function updateDevfile(cheApi: any): Promise<void> {
     throw new Error(`The devfile was not found at: ${devfilePath}`);
   }
 
-  const currentDevfile = await devfileService.get()
+  const currentDevfile = await devfileService.get();
   const projects = currentDevfile.projects || [];
-
-  const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorEntry: DEFAULT_EDITOR_ENTRY, projects: [] }, axios.default);
+  const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, projects: [] }, axios.default);
   if (newContent) {
     newContent.devWorkspace.spec!.template!.projects = projects;
     await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);


### PR DESCRIPTION
### What does this PR do?
Allows to avoid requests to the plugin registry for the new Devfile context generation.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
should fix https://github.com/eclipse/che/issues/22242

### How to test this PR?
1. Start a workspace from [the repo](https://github.com/RomanNikitenko/web-nodejs-sample/tree/fix-restart-from-devfile), it [contains a reference to the image ](https://github.com/RomanNikitenko/web-nodejs-sample/blob/a1335f91798efc4c83570a2f37ce5ad825726b76/.che/che-editor.yaml#L33) that was built for the current pull request.
2. Provide a change to the devfile
3. Restart the workspace using `Restart From Local Devfile` action  
