### PR TITLE
chore: add more memory for the dev container

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -14,7 +14,7 @@ components:
   - name: dev
     container:
       image: quay.io/che-incubator/che-code-dev:insiders
-      memoryLimit: 7Gi
+      memoryLimit: 12Gi
       cpuLimit: 3500m
       endpoints:
         - exposure: public


### PR DESCRIPTION
### What does this PR do?
Adds more memory for the dev container to be able to built che-code with yarn on the dogfooding instance.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
No issue

### How to test this PR?
- Create a workspace from this branch
- Open a terminal, run `yarn prepare` and then `yarn watch` or `yarn build`.
