### PR TITLE
Switch to canvas xterm.js renderrer, by default

### DIFF
--- a/code/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/code/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -293,7 +293,7 @@ const terminalConfiguration: IConfigurationNode = {
 				localize('terminal.integrated.gpuAcceleration.off', "Disable GPU acceleration within the terminal. The terminal will render much slower when GPU acceleration is off but it should reliably work on all systems."),
 				localize('terminal.integrated.gpuAcceleration.canvas', "Use the terminal's fallback canvas renderer which uses a 2d context instead of webgl which may perform better on some systems. Note that some features are limited in the canvas renderer like opaque selection.")
 			],
-			default: 'auto',
+			default: 'canvas', // to fix the invisible characters issue
 			description: localize('terminal.integrated.gpuAcceleration', "Controls whether the terminal will leverage the GPU to do its rendering.")
 		},
 		[TerminalSettingId.TerminalTitleSeparator]: {


### PR DESCRIPTION
### What does this PR do?
Backports https://github.com/che-incubator/che-code/pull/245 to 7.67.x

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

