### PR TITLE
fix: take into account all certificates located in /public-certs

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -132,6 +132,11 @@ if [ ! -f "$EXTRA_CERTS" ]; then
   CHE_CUSTOM_CERTIFICATE="/tmp/che/secret/ca.crt"
   if [ -f "$CHE_CUSTOM_CERTIFICATE" ]; then
     cat "$CHE_CUSTOM_CERTIFICATE" >> "$EXTRA_CERTS"
+
+    # check if it is needed to add a new line character
+    if [[ $(tail -c1 "$CHE_CUSTOM_CERTIFICATE") != "" ]]; then
+      echo >> "$EXTRA_CERTS"
+    fi
   fi
 
   # Check if we have public certificates in /public-certs
@@ -141,6 +146,11 @@ if [ ! -f "$EXTRA_CERTS" ]; then
     do
       if [ -f "$ENTRY" ]; then
         cat "$ENTRY" >> "$EXTRA_CERTS"
+
+        # check if it is needed to add a new line character
+        if [[ $(tail -c1 "$ENTRY") != "" ]]; then
+          echo >> "$EXTRA_CERTS"
+        fi
       fi
     done
   fi

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -117,11 +117,39 @@ if [ -n "${WEBVIEW_LOCAL_RESOURCES+x}" ]; then
 fi
 
 
-# Check if we have a custom CA certificate
-if [ -f /tmp/che/secret/ca.crt ]; then
-  echo "Adding custom CA certificate"
-  export NODE_EXTRA_CA_CERTS=/tmp/che/secret/ca.crt
+###################################################################################
+#
+# Prepare /tmp/node-extra-certificates/ca.crt bundle, initilize NODE_EXTRA_CA_CERTS 
+#
+###################################################################################
+EXTRA_CERTS_DIR="/tmp/node-extra-certificates"
+EXTRA_CERTS="$EXTRA_CERTS_DIR/ca.crt"
+
+if [ ! -f "$EXTRA_CERTS" ]; then
+  mkdir -p "$EXTRA_CERTS_DIR"
+
+  # Check if we have a custom Che CA certificate
+  CHE_CUSTOM_CERTIFICATE="/tmp/che/secret/ca.crt"
+  if [ -f "$CHE_CUSTOM_CERTIFICATE" ]; then
+    cat "$CHE_CUSTOM_CERTIFICATE" >> "$EXTRA_CERTS"
+  fi
+
+  # Check if we have public certificates in /public-certs
+  CUSTOM_PUBLIC_CERTIFICATES="/public-certs"
+  if [[ -d "$CUSTOM_PUBLIC_CERTIFICATES" ]]; then
+    for ENTRY in "$CUSTOM_PUBLIC_CERTIFICATES"/*
+    do
+      if [ -f "$ENTRY" ]; then
+        cat "$ENTRY" >> "$EXTRA_CERTS"
+      fi
+    done
+  fi
 fi
+
+if [ -f "$EXTRA_CERTS" ]; then
+  export NODE_EXTRA_CA_CERTS="$EXTRA_CERTS"
+fi
+
 
 if [ -z "$VSCODE_NODEJS_RUNTIME_DIR" ]; then
   VSCODE_NODEJS_RUNTIME_DIR="$(pwd)" 


### PR DESCRIPTION
### What does this PR do?
On each container run
- checks for `/tmp/che/secret/ca.crt` and for all certificates in `/public-certs`
- combines all found certificates in one `/tmp/node-extra-certificates/ca.crt`
- initializes NODE_EXTRA_CA_CERTS environment variable with `/tmp/node-extra-certificates/ca.crt`

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/22277

### How to test this PR?
#### 1. Use prepared sample to test the changes using che-code image, built by github action ( see comments below )
To test:
- create a repository from https://github.com/vitaliy-guliy/web-nodejs-sample/tree/test-public-certs-pr243
- open a terminal, run `env | grep NODE_EXTRA_CA_CERTS` to ensure `NODE_EXTRA_CA_CERTS` is set and points to a real certificate
- run `cat /checode/entrypoint-volume.sh` and check the changes provided by this pull request are present in the file

#### 2. The second one:
- clone the repository, checkout this branch
- build che-code docker image by hands, upload to your `quay.io` account
- fork any sample, define `.che/che-editor.yaml`, specify che-code image
- create a workspace from the fork

#### 3. I build [che-code docker image](quay.io/vgulyy/che-code:test-public-certs) locally and [prepared a sample](https://github.com/vitaliy-guliy/web-nodejs-sample/tree/test-public-certs).

To test:
- create a repository from https://github.com/vitaliy-guliy/web-nodejs-sample/tree/test-public-certs
- open a terminal, run `env | grep NODE_EXTRA_CA_CERTS` to ensure `NODE_EXTRA_CA_CERTS` is set and points to a real certificate

