### PR TITLE
fix: plugin endpoints should be visible by default

### DIFF
--- a/code/extensions/che-port/package.json
+++ b/code/extensions/che-port/package.json
@@ -63,7 +63,7 @@
     "views": {
       "endpoints": [
         {
-          "name": "endpoints",
+          "name": "Endpoints",
           "id": "endpoints"
         }
       ]

--- a/code/extensions/che-port/src/endpoints-tree-data-provider.ts
+++ b/code/extensions/che-port/src/endpoints-tree-data-provider.ts
@@ -104,7 +104,7 @@ export class EndpointsTreeDataProvider implements vscode.TreeDataProvider<Endpoi
     );
 
     // initialize context
-    this.updateContext(treeView, false);
+    this.updateContext(treeView, true);
   }
 
   // update global context (like toggle mode for showing plugins)


### PR DESCRIPTION
### What does this PR do?
Makes plugins endpoints visible by default

![Screenshot from 2023-06-12 16-38-01](https://github.com/che-incubator/che-code/assets/1655894/11131787-f58d-46c0-b555-a46fa24e933c)

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-4521

### How to test this PR?
Two ways:

The first, is to wait for che-code image, that will be build by this pull request and use it to test the changes

Second (preferable), use Che instance to
- create a workspsce from the branch
- run `prepare` and then `build` devfile commands
- then run `run` command to start server
- use the notification with proposal to open a new che-code instance in separate browser tab
- open to Endpoints view and check the endpoints
