### PR TITLE
Switch to `canvas` xterm.js renderrer, by default

### DIFF
--- a/code/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/code/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -293,7 +293,7 @@ const terminalConfiguration: IConfigurationNode = {
 				localize('terminal.integrated.gpuAcceleration.off', "Disable GPU acceleration within the terminal. The terminal will render much slower when GPU acceleration is off but it should reliably work on all systems."),
 				localize('terminal.integrated.gpuAcceleration.canvas', "Use the terminal's fallback canvas renderer which uses a 2d context instead of webgl which may perform better on some systems. Note that some features are limited in the canvas renderer like opaque selection.")
 			],
-			default: 'auto',
+			default: 'canvas', // to fix the invisible characters issue
 			description: localize('terminal.integrated.gpuAcceleration', "Controls whether the terminal will leverage the GPU to do its rendering.")
 		},
 		[TerminalSettingId.TerminalTitleSeparator]: {


### PR DESCRIPTION
### What does this PR do?
Switches the default terminal renderer from `webgl` (auto) to `canvas`.
It fixes the problem when the characters are not visible in a terminal while typing.
This issue comes from xterm.js which currently doesn't work correctly with the latest Chrome versions when GPU Acceleration is enabled.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-4513

### How to test this PR?
1. Start a workspace from https://github.com/azatsarynnyy/java-spring-petclinic/tree/xterm
2. Check that the `canvas` terminal renderer is set by default:
![image](https://github.com/che-incubator/che-code/assets/1636395/fcb91446-d219-4ca0-8f61-e8c0ec13fd1c)
