### PR TITLE
feat: Add Device Authentication flow support

### DIFF
--- a/code/extensions/che-api/src/api/github-service.ts
+++ b/code/extensions/che-api/src/api/github-service.ts
@@ -21,22 +21,16 @@ export const GithubService = Symbol('GithubService');
 
 export interface GithubService {
     getToken(): Promise<string>;
-    
-    /**
-     * Updates in-memory value of the token,
-     * use {@link GithubService.persistToken()} to store a token to the corresponding secret   
-     */
-    updateCachedToken(token: string): Promise<void>;
 
     /**
      * Persists the given token to the corresponding secret, the in-memory value will be updated as well.
      * A new secret will be created if there is no secret yet.
      * Note: The existing token will be owerriten by the given one.   
-     */ 
-    persistToken(token: string): Promise<void>;
+     */
+    persistDeviceAuthToken(token: string): Promise<void>;
 
-    /* Returns true if the 'git-credentials-secret' already exists */
-    githubTokenSecretExists(): Promise<boolean>;
+    /* Removes Device Authentication secret, extracts a token from another source (.git-credentials/credentials file or git-credentials secret) */
+    removeDeviceAuthToken(): Promise<void>;
 
     getUser(): Promise<GithubUser>;
     getTokenScopes(token: string): Promise<string[]>;

--- a/code/extensions/che-api/src/api/github-service.ts
+++ b/code/extensions/che-api/src/api/github-service.ts
@@ -21,6 +21,23 @@ export const GithubService = Symbol('GithubService');
 
 export interface GithubService {
     getToken(): Promise<string>;
+    
+    /**
+     * Updates in-memory value of the token,
+     * use {@link GithubService.persistToken()} to store a token to the corresponding secret   
+     */
+    updateCachedToken(token: string): Promise<void>;
+
+    /**
+     * Persists the given token to the corresponding secret, the in-memory value will be updated as well.
+     * A new secret will be created if there is no secret yet.
+     * Note: The existing token will be owerriten by the given one.   
+     */ 
+    persistToken(token: string): Promise<void>;
+
+    /* Returns true if the 'git-credentials-secret' already exists */
+    githubTokenSecretExists(): Promise<boolean>;
+
     getUser(): Promise<GithubUser>;
     getTokenScopes(token: string): Promise<string[]>;
 }

--- a/code/extensions/che-api/src/extension.ts
+++ b/code/extensions/che-api/src/extension.ts
@@ -27,6 +27,7 @@ import { GithubServiceImpl } from './impl/github-service-impl';
 import { TelemetryService } from './api/telemetry-service';
 import { K8sTelemetryServiceImpl } from './impl/k8s-telemetry-service-impl';
 import * as axios from 'axios';
+import { Logger } from './logger';
 
 
 export async function activate(_extensionContext: vscode.ExtensionContext): Promise<Api> {
@@ -42,6 +43,7 @@ export async function activate(_extensionContext: vscode.ExtensionContext): Prom
     container.bind(GithubServiceImpl).toSelf().inSingletonScope();
     container.bind(GithubService).to(GithubServiceImpl).inSingletonScope();
     container.bind(TelemetryService).to(K8sTelemetryServiceImpl).inSingletonScope();
+    container.bind(Logger).toSelf().inSingletonScope();
 
     const devfileService = container.get(DevfileService) as DevfileService;
     const workspaceService = container.get(WorkspaceService) as WorkspaceService;

--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -10,17 +10,32 @@
 
 /* eslint-disable header/header */
 
-import { GithubService, GithubUser } from '../api/github-service';
-import { inject, injectable } from 'inversify';
+import * as k8s from '@kubernetes/client-node';
 import { AxiosInstance } from 'axios';
 import * as fs from 'fs-extra';
+import { inject, injectable } from 'inversify';
 import * as path from 'path';
+import { GithubService, GithubUser } from '../api/github-service';
+import { Logger } from '../logger';
+import { K8SServiceImpl } from './k8s-service-impl';
+import { base64Encode, createLabelsSelector, randomString } from './utils';
+
+const GIT_CREDENTIAL_LABEL = {
+    'controller.devfile.io/git-credential': 'true'
+};
+const SCM_URL_ATTRIBUTE = 'che.eclipse.org/scm-url';
+const GITHUB_URL = 'https://github.com';
+const GIT_CREDENTIALS_LABEL_SELECTOR: string = createLabelsSelector(GIT_CREDENTIAL_LABEL);
 
 @injectable()
 export class GithubServiceImpl implements GithubService {
-    private readonly token: string | undefined;
+    private token: string | undefined;
 
-    constructor(@inject(Symbol.for('AxiosInstance')) private readonly axiosInstance: AxiosInstance) {
+    constructor(
+        @inject(Logger) private logger: Logger,
+        @inject(K8SServiceImpl) private readonly k8sService: K8SServiceImpl,
+        @inject(Symbol.for('AxiosInstance')) private readonly axiosInstance: AxiosInstance
+    ) {
         const credentialsPath = path.resolve('/.git-credentials', 'credentials');
         if (fs.existsSync(credentialsPath)) {
             const token = fs.readFileSync(credentialsPath).toString();
@@ -53,5 +68,81 @@ export class GithubServiceImpl implements GithubService {
             headers: { Authorization: `Bearer ${token}` },
         });
         return result.headers['x-oauth-scopes'].split(', ');
+    }
+
+    async updateCachedToken(token: string): Promise<void> {
+        this.token = token;
+    }
+
+    async persistToken(token: string): Promise<void> {
+        this.updateCachedToken(token);
+        this.logger.info(`Github Service: adding token to the git-credentials secret...`);
+
+        const gitCredentialSecret = await this.getGithubSecret();
+        if (!gitCredentialSecret) {
+            this.logger.info(`Github Service: git-credentials secret not found, creating a new secret...`);
+
+            const namespace = this.k8sService.getDevWorkspaceNamespace();
+            const newSecret = this.toSecret(namespace, token);
+            this.k8sService.createNamespacedSecret(newSecret);
+
+            this.logger.info(`Github Service: git-credentials secret was created successfully!`);
+            return;
+        }
+
+        this.logger.info(`Github Service: updating exsting git-credentials secret...`);
+
+        const data = {
+            credentials: base64Encode(`https://oauth2:${token}@github.com`)
+        };
+
+        const updatedSecret = { ...gitCredentialSecret, data };
+        const name = gitCredentialSecret.metadata?.name || `git-credentials-secret-${randomString(5).toLowerCase()}`;
+        this.k8sService.replaceNamespacedSecret(name, updatedSecret);
+
+        this.logger.info(`Github Service: git-credentials secret was updated successfully!`);
+    }
+
+    async githubTokenSecretExists(): Promise<boolean> {
+        const gitCredentialSecret = await this.getGithubSecret();
+        return !!gitCredentialSecret;
+    }
+
+    private async getGithubSecret(): Promise<k8s.V1Secret | undefined> {
+        this.logger.info(`Github Service: looking for the corresponding git-credentials secret...`);
+
+        const gitCredentialSecrets = await this.k8sService.getSecret(GIT_CREDENTIALS_LABEL_SELECTOR);
+        this.logger.info(`Github Service: found ${gitCredentialSecrets.length} secrets`);
+
+        if (gitCredentialSecrets.length === 0) {
+            return undefined
+        }
+
+        if (gitCredentialSecrets.length === 1) {
+            return gitCredentialSecrets[0];
+        }
+        return gitCredentialSecrets.find(secret => secret.metadata?.annotations?.[SCM_URL_ATTRIBUTE] === GITHUB_URL) || gitCredentialSecrets[0];
+    }
+
+    private toSecret(namespace: string, token: string): k8s.V1Secret {
+        return {
+            apiVersion: 'v1',
+            kind: 'Secret',
+            metadata: {
+                name: `git-credentials-secret-${randomString(5).toLowerCase()}`,
+                namespace,
+                labels: {
+                    'controller.devfile.io/git-credential': 'true',
+                    'controller.devfile.io/watch-secret': 'true',
+                },
+                annotations: {
+                    'che.eclipse.org/scm-url': 'https://github.com'
+                }
+            },
+            type: 'Opaque',
+            data: {
+                credentials: base64Encode(`https://oauth2:${token}@github.com`)
+            },
+        };
     }
 }

--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -15,134 +15,196 @@ import { AxiosInstance } from 'axios';
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
+
 import { GithubService, GithubUser } from '../api/github-service';
 import { Logger } from '../logger';
 import { K8SServiceImpl } from './k8s-service-impl';
-import { base64Encode, createLabelsSelector, randomString } from './utils';
+import { base64Decode, base64Encode, createLabelsSelector, randomString } from './utils';
 
+export const GIT_CREDENTIALS_PATH = path.resolve('/.git-credentials', 'credentials');
 const GIT_CREDENTIAL_LABEL = {
-    'controller.devfile.io/git-credential': 'true'
+  'controller.devfile.io/git-credential': 'true'
 };
+const DEVICE_AUTHENTICATION_LABEL = {
+  'che.eclipse.org/device-authentication': 'true'
+}
+const DEVICE_AUTHENTICATION_LABEL_SELECTOR: string = createLabelsSelector(DEVICE_AUTHENTICATION_LABEL);
 const SCM_URL_ATTRIBUTE = 'che.eclipse.org/scm-url';
 const GITHUB_URL = 'https://github.com';
 const GIT_CREDENTIALS_LABEL_SELECTOR: string = createLabelsSelector(GIT_CREDENTIAL_LABEL);
 
 @injectable()
 export class GithubServiceImpl implements GithubService {
-    private token: string | undefined;
+  private token: string | undefined;
 
-    constructor(
-        @inject(Logger) private logger: Logger,
-        @inject(K8SServiceImpl) private readonly k8sService: K8SServiceImpl,
-        @inject(Symbol.for('AxiosInstance')) private readonly axiosInstance: AxiosInstance
-    ) {
-        const credentialsPath = path.resolve('/.git-credentials', 'credentials');
-        if (fs.existsSync(credentialsPath)) {
-            const token = fs.readFileSync(credentialsPath).toString();
-            this.token = token.substring(token.lastIndexOf(':') + 1, token.indexOf('@'));
-        }
+  constructor(
+    @inject(Logger) private logger: Logger,
+    @inject(K8SServiceImpl) private readonly k8sService: K8SServiceImpl,
+    @inject(Symbol.for('AxiosInstance')) private readonly axiosInstance: AxiosInstance
+  ) {
+    this.iniitializeToken();
+  }
+
+  private checkToken(): void {
+    if (!this.token) {
+      throw new Error('GitHub authentication token is not setup');
+    }
+  }
+
+  async getToken(): Promise<string> {
+    this.checkToken();
+    return this.token!;
+  }
+
+  async getUser(): Promise<GithubUser> {
+    this.checkToken();
+    const result = await this.axiosInstance.get<GithubUser>('https://api.github.com/user', {
+      headers: { Authorization: `Bearer ${this.token}` },
+    });
+    return result.data;
+  }
+
+  async getTokenScopes(token: string): Promise<string[]> {
+    this.checkToken();
+    const result = await this.axiosInstance.get<GithubUser>('https://api.github.com/user', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return result.headers['x-oauth-scopes'].split(', ');
+  }
+
+  async persistDeviceAuthToken(token: string): Promise<void> {
+    this.token = token;
+    this.logger.info(`Github Service: adding token to the device-authentication secret...`);
+
+    const deviceAuthSecrets = await this.k8sService.getSecret(DEVICE_AUTHENTICATION_LABEL_SELECTOR);
+    if (deviceAuthSecrets.length < 1) {
+      this.logger.info(`Github Service: device-authentication secret not found, creating a new secret...`);
+
+      const namespace = this.k8sService.getDevWorkspaceNamespace();
+      const newSecret = toDeviceAuthSecret(token, namespace);
+      await this.k8sService.createNamespacedSecret(newSecret);
+
+      this.logger.info(`Github Service: device-authentication secret was created successfully!`);
+      return;
     }
 
-    private checkToken(): void {
-        if (!this.token) {
-            throw new Error('GitHub authentication token is not setup');
-        }
+    const deviceAuthSecret = deviceAuthSecrets[0];
+    this.logger.info(`Github Service: updating exsting device-authentication secret...`);
+
+    const data = {
+      token: base64Encode(`${token}`)
+    };
+
+    const updatedSecret = { ...deviceAuthSecret, data };
+    const name = deviceAuthSecret.metadata?.name || `device-authentication-secret-${randomString(5).toLowerCase()}`;
+    this.k8sService.replaceNamespacedSecret(name, updatedSecret);
+
+    this.logger.info(`Github Service: device-authentication secret was updated successfully!`);
+  }
+
+  async removeDeviceAuthToken(): Promise<void> {
+    this.token = undefined;
+
+    this.logger.info(`Github Service: got request for removing a device-authentication secret`);
+    const deviceAuthSecrets = await this.k8sService.getSecret(DEVICE_AUTHENTICATION_LABEL_SELECTOR);
+    if (deviceAuthSecrets.length < 1) {
+      this.logger.warn('Github Service: device-authentication secret not found');
+      return;
     }
 
-    async getToken(): Promise<string> {
-        this.checkToken();
-        return this.token!;
+    for (const secret of deviceAuthSecrets) {
+      this.logger.info(`Github Service: removing device-authentication secret with ${secret.metadata?.name} name...`);
+      await this.k8sService.deleteNamespacedSecret(secret);
+      this.logger.info(`Github Service: device-authentication secret with ${secret.metadata?.name} name was deleted successfully!`);
     }
 
-    async getUser(): Promise<GithubUser> {
-        this.checkToken();
-        const result = await this.axiosInstance.get<GithubUser>('https://api.github.com/user', {
-            headers: { Authorization: `Bearer ${this.token}` },
-        });
-        return result.data;
+    // another token should be used by the Github Service after removing the Device Authentication token
+    this.iniitializeToken();
+  }
+
+  private async iniitializeToken(): Promise<void> {
+    this.logger.info('Github Service: extracting token...');
+
+    const deviceAuthToken = await this.getDeviceAuthToken();
+    if (deviceAuthToken) {
+      this.token = deviceAuthToken;
+      this.logger.info('Github Service: Device Authentication token is used');
+      return;
     }
 
-    async getTokenScopes(token: string): Promise<string[]> {
-        this.checkToken();
-        const result = await this.axiosInstance.get<GithubUser>('https://api.github.com/user', {
-            headers: { Authorization: `Bearer ${token}` },
-        });
-        return result.headers['x-oauth-scopes'].split(', ');
+    const gitCredentialTokens = await this.getGitCredentialTokens();
+    if (gitCredentialTokens.length === 1) {
+      this.token = gitCredentialTokens[0];
+      this.logger.info('Github Service: git-credential token is used');
+      return;
+    }
+    this.token = await this.getTokenFromSecret();
+  }
+
+  /* Extracts a token from the device-authentication secret */
+  private async getDeviceAuthToken(): Promise<string | undefined> {
+    const deviceAuthSecrets = await this.k8sService.getSecret(DEVICE_AUTHENTICATION_LABEL_SELECTOR);
+    this.logger.info(`Github Service: found ${deviceAuthSecrets.length} device-authentication secrets`);
+    if (deviceAuthSecrets.length > 0) {
+      const decodedToken = base64Decode(deviceAuthSecrets[0].data!.token);
+      return decodedToken;
+    } else {
+      return undefined;
+    }
+  }
+
+  /* Extracts tokens from the .git-credentials/credentials file */
+  private async getGitCredentialTokens(): Promise<Array<string>> {
+    const tokens: string[] = [];
+    if (!fs.existsSync(GIT_CREDENTIALS_PATH)) {
+      return tokens;
     }
 
-    async updateCachedToken(token: string): Promise<void> {
-        this.token = token;
+    const credentialsFileContent = fs.readFileSync(GIT_CREDENTIALS_PATH).toString();
+    const lines = credentialsFileContent.split('\n');
+    for (const line of lines) {
+      const token = line.substring(line.lastIndexOf(':') + 1, line.indexOf('@'));
+      tokens.push(token);
+    }
+    return tokens;
+  }
+
+  /* Extracts token from the git-credential secret */
+  private async getTokenFromSecret(): Promise<string | undefined> {
+    this.logger.info(`Github Service: looking for the corresponding git-credentials secret to get token...`);
+
+    const gitCredentialSecrets = await this.k8sService.getSecret(GIT_CREDENTIALS_LABEL_SELECTOR);
+    if (gitCredentialSecrets.length === 0) {
+      this.logger.warn('Github Service: token is not found');
+      return undefined;
     }
 
-    async persistToken(token: string): Promise<void> {
-        this.updateCachedToken(token);
-        this.logger.info(`Github Service: adding token to the git-credentials secret...`);
+    const githubSecrets = gitCredentialSecrets.filter(secret => secret.metadata?.annotations?.[SCM_URL_ATTRIBUTE] === GITHUB_URL);
+    this.logger.info(`Github Service: found ${githubSecrets.length} github secrets`);
 
-        const gitCredentialSecret = await this.getGithubSecret();
-        if (!gitCredentialSecret) {
-            this.logger.info(`Github Service: git-credentials secret not found, creating a new secret...`);
+    const credentials = githubSecrets.length > 0 ? githubSecrets[0].data!.credentials : gitCredentialSecrets[0].data!.credentials;
+    const decodedCredentials = base64Decode(credentials);
+    const decodedToken = decodedCredentials.substring(decodedCredentials.lastIndexOf(':') + 1, decodedCredentials.indexOf('@'));
+    this.logger.info('Github Service: a token from the git-credential secret is used');
 
-            const namespace = this.k8sService.getDevWorkspaceNamespace();
-            const newSecret = this.toSecret(namespace, token);
-            this.k8sService.createNamespacedSecret(newSecret);
+    return decodedToken;
+  }
+}
 
-            this.logger.info(`Github Service: git-credentials secret was created successfully!`);
-            return;
-        }
-
-        this.logger.info(`Github Service: updating exsting git-credentials secret...`);
-
-        const data = {
-            credentials: base64Encode(`https://oauth2:${token}@github.com`)
-        };
-
-        const updatedSecret = { ...gitCredentialSecret, data };
-        const name = gitCredentialSecret.metadata?.name || `git-credentials-secret-${randomString(5).toLowerCase()}`;
-        this.k8sService.replaceNamespacedSecret(name, updatedSecret);
-
-        this.logger.info(`Github Service: git-credentials secret was updated successfully!`);
-    }
-
-    async githubTokenSecretExists(): Promise<boolean> {
-        const gitCredentialSecret = await this.getGithubSecret();
-        return !!gitCredentialSecret;
-    }
-
-    private async getGithubSecret(): Promise<k8s.V1Secret | undefined> {
-        this.logger.info(`Github Service: looking for the corresponding git-credentials secret...`);
-
-        const gitCredentialSecrets = await this.k8sService.getSecret(GIT_CREDENTIALS_LABEL_SELECTOR);
-        this.logger.info(`Github Service: found ${gitCredentialSecrets.length} secrets`);
-
-        if (gitCredentialSecrets.length === 0) {
-            return undefined
-        }
-
-        if (gitCredentialSecrets.length === 1) {
-            return gitCredentialSecrets[0];
-        }
-        return gitCredentialSecrets.find(secret => secret.metadata?.annotations?.[SCM_URL_ATTRIBUTE] === GITHUB_URL) || gitCredentialSecrets[0];
-    }
-
-    private toSecret(namespace: string, token: string): k8s.V1Secret {
-        return {
-            apiVersion: 'v1',
-            kind: 'Secret',
-            metadata: {
-                name: `git-credentials-secret-${randomString(5).toLowerCase()}`,
-                namespace,
-                labels: {
-                    'controller.devfile.io/git-credential': 'true',
-                    'controller.devfile.io/watch-secret': 'true',
-                },
-                annotations: {
-                    'che.eclipse.org/scm-url': 'https://github.com'
-                }
-            },
-            type: 'Opaque',
-            data: {
-                credentials: base64Encode(`https://oauth2:${token}@github.com`)
-            },
-        };
-    }
+function toDeviceAuthSecret(token: string, namespace: string): k8s.V1Secret {
+  return {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name: `device-authentication-secret-${randomString(5).toLowerCase()}`,
+      namespace,
+      labels: {
+        'che.eclipse.org/device-authentication': 'true'
+      }
+    },
+    type: 'Opaque',
+    data: {
+      token: base64Encode(`${token}`)
+    },
+  };
 }

--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -109,7 +109,7 @@ export class GithubServiceImpl implements GithubService {
     const deviceAuthSecrets = await this.k8sService.getSecret(DEVICE_AUTHENTICATION_LABEL_SELECTOR);
     if (deviceAuthSecrets.length < 1) {
       this.logger.warn('Github Service: device-authentication secret not found');
-      return;
+      throw new Error('device-authentication secret not found');
     }
 
     for (const secret of deviceAuthSecrets) {

--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -103,8 +103,6 @@ export class GithubServiceImpl implements GithubService {
   }
 
   async removeDeviceAuthToken(): Promise<void> {
-    this.token = undefined;
-
     this.logger.info(`Github Service: got request for removing a device-authentication secret`);
     const deviceAuthSecrets = await this.k8sService.getSecret(DEVICE_AUTHENTICATION_LABEL_SELECTOR);
     if (deviceAuthSecrets.length < 1) {
@@ -155,8 +153,10 @@ export class GithubServiceImpl implements GithubService {
 
   /* Extracts tokens from the .git-credentials/credentials file */
   private async getGitCredentialTokens(): Promise<Array<string>> {
+    this.logger.info(`Github Service: looking for the github token in the ${GIT_CREDENTIALS_PATH} file...`);
     const tokens: string[] = [];
     if (!fs.existsSync(GIT_CREDENTIALS_PATH)) {
+      this.logger.info(`Github Service: ${GIT_CREDENTIALS_PATH} file does not exist`);
       return tokens;
     }
 
@@ -166,6 +166,7 @@ export class GithubServiceImpl implements GithubService {
       const token = line.substring(line.lastIndexOf(':') + 1, line.indexOf('@'));
       tokens.push(token);
     }
+    this.logger.info(`Github Service: found ${tokens.length} tokens in the ${GIT_CREDENTIALS_PATH} file`);
     return tokens;
   }
 

--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -21,7 +21,7 @@ import { Logger } from '../logger';
 import { K8SServiceImpl } from './k8s-service-impl';
 import { base64Decode, base64Encode, createLabelsSelector, randomString } from './utils';
 
-export const GIT_CREDENTIALS_PATH = path.resolve('/.git-credentials', 'credentials');
+const GIT_CREDENTIALS_PATH = path.resolve('/.git-credentials', 'credentials');
 const GIT_CREDENTIAL_LABEL = {
   'controller.devfile.io/git-credential': 'true'
 };

--- a/code/extensions/che-api/src/impl/k8s-service-impl.ts
+++ b/code/extensions/che-api/src/impl/k8s-service-impl.ts
@@ -10,6 +10,12 @@
 
 /* eslint-disable header/header */
 import * as k8s from '@kubernetes/client-node';
+import {
+  devworkspaceGroup,
+  devworkspaceLatestVersion,
+  devworkspacePlural,
+  V1alpha2DevWorkspace
+} from '@devfile/api';
 
 import { ApiType } from '@kubernetes/client-node';
 import { injectable } from 'inversify';
@@ -19,17 +25,21 @@ const request = require('request');
 
 @injectable()
 export class K8SServiceImpl implements K8SService {
-  private kc: k8s.KubeConfig;
+  private coreV1API!: k8s.CoreV1Api;
+  private customObjectsApi!: k8s.CustomObjectsApi;
+  private k8sConfig: k8s.KubeConfig;
+  private devWorkspaceName!: string;
+  private devWorkspaceNamespace!: string;
 
   constructor() {
-    this.kc = new k8s.KubeConfig();
-    this.kc.loadFromCluster();
+    this.k8sConfig = new k8s.KubeConfig();
+    this.k8sConfig.loadFromCluster();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sendRawQuery(requestURL: string, opts: any): Promise<K8SRawResponse> {
-    this.kc.applyToRequest(opts);
-    const cluster = this.kc.getCurrentCluster();
+    this.k8sConfig.applyToRequest(opts);
+    const cluster = this.k8sConfig.getCurrentCluster();
     if (!cluster) {
       throw new Error('K8S cluster is not defined');
     }
@@ -52,10 +62,119 @@ export class K8SServiceImpl implements K8SService {
   }
 
   getConfig(): k8s.KubeConfig {
-    return this.kc;
+    return this.k8sConfig;
   }
 
   makeApiClient<T extends ApiType>(apiClientType: new (server: string) => T): T {
-    return this.kc.makeApiClient(apiClientType);
+    return this.k8sConfig.makeApiClient(apiClientType);
+  }
+
+  getCoreApi(): k8s.CoreV1Api {
+    if (!this.coreV1API) {
+      this.k8sConfig.loadFromCluster();
+      this.coreV1API = this.makeApiClient(k8s.CoreV1Api);
+    }
+    return this.coreV1API;
+  }
+
+  getCustomObjectsApi(): k8s.CustomObjectsApi {
+    if (!this.customObjectsApi) {
+      this.k8sConfig.loadFromCluster();
+      this.customObjectsApi = this.makeApiClient(k8s.CustomObjectsApi);
+    }
+    return this.customObjectsApi;
+  }
+
+  async getSecret(labelSelector?: string): Promise<Array<k8s.V1Secret>> {
+    const coreV1API = this.getCoreApi();
+    const namespace = this.getDevWorkspaceNamespace();
+    if (!namespace) {
+      throw new Error('Can not get secrets: DEVWORKSPACE_NAMESPACE env variable is not defined');
+    }
+
+    try {
+      const { body } = await coreV1API.listNamespacedSecret(
+        namespace,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        labelSelector,
+      );
+      return body.items;
+    } catch (error) {
+      console.error('Can not get secret ', error);
+      return [];
+    }
+  }
+
+  async replaceNamespacedSecret(name: string, secret: k8s.V1Secret): Promise<void> {
+    const namespace = this.getDevWorkspaceNamespace();
+    if (!namespace) {
+      throw new Error('Can not replace a secret: DEVWORKSPACE_NAMESPACE env variable is not defined');
+    }
+
+    const coreV1API = this.getCoreApi();
+    await coreV1API.replaceNamespacedSecret(name, namespace, secret);
+  }
+
+  async createNamespacedSecret(secret: k8s.V1Secret): Promise<void> {
+    const namespace = this.getDevWorkspaceNamespace();
+    if (!namespace) {
+      throw new Error('Can not create a secret: DEVWORKSPACE_NAMESPACE env variable is not defined');
+    }
+
+    const coreV1API = this.getCoreApi();
+    await coreV1API.createNamespacedSecret(namespace, secret);
+  }
+
+  async getDevWorkspace(): Promise<V1alpha2DevWorkspace> {
+    try {
+      const workspaceName = this.getDevWorkspaceName();
+      const namespace = this.getDevWorkspaceNamespace();
+      const customObjectsApi = this.getCustomObjectsApi();
+
+      const resp = await customObjectsApi.getNamespacedCustomObject(
+        devworkspaceGroup,
+        devworkspaceLatestVersion,
+        namespace,
+        devworkspacePlural,
+        workspaceName,
+      );
+      return resp.body as V1alpha2DevWorkspace;
+    } catch (e) {
+      console.error(e);
+      throw new Error('Unable to get Dev Workspace');
+    }
+  }
+
+  getDevWorkspaceName(): string {
+    if (this.devWorkspaceName) {
+      return this.devWorkspaceName;
+    }
+
+    const workspaceName = process.env.DEVWORKSPACE_NAME;
+    if (workspaceName) {
+      this.devWorkspaceName = workspaceName;
+      return this.devWorkspaceName;
+    }
+
+    console.error('Can not get Dev Workspace name: DEVWORKSPACE_NAME env variable is not defined');
+    throw new Error('Can not get Dev Workspace name');
+  }
+
+  getDevWorkspaceNamespace(): string {
+    if (this.devWorkspaceNamespace) {
+      return this.devWorkspaceNamespace;
+    }
+
+    const workspaceNamespace = process.env.DEVWORKSPACE_NAMESPACE;
+    if (workspaceNamespace) {
+      this.devWorkspaceNamespace = workspaceNamespace;
+      return this.devWorkspaceNamespace;
+    }
+
+    console.error('Can not get Dev Workspace namespace: DEVWORKSPACE_NAMESPACE env variable is not defined');
+    throw new Error('Can not get Dev Workspace namespace');
   }
 }

--- a/code/extensions/che-api/src/impl/utils.ts
+++ b/code/extensions/che-api/src/impl/utils.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+export function arrayEquals<T>(first: ReadonlyArray<T> | undefined, second: ReadonlyArray<T> | undefined, itemEquals: (a: T, b: T) => boolean = (a, b) => a === b): boolean {
+	if (first === second) {
+		return true;
+	}
+	if (!first || !second) {
+		return false;
+	}
+	if (first.length !== second.length) {
+		return false;
+	}
+	for (let i = 0, len = first.length; i < len; i++) {
+		if (!itemEquals(first[i], second[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+export function base64Encode(toEncode: string): string {
+	return Buffer.from(toEncode, 'binary').toString('base64');
+}
+
+export function randomString(length: number): string {
+	let result = '';
+	while (result.length < length) {
+		result += 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'[
+			(Math.random() * 60) | 0
+		];
+	}
+	return result;
+}
+
+export function createLabelsSelector(labels: { [key: string]: string; }): string {
+	return Object.entries(labels)
+		.map(([key, value]) => `${key}=${value}`)
+		.join(',');
+}

--- a/code/extensions/che-api/src/impl/utils.ts
+++ b/code/extensions/che-api/src/impl/utils.ts
@@ -11,39 +11,43 @@
 /* eslint-disable header/header */
 
 export function arrayEquals<T>(first: ReadonlyArray<T> | undefined, second: ReadonlyArray<T> | undefined, itemEquals: (a: T, b: T) => boolean = (a, b) => a === b): boolean {
-	if (first === second) {
-		return true;
-	}
-	if (!first || !second) {
-		return false;
-	}
-	if (first.length !== second.length) {
-		return false;
-	}
-	for (let i = 0, len = first.length; i < len; i++) {
-		if (!itemEquals(first[i], second[i])) {
-			return false;
-		}
-	}
-	return true;
+  if (first === second) {
+    return true;
+  }
+  if (!first || !second) {
+    return false;
+  }
+  if (first.length !== second.length) {
+    return false;
+  }
+  for (let i = 0, len = first.length; i < len; i++) {
+    if (!itemEquals(first[i], second[i])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function base64Encode(toEncode: string): string {
-	return Buffer.from(toEncode, 'binary').toString('base64');
+  return Buffer.from(toEncode, 'binary').toString('base64');
+}
+
+export function base64Decode(toDecode: string): string {
+  return Buffer.from(toDecode, 'base64').toString('binary');
 }
 
 export function randomString(length: number): string {
-	let result = '';
-	while (result.length < length) {
-		result += 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'[
-			(Math.random() * 60) | 0
-		];
-	}
-	return result;
+  let result = '';
+  while (result.length < length) {
+    result += 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'[
+      (Math.random() * 60) | 0
+    ];
+  }
+  return result;
 }
 
 export function createLabelsSelector(labels: { [key: string]: string; }): string {
-	return Object.entries(labels)
-		.map(([key, value]) => `${key}=${value}`)
-		.join(',');
+  return Object.entries(labels)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',');
 }

--- a/code/extensions/che-api/src/logger.ts
+++ b/code/extensions/che-api/src/logger.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+import { injectable } from 'inversify';
+import * as vscode from 'vscode';
+
+@injectable()
+export class Logger {
+	private outputChannel: vscode.LogOutputChannel;
+
+	constructor() {
+		this.outputChannel = vscode.window.createOutputChannel('Eclipse Che API', { log: true });
+	}
+
+	info(message: string): void {
+		this.outputChannel.info(message);
+	}
+
+	warn(message: string): void {
+		this.outputChannel.warn(message);
+	}
+
+	error(message: string): void {
+		this.outputChannel.error(message);
+	}
+
+	trace(message: string): void {
+		this.outputChannel.trace(message);
+	}
+}

--- a/code/extensions/che-api/src/logger.ts
+++ b/code/extensions/che-api/src/logger.ts
@@ -15,25 +15,25 @@ import * as vscode from 'vscode';
 
 @injectable()
 export class Logger {
-	private outputChannel: vscode.LogOutputChannel;
+  private outputChannel: vscode.LogOutputChannel;
 
-	constructor() {
-		this.outputChannel = vscode.window.createOutputChannel('Eclipse Che API', { log: true });
-	}
+  constructor() {
+    this.outputChannel = vscode.window.createOutputChannel('Eclipse Che API', { log: true });
+  }
 
-	info(message: string): void {
-		this.outputChannel.info(message);
-	}
+  info(message: string): void {
+    this.outputChannel.info(message);
+  }
 
-	warn(message: string): void {
-		this.outputChannel.warn(message);
-	}
+  warn(message: string): void {
+    this.outputChannel.warn(message);
+  }
 
-	error(message: string): void {
-		this.outputChannel.error(message);
-	}
+  error(message: string): void {
+    this.outputChannel.error(message);
+  }
 
-	trace(message: string): void {
-		this.outputChannel.trace(message);
-	}
+  trace(message: string): void {
+    this.outputChannel.trace(message);
+  }
 }

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -34,6 +34,12 @@
         "title": "Device Authentication",
         "category": "GitHub",
         "enablement": "github-authentication.device-code-flow.enabled"
+      },
+      {
+        "command": "github-authentication.device-code-flow.remove-token",
+        "title": "Remove Device Authentication Token",
+        "category": "GitHub",
+        "enablement": "github-authentication.device-code-flow.enabled"
       }
     ]
   },

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -27,6 +27,14 @@
         "label": "GitHub",
         "id": "github"
       }
+    ],
+    "commands": [
+      {
+        "command": "github-authentication.device-code-flow.authentication",
+        "title": "Device Authentication",
+        "category": "GitHub",
+        "enablement": "github-authentication.device-code-flow.enabled"
+      }
     ]
   },
   "main": "./out/extension.js",
@@ -43,9 +51,9 @@
     "@kubernetes/client-node": "^0.19.0",
     "node-fetch": "2.6.7",
     "uuid": "8.1.0",
-    "@vscode/extension-telemetry": "0.4.10",
+    "@vscode/extension-telemetry": "0.7.5",
     "vscode-nls": "^5.0.0",
-    "vscode-tas-client": "^0.1.31"
+    "vscode-tas-client": "^0.1.47"
   },
   "devDependencies": {
     "@types/node": "18.x",

--- a/code/extensions/che-github-authentication/src/device-authentication.ts
+++ b/code/extensions/che-github-authentication/src/device-authentication.ts
@@ -64,7 +64,15 @@ export class DeviceAuthentication {
   }
 
   async removeDeviceAuthToken(): Promise<void> {
-    return this.githubService.removeDeviceAuthToken();
+    try {
+      await this.githubService.removeDeviceAuthToken();
+      const message = 'The token was deleted successfully. Some operations may require Github Sign Out => Sign In to use another token.'
+      vscode.window.showInformationMessage(message);
+    } catch (error) {
+      const message = `Can not remove Device Authentication token: ${error.message}`;
+      vscode.window.showErrorMessage(message);
+    }
+
   }
 
   private async onTokenGenerated(scopes: string): Promise<void> {

--- a/code/extensions/che-github-authentication/src/device-authentication.ts
+++ b/code/extensions/che-github-authentication/src/device-authentication.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+import { inject, injectable } from 'inversify';
+import * as vscode from 'vscode';
+import { ExtensionContext } from './extension-context';
+import { GitHubAuthProvider, GithubService } from './github';
+import { Logger } from './logger';
+
+@injectable()
+export class DeviceAuthentication {
+	constructor(
+		@inject(Logger) private logger: Logger,
+		@inject(ExtensionContext) private extensionContext: ExtensionContext,
+		@inject(GitHubAuthProvider) private gitHubAuthProvider: GitHubAuthProvider,
+		@inject(Symbol.for('GithubServiceInstance')) private githubService: GithubService
+	) {
+		this.extensionContext.getContext().subscriptions.push(
+			vscode.commands.registerCommand('github-authentication.device-code-flow.authentication', async () => this.trigger()),
+		);
+		this.logger.info('Device Authentication command has been registered');
+	}
+
+	async trigger(scopes = 'user:email'): Promise<string> {
+		this.logger.info(`Device Authentication is triggered for scopes: ${scopes}`);
+
+		const sessionsToRemove = await this.gitHubAuthProvider.getSessions([scopes]);
+		this.logger.info(`Device Authentication: found ${sessionsToRemove.length} existing sessions with scopes: ${scopes}`);
+
+		for (const session of sessionsToRemove) {
+			try {
+				this.logger.info(`Device Authentication: removing a session with scopes: ${session.scopes}`);
+
+				await this.gitHubAuthProvider.removeSession(session.id);
+
+				this.logger.info(`Device Authentication: session with scopes: ${session.scopes} has been removed successfully`);
+			} catch (e) {
+				console.warn(e.message);
+				this.logger.warn(`Device Authentication: an error happened at removing a session with scopes: ${session.scopes}`);
+			}
+		}
+
+		const token = await vscode.commands.executeCommand<string>('github-authentication.device-code-flow');
+		this.logger.info(`Device Authentication: token for scopes: ${scopes} has been generated successfully`);
+
+		await this.githubService.updateCachedToken(token);
+		await this.gitHubAuthProvider.createSession([scopes]);
+
+		this.onTokenGenerated(token, scopes);
+		return token;
+	}
+
+	private async onTokenGenerated(token: string, scopes: string): Promise<void> {
+		const githubTokenSecretExists = await this.githubService.githubTokenSecretExists();
+		if (githubTokenSecretExists) {
+			this.githubService.persistToken(token);
+
+			const message = `A new session has been created for ${scopes} scopes. Please reload window to apply it.`
+			const reloadNow = vscode.l10n.t('Reload Now');
+			const action = await vscode.window.showInformationMessage(message, reloadNow);
+			if (action === reloadNow) {
+				vscode.commands.executeCommand('workbench.action.reloadWindow');
+			}
+		} else {
+			const message = 'A new token was generated successfully. The workspace restarting is required to store the token to the git-credentials secret.'
+			const restartWorkspace = vscode.l10n.t('Restart Workspace');
+			const action = await vscode.window.showInformationMessage(message, restartWorkspace);
+			
+			if (action === restartWorkspace) {
+				await this.githubService.persistToken(token);
+				vscode.commands.executeCommand('che-remote.command.restartWorkspace');
+			}
+		}
+	}
+}

--- a/code/extensions/che-github-authentication/src/error-handler.ts
+++ b/code/extensions/che-github-authentication/src/error-handler.ts
@@ -17,7 +17,8 @@ import * as k8s from '@kubernetes/client-node';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { K8sHelper, createLabelsSelector, filterCheSecrets, getDevfileAnnotation } from './k8s-helper';
+import { K8sHelper, filterCheSecrets, getDevfileAnnotation } from './k8s-helper';
+import { createLabelsSelector } from './utils';
 
 const GIT_CREDENTIAL_LABEL = {
   'controller.devfile.io/git-credential': 'true'
@@ -38,7 +39,6 @@ const DEVWORKSPACE_OPERATOR_DOCS_REFERENCE = 'https://github.com/devfile/devwork
 
 @injectable()
 export class ErrorHandler {
-  
   @inject(K8sHelper)
   private k8sHelper!: K8sHelper;
 
@@ -110,7 +110,7 @@ export class ErrorHandler {
   private async isWorkspaceManagedByChe(): Promise<Boolean> {
     const devWorkspace = await this.k8sHelper.getDevWorkspace();
     const devfileAnnotation = getDevfileAnnotation(devWorkspace.metadata?.annotations);
-    return devfileAnnotation ? true : false; 
+    return devfileAnnotation ? true : false;
   }
 
   private async suggestOpenDocumentation(message: string, buttonLabel: string, docsReference: string): Promise<void> {

--- a/code/extensions/che-github-authentication/src/extension-context.ts
+++ b/code/extensions/che-github-authentication/src/extension-context.ts
@@ -15,9 +15,9 @@ import * as vscode from 'vscode';
 
 @injectable()
 export class ExtensionContext {
-	constructor(private readonly context: vscode.ExtensionContext) { }
+  constructor(private readonly context: vscode.ExtensionContext) { }
 
-	getContext(): vscode.ExtensionContext {
-		return this.context;
-	}
+  getContext(): vscode.ExtensionContext {
+    return this.context;
+  }
 }

--- a/code/extensions/che-github-authentication/src/extension-context.ts
+++ b/code/extensions/che-github-authentication/src/extension-context.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+import { injectable } from 'inversify';
+import * as vscode from 'vscode';
+
+@injectable()
+export class ExtensionContext {
+	constructor(private readonly context: vscode.ExtensionContext) { }
+
+	getContext(): vscode.ExtensionContext {
+		return this.context;
+	}
+}

--- a/code/extensions/che-github-authentication/src/github.ts
+++ b/code/extensions/che-github-authentication/src/github.ts
@@ -1,0 +1,136 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+import { inject, injectable } from 'inversify';
+import { v4 } from 'uuid';
+import * as vscode from 'vscode';
+import { ErrorHandler } from './error-handler';
+import { ExtensionContext } from './extension-context';
+import { Logger } from './logger';
+import { arrayEquals } from './utils';
+
+export interface GithubUser {
+	login: string;
+	id: number;
+	name: string;
+	email: string;
+}
+
+export interface GithubService {
+	getToken(): Promise<string>;
+	updateCachedToken(token: string): Promise<void>;
+	persistToken(token: string): Promise<void>;
+	githubTokenSecretExists(): Promise<boolean>;
+	getUser(): Promise<GithubUser>;
+	getTokenScopes(token: string): Promise<string[]>;
+}
+
+@injectable()
+export class GitHubAuthProvider implements vscode.AuthenticationProvider {
+	private readonly sessions: vscode.AuthenticationSession[];
+	private readonly sessionChangeEmitter = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+
+	get onDidChangeSessions() {
+		return this.sessionChangeEmitter.event;
+	}
+
+	constructor(
+		@inject(Logger) private logger: Logger,
+		@inject(ErrorHandler) private errorHandler: ErrorHandler,
+		@inject(ExtensionContext) private extensionContext: ExtensionContext,
+		@inject(Symbol.for('GithubServiceInstance')) private githubService: GithubService
+	) {
+		this.sessions = this.extensionContext.getContext().workspaceState.get('sessions') || [];
+	}
+
+	async getSessions(sessionScopes?: string[]): Promise<vscode.AuthenticationSession[]> {
+		this.logger.info(`GitHubAuthProvider: GET SESSIONS for scopes: ${sessionScopes}`);
+
+		const sortedScopes = sessionScopes?.sort() || [];
+		const filteredSessions = sortedScopes.length
+			? this.sessions.filter(session => arrayEquals([...session.scopes].sort(), sortedScopes))
+			: this.sessions;
+
+		for (const session of filteredSessions) {
+			try {
+				await this.githubService.getTokenScopes(session.accessToken);
+			} catch (e) {
+				filteredSessions.splice(this.sessions.findIndex(s => s.id === session.id), 1);
+				this.logger.info(`GitHubAuthProvider: GET sessions - removing one session for scopes: ${sessionScopes}`);
+				console.warn(e.message);
+			}
+		}
+		this.logger.info(`GitHubAuthProvider: GET sessions - found ${filteredSessions.length} sessions for scopes: ${sessionScopes}`);
+		return filteredSessions;
+	}
+
+	async createSession(scopes: string[]): Promise<vscode.AuthenticationSession> {
+		this.logger.info(`GitHubAuthProvider: CREATE SESSION for scopes: ${JSON.stringify(scopes)}`);
+		let token = '';
+		try {
+			token = await this.githubService.getToken();
+		} catch (error) {
+			this.logger.error(`GitHubAuthProvider: an error happened at session creation (get token step): ${error.message}`);
+
+			this.errorHandler.onUnauthorizedError();
+
+			throw new Error(error.message);
+		}
+
+		let githubUser;
+		try {
+			githubUser = await this.githubService.getUser();
+		} catch (error) {
+			this.logger.error(`GitHubAuthProvider: an error happened at session creation (get user step): ${error.message}`);
+
+			if (error && error.response && error.response.status === 401) {
+				this.errorHandler.onUnauthorizedError();
+			}
+			throw new Error(error.message);
+		}
+
+		const session = {
+			id: v4(),
+			accessToken: token,
+			account: { label: githubUser.login, id: githubUser.id.toString() },
+			scopes,
+		};
+
+		const sessionIndex = this.sessions.findIndex(s => s.id === session.id);
+		if (sessionIndex > -1) {
+			this.sessions.splice(sessionIndex, 1, session);
+		} else {
+			this.sessions.push(session);
+		}
+
+		this.extensionContext.getContext().workspaceState.update('sessions', this.sessions);
+		this.sessionChangeEmitter.fire({ added: [session], removed: [], changed: [] });
+
+		this.logger.info(`GitHubAuthProvider: session was created successfully for scopes: ${JSON.stringify(scopes)}`);
+		return session;
+	}
+
+	async removeSession(id: string) {
+		this.logger.info(`GitHubAuthProvider: REMOVE SESSION `);
+
+		const session = this.sessions.find(s => s.id === id);
+		if (session) {
+			this.sessions.splice(this.sessions.findIndex(s => s.id === id), 1);
+			this.extensionContext.getContext().workspaceState.update('sessions', this.sessions);
+			this.sessionChangeEmitter.fire({ added: [], removed: [session], changed: [] });
+
+			this.logger.info(`GitHubAuthProvider: session was removed ssuccessfully! `);
+		} else {
+			this.logger.warn(`GitHubAuthProvider: session for removing not found`);
+		}
+	}
+}

--- a/code/extensions/che-github-authentication/src/github.ts
+++ b/code/extensions/che-github-authentication/src/github.ts
@@ -19,118 +19,117 @@ import { Logger } from './logger';
 import { arrayEquals } from './utils';
 
 export interface GithubUser {
-	login: string;
-	id: number;
-	name: string;
-	email: string;
+  login: string;
+  id: number;
+  name: string;
+  email: string;
 }
 
 export interface GithubService {
-	getToken(): Promise<string>;
-	updateCachedToken(token: string): Promise<void>;
-	persistToken(token: string): Promise<void>;
-	githubTokenSecretExists(): Promise<boolean>;
-	getUser(): Promise<GithubUser>;
-	getTokenScopes(token: string): Promise<string[]>;
+  getToken(): Promise<string>;
+  persistDeviceAuthToken(token: string): Promise<void>;
+  removeDeviceAuthToken(): Promise<void>;
+  getUser(): Promise<GithubUser>;
+  getTokenScopes(token: string): Promise<string[]>;
 }
 
 @injectable()
 export class GitHubAuthProvider implements vscode.AuthenticationProvider {
-	private readonly sessions: vscode.AuthenticationSession[];
-	private readonly sessionChangeEmitter = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+  private readonly sessions: vscode.AuthenticationSession[];
+  private readonly sessionChangeEmitter = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
 
-	get onDidChangeSessions() {
-		return this.sessionChangeEmitter.event;
-	}
+  get onDidChangeSessions() {
+    return this.sessionChangeEmitter.event;
+  }
 
-	constructor(
-		@inject(Logger) private logger: Logger,
-		@inject(ErrorHandler) private errorHandler: ErrorHandler,
-		@inject(ExtensionContext) private extensionContext: ExtensionContext,
-		@inject(Symbol.for('GithubServiceInstance')) private githubService: GithubService
-	) {
-		this.sessions = this.extensionContext.getContext().workspaceState.get('sessions') || [];
-	}
+  constructor(
+    @inject(Logger) private logger: Logger,
+    @inject(ErrorHandler) private errorHandler: ErrorHandler,
+    @inject(ExtensionContext) private extensionContext: ExtensionContext,
+    @inject(Symbol.for('GithubServiceInstance')) private githubService: GithubService
+  ) {
+    this.sessions = this.extensionContext.getContext().workspaceState.get('sessions') || [];
+  }
 
-	async getSessions(sessionScopes?: string[]): Promise<vscode.AuthenticationSession[]> {
-		this.logger.info(`GitHubAuthProvider: GET SESSIONS for scopes: ${sessionScopes}`);
+  async getSessions(sessionScopes?: string[]): Promise<vscode.AuthenticationSession[]> {
+    this.logger.info(`GitHubAuthProvider: GET SESSIONS for scopes: ${sessionScopes}`);
 
-		const sortedScopes = sessionScopes?.sort() || [];
-		const filteredSessions = sortedScopes.length
-			? this.sessions.filter(session => arrayEquals([...session.scopes].sort(), sortedScopes))
-			: this.sessions;
+    const sortedScopes = sessionScopes?.sort() || [];
+    const filteredSessions = sortedScopes.length
+      ? this.sessions.filter(session => arrayEquals([...session.scopes].sort(), sortedScopes))
+      : this.sessions;
 
-		for (const session of filteredSessions) {
-			try {
-				await this.githubService.getTokenScopes(session.accessToken);
-			} catch (e) {
-				filteredSessions.splice(this.sessions.findIndex(s => s.id === session.id), 1);
-				this.logger.info(`GitHubAuthProvider: GET sessions - removing one session for scopes: ${sessionScopes}`);
-				console.warn(e.message);
-			}
-		}
-		this.logger.info(`GitHubAuthProvider: GET sessions - found ${filteredSessions.length} sessions for scopes: ${sessionScopes}`);
-		return filteredSessions;
-	}
+    for (const session of filteredSessions) {
+      try {
+        await this.githubService.getTokenScopes(session.accessToken);
+      } catch (e) {
+        filteredSessions.splice(this.sessions.findIndex(s => s.id === session.id), 1);
+        this.logger.info(`GitHubAuthProvider: GET sessions - removing one session for scopes: ${sessionScopes}`);
+        console.warn(e.message);
+      }
+    }
+    this.logger.info(`GitHubAuthProvider: GET sessions - found ${filteredSessions.length} sessions for scopes: ${sessionScopes}`);
+    return filteredSessions;
+  }
 
-	async createSession(scopes: string[]): Promise<vscode.AuthenticationSession> {
-		this.logger.info(`GitHubAuthProvider: CREATE SESSION for scopes: ${JSON.stringify(scopes)}`);
-		let token = '';
-		try {
-			token = await this.githubService.getToken();
-		} catch (error) {
-			this.logger.error(`GitHubAuthProvider: an error happened at session creation (get token step): ${error.message}`);
+  async createSession(scopes: string[]): Promise<vscode.AuthenticationSession> {
+    this.logger.info(`GitHubAuthProvider: CREATE SESSION for scopes: ${JSON.stringify(scopes)}`);
+    let token = '';
+    try {
+      token = await this.githubService.getToken();
+    } catch (error) {
+      this.logger.error(`GitHubAuthProvider: an error happened at session creation (get token step): ${error.message}`);
 
-			this.errorHandler.onUnauthorizedError();
+      this.errorHandler.onUnauthorizedError();
 
-			throw new Error(error.message);
-		}
+      throw new Error(error.message);
+    }
 
-		let githubUser;
-		try {
-			githubUser = await this.githubService.getUser();
-		} catch (error) {
-			this.logger.error(`GitHubAuthProvider: an error happened at session creation (get user step): ${error.message}`);
+    let githubUser;
+    try {
+      githubUser = await this.githubService.getUser();
+    } catch (error) {
+      this.logger.error(`GitHubAuthProvider: an error happened at session creation (get user step): ${error.message}`);
 
-			if (error && error.response && error.response.status === 401) {
-				this.errorHandler.onUnauthorizedError();
-			}
-			throw new Error(error.message);
-		}
+      if (error && error.response && error.response.status === 401) {
+        this.errorHandler.onUnauthorizedError();
+      }
+      throw new Error(error.message);
+    }
 
-		const session = {
-			id: v4(),
-			accessToken: token,
-			account: { label: githubUser.login, id: githubUser.id.toString() },
-			scopes,
-		};
+    const session = {
+      id: v4(),
+      accessToken: token,
+      account: { label: githubUser.login, id: githubUser.id.toString() },
+      scopes,
+    };
 
-		const sessionIndex = this.sessions.findIndex(s => s.id === session.id);
-		if (sessionIndex > -1) {
-			this.sessions.splice(sessionIndex, 1, session);
-		} else {
-			this.sessions.push(session);
-		}
+    const sessionIndex = this.sessions.findIndex(s => s.id === session.id);
+    if (sessionIndex > -1) {
+      this.sessions.splice(sessionIndex, 1, session);
+    } else {
+      this.sessions.push(session);
+    }
 
-		this.extensionContext.getContext().workspaceState.update('sessions', this.sessions);
-		this.sessionChangeEmitter.fire({ added: [session], removed: [], changed: [] });
+    this.extensionContext.getContext().workspaceState.update('sessions', this.sessions);
+    this.sessionChangeEmitter.fire({ added: [session], removed: [], changed: [] });
 
-		this.logger.info(`GitHubAuthProvider: session was created successfully for scopes: ${JSON.stringify(scopes)}`);
-		return session;
-	}
+    this.logger.info(`GitHubAuthProvider: session was created successfully for scopes: ${JSON.stringify(scopes)}`);
+    return session;
+  }
 
-	async removeSession(id: string) {
-		this.logger.info(`GitHubAuthProvider: REMOVE SESSION `);
+  async removeSession(id: string) {
+    this.logger.info(`GitHubAuthProvider: REMOVE SESSION `);
 
-		const session = this.sessions.find(s => s.id === id);
-		if (session) {
-			this.sessions.splice(this.sessions.findIndex(s => s.id === id), 1);
-			this.extensionContext.getContext().workspaceState.update('sessions', this.sessions);
-			this.sessionChangeEmitter.fire({ added: [], removed: [session], changed: [] });
+    const session = this.sessions.find(s => s.id === id);
+    if (session) {
+      this.sessions.splice(this.sessions.findIndex(s => s.id === id), 1);
+      this.extensionContext.getContext().workspaceState.update('sessions', this.sessions);
+      this.sessionChangeEmitter.fire({ added: [], removed: [session], changed: [] });
 
-			this.logger.info(`GitHubAuthProvider: session was removed ssuccessfully! `);
-		} else {
-			this.logger.warn(`GitHubAuthProvider: session for removing not found`);
-		}
-	}
+      this.logger.info(`GitHubAuthProvider: session was removed successfully! `);
+    } else {
+      this.logger.warn(`GitHubAuthProvider: session for removing not found`);
+    }
+  }
 }

--- a/code/extensions/che-github-authentication/src/k8s-helper.ts
+++ b/code/extensions/che-github-authentication/src/k8s-helper.ts
@@ -84,7 +84,7 @@ export class K8sHelper {
     const coreV1API = this.getCoreApi();
     const namespace = this.getDevWorkspaceNamespace();
     if (!namespace) {
-      throw new Error('Can not get git credential secrets: DEVWORKSPACE_NAMESPACE env variable is not defined');
+      throw new Error('Can not get secrets: DEVWORKSPACE_NAMESPACE env variable is not defined');
     }
 
     try {
@@ -103,7 +103,7 @@ export class K8sHelper {
     }
   }
 
-  protected getDevWorkspaceName(): string {
+  getDevWorkspaceName(): string {
     if (this.devWorkspaceName) {
       return this.devWorkspaceName;
     }
@@ -118,7 +118,7 @@ export class K8sHelper {
     throw new Error('Can not get Dev Workspace name');
   }
 
-  protected getDevWorkspaceNamespace(): string {
+  getDevWorkspaceNamespace(): string {
     if (this.devWorkspaceNamespace) {
       return this.devWorkspaceNamespace;
     }
@@ -152,10 +152,4 @@ export function getDevfileAnnotation(annotations?: { [key: string]: string }): s
     console.log('NO annotations');
     return undefined;
   }
-}
-
-export function createLabelsSelector(labels: { [key: string]: string; }): string {
-  return Object.entries(labels)
-    .map(([key, value]) => `${key}=${value}`)
-    .join(',');
 }

--- a/code/extensions/che-github-authentication/src/logger.ts
+++ b/code/extensions/che-github-authentication/src/logger.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+import { injectable } from 'inversify';
+import * as vscode from 'vscode';
+
+@injectable()
+export class Logger {
+	private outputChannel: vscode.LogOutputChannel;
+
+	constructor() {
+		this.outputChannel = vscode.window.createOutputChannel('Che GitHub Authentication', { log: true });
+	}
+
+	info(message: string): void {
+		this.outputChannel.info(message);
+	}
+
+	warn(message: string): void {
+		this.outputChannel.warn(message);
+	}
+
+	error(message: string): void {
+		this.outputChannel.error(message);
+	}
+
+	trace(message: string): void {
+		this.outputChannel.trace(message);
+	}
+}

--- a/code/extensions/che-github-authentication/src/logger.ts
+++ b/code/extensions/che-github-authentication/src/logger.ts
@@ -15,25 +15,25 @@ import * as vscode from 'vscode';
 
 @injectable()
 export class Logger {
-	private outputChannel: vscode.LogOutputChannel;
+  private outputChannel: vscode.LogOutputChannel;
 
-	constructor() {
-		this.outputChannel = vscode.window.createOutputChannel('Che GitHub Authentication', { log: true });
-	}
+  constructor() {
+    this.outputChannel = vscode.window.createOutputChannel('Che GitHub Authentication', { log: true });
+  }
 
-	info(message: string): void {
-		this.outputChannel.info(message);
-	}
+  info(message: string): void {
+    this.outputChannel.info(message);
+  }
 
-	warn(message: string): void {
-		this.outputChannel.warn(message);
-	}
+  warn(message: string): void {
+    this.outputChannel.warn(message);
+  }
 
-	error(message: string): void {
-		this.outputChannel.error(message);
-	}
+  error(message: string): void {
+    this.outputChannel.error(message);
+  }
 
-	trace(message: string): void {
-		this.outputChannel.trace(message);
-	}
+  trace(message: string): void {
+    this.outputChannel.trace(message);
+  }
 }

--- a/code/extensions/che-github-authentication/src/logger.ts
+++ b/code/extensions/che-github-authentication/src/logger.ts
@@ -13,12 +13,14 @@
 import { injectable } from 'inversify';
 import * as vscode from 'vscode';
 
+export const CHANNEL_NAME = 'Che GitHub Authentication';
+
 @injectable()
 export class Logger {
   private outputChannel: vscode.LogOutputChannel;
 
   constructor() {
-    this.outputChannel = vscode.window.createOutputChannel('Che GitHub Authentication', { log: true });
+    this.outputChannel = vscode.window.createOutputChannel(CHANNEL_NAME, { log: true });
   }
 
   info(message: string): void {

--- a/code/extensions/che-github-authentication/src/utils.ts
+++ b/code/extensions/che-github-authentication/src/utils.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+export function arrayEquals<T>(first: ReadonlyArray<T> | undefined, second: ReadonlyArray<T> | undefined, itemEquals: (a: T, b: T) => boolean = (a, b) => a === b): boolean {
+	if (first === second) {
+		return true;
+	}
+	if (!first || !second) {
+		return false;
+	}
+	if (first.length !== second.length) {
+		return false;
+	}
+	for (let i = 0, len = first.length; i < len; i++) {
+		if (!itemEquals(first[i], second[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+export function createLabelsSelector(labels: { [key: string]: string; }): string {
+	return Object.entries(labels)
+		.map(([key, value]) => `${key}=${value}`)
+		.join(',');
+}

--- a/code/extensions/che-github-authentication/src/utils.ts
+++ b/code/extensions/che-github-authentication/src/utils.ts
@@ -11,25 +11,25 @@
 /* eslint-disable header/header */
 
 export function arrayEquals<T>(first: ReadonlyArray<T> | undefined, second: ReadonlyArray<T> | undefined, itemEquals: (a: T, b: T) => boolean = (a, b) => a === b): boolean {
-	if (first === second) {
-		return true;
-	}
-	if (!first || !second) {
-		return false;
-	}
-	if (first.length !== second.length) {
-		return false;
-	}
-	for (let i = 0, len = first.length; i < len; i++) {
-		if (!itemEquals(first[i], second[i])) {
-			return false;
-		}
-	}
-	return true;
+  if (first === second) {
+    return true;
+  }
+  if (!first || !second) {
+    return false;
+  }
+  if (first.length !== second.length) {
+    return false;
+  }
+  for (let i = 0, len = first.length; i < len; i++) {
+    if (!itemEquals(first[i], second[i])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function createLabelsSelector(labels: { [key: string]: string; }): string {
-	return Object.entries(labels)
-		.map(([key, value]) => `${key}=${value}`)
-		.join(',');
+  return Object.entries(labels)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',');
 }

--- a/code/extensions/che-github-authentication/yarn.lock
+++ b/code/extensions/che-github-authentication/yarn.lock
@@ -2,6 +2,59 @@
 # yarn lockfile v1
 
 
+"@azure/abort-controller@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@azure/abort-controller/-/abort-controller-1.1.0.tgz#788ee78457a55af8a1ad342acb182383d2119249"
+  integrity sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==
+  dependencies:
+    tslib "^2.2.0"
+
+"@azure/core-auth@^1.4.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.5.0.tgz#a41848c5c31cb3b7c84c409885267d55a2c92e44"
+  integrity sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-util" "^1.1.0"
+    tslib "^2.2.0"
+
+"@azure/core-rest-pipeline@^1.10.0":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.12.1.tgz#d49f3daa8d282347dda6395f489af0050087901f"
+  integrity sha512-SsyWQ+T5MFQRX+M8H/66AlaI6HyCbQStGfFngx2fuiW+vKI2DkhtOvbYodPyf9fOe/ARLWWc3ohX54lQ5Kmaog==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-tracing" "^1.0.1"
+    "@azure/core-util" "^1.3.0"
+    "@azure/logger" "^1.0.0"
+    form-data "^4.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.0"
+    tslib "^2.2.0"
+
+"@azure/core-tracing@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.0.1.tgz#352a38cbea438c4a83c86b314f48017d70ba9503"
+  integrity sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==
+  dependencies:
+    tslib "^2.2.0"
+
+"@azure/core-util@^1.1.0", "@azure/core-util@^1.3.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.5.0.tgz#ffe49c3e867044da67daeb8122143fa065e1eb0e"
+  integrity sha512-GZBpVFDtQ/15hW1OgBcRdT4Bl7AEpcEZqLfbAvOtm1CQUncKWiYapFHVD588hmlV27NbOOtSm3cnLF3lvoHi4g==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    tslib "^2.2.0"
+
+"@azure/logger@^1.0.0":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.0.4.tgz#28bc6d0e5b3c38ef29296b32d35da4e483593fa1"
+  integrity sha512-ustrPY8MryhloQj7OWGe+HrYx+aoiOxzbXTtgblbV3xwCqpzUK36phH3XNHQKj3EPonyFUuDTfR3qFhTEAuZEg==
+  dependencies:
+    tslib "^2.2.0"
+
 "@devfile/api@^2.2.0-alpha-1641413790":
   version "2.2.0-alpha-1666195451"
   resolved "https://registry.yarnpkg.com/@devfile/api/-/api-2.2.0-alpha-1666195451.tgz#19e5b1f35416d42cf661b779b571401b5033e684"
@@ -34,6 +87,116 @@
     ws "^8.11.0"
   optionalDependencies:
     openid-client "^5.3.0"
+
+"@microsoft/1ds-core-js@3.2.14", "@microsoft/1ds-core-js@^3.2.8":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@microsoft/1ds-core-js/-/1ds-core-js-3.2.14.tgz#407c83999b0f75d9939bb32f6fc10b1439938cef"
+  integrity sha512-UW1YrUTPuvXmAarzqVSeYU1vwTzxCCZdd+ANcf/SDkxm53mCCgxSodVP9yrxtGOQdKhE9Y3rZdETRSvBBdKdXg==
+  dependencies:
+    "@microsoft/applicationinsights-core-js" "2.8.16"
+    "@microsoft/applicationinsights-shims" "^2.0.2"
+    "@microsoft/dynamicproto-js" "^1.1.7"
+
+"@microsoft/1ds-post-js@^3.2.8":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@microsoft/1ds-post-js/-/1ds-post-js-3.2.14.tgz#1ebd873a47eab9d97fa0cff593de303f641cdb51"
+  integrity sha512-pXTfyW8SI6LS2r92W2Zaxl/YjJCHTEX9ej/GdabtlMAikGGgAlEsMlk5a4SJ3BI3K8sDUSGi+oTmJ1FtVes+bQ==
+  dependencies:
+    "@microsoft/1ds-core-js" "3.2.14"
+    "@microsoft/applicationinsights-shims" "^2.0.2"
+    "@microsoft/dynamicproto-js" "^1.1.7"
+
+"@microsoft/applicationinsights-channel-js@2.8.16":
+  version "2.8.16"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.16.tgz#750319bc33d1c32b367a3932517bbfcaf444c2aa"
+  integrity sha512-k0W4UKmkVfKgdCyKjcadiysCfndK4PrO6FhU4Jt3B4PaUmTs2w2ematfq2EqKOTsfkSAfo036jx6Rf/OOT3Rfg==
+  dependencies:
+    "@microsoft/applicationinsights-common" "2.8.16"
+    "@microsoft/applicationinsights-core-js" "2.8.16"
+    "@microsoft/applicationinsights-shims" "2.0.2"
+    "@microsoft/dynamicproto-js" "^1.1.9"
+
+"@microsoft/applicationinsights-common@2.8.16":
+  version "2.8.16"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.16.tgz#802d63729bce46fd93ad6dbf8d527496961f8344"
+  integrity sha512-rZutcK7gzixhdtfUVkjy10Kn+/i66ti6YqBN2pFopOkgpqyGydtVhWio2TGrtAK3Pjz8cj7yUkrO+Z0y6/McFA==
+  dependencies:
+    "@microsoft/applicationinsights-core-js" "2.8.16"
+    "@microsoft/applicationinsights-shims" "2.0.2"
+    "@microsoft/dynamicproto-js" "^1.1.9"
+
+"@microsoft/applicationinsights-core-js@2.8.16":
+  version "2.8.16"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.16.tgz#b209c908a63128b4603d00d30357d646bb7da8d3"
+  integrity sha512-pO5rR6UuiPymiHFj8XxNXhQgBSTvyHWygf+gdEVDh0xpUXYFO99bZe0Ux0D0HqYqVkJrRfXzL1Ocru6+S0x53Q==
+  dependencies:
+    "@microsoft/applicationinsights-shims" "2.0.2"
+    "@microsoft/dynamicproto-js" "^1.1.9"
+
+"@microsoft/applicationinsights-shims@2.0.2", "@microsoft/applicationinsights-shims@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz#92b36a09375e2d9cb2b4203383b05772be837085"
+  integrity sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg==
+
+"@microsoft/applicationinsights-web-basic@^2.8.9":
+  version "2.8.16"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-2.8.16.tgz#0b4ccca32daaf15ccdbd641942b5eda7df61b21e"
+  integrity sha512-ZQvWZL4cbZtiloBXf9g6MD4r/aIvXy7udJ2rnL784MwWGBtrfPgTsM1mniBYL/v2a0ufW7blIKp3CYe381iKrg==
+  dependencies:
+    "@microsoft/applicationinsights-channel-js" "2.8.16"
+    "@microsoft/applicationinsights-common" "2.8.16"
+    "@microsoft/applicationinsights-core-js" "2.8.16"
+    "@microsoft/applicationinsights-shims" "2.0.2"
+    "@microsoft/dynamicproto-js" "^1.1.9"
+
+"@microsoft/applicationinsights-web-snippet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz#6bb788b2902e48bf5d460c38c6bb7fedd686ddd7"
+  integrity sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ==
+
+"@microsoft/dynamicproto-js@^1.1.7", "@microsoft/dynamicproto-js@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz#7437db7aa061162ee94e4131b69a62b8dad5dea6"
+  integrity sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ==
+
+"@opentelemetry/api@^1.0.4":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.6.0.tgz#de2c6823203d6f319511898bb5de7e70f5267e19"
+  integrity sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==
+
+"@opentelemetry/core@1.17.1", "@opentelemetry/core@^1.0.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.17.1.tgz#10c5e09c63aeb1836b34d80baf7113760fb19d96"
+  integrity sha512-I6LrZvl1FF97FQXPR0iieWQmKnGxYtMbWA1GrAXnLUR+B1Hn2m8KqQNEIlZAucyv00GBgpWkpllmULmZfG8P3g==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "1.17.1"
+
+"@opentelemetry/resources@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.17.1.tgz#932f70f58c0e03fb1d38f0cba12672fd70804d99"
+  integrity sha512-M2e5emqg5I7qRKqlzKx0ROkcPyF8PbcSaWEdsm72od9txP7Z/Pl8PDYOyu80xWvbHAWk5mDxOF6v3vNdifzclA==
+  dependencies:
+    "@opentelemetry/core" "1.17.1"
+    "@opentelemetry/semantic-conventions" "1.17.1"
+
+"@opentelemetry/sdk-trace-base@^1.0.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.17.1.tgz#8ede213df8b0c957028a869c66964e535193a4fd"
+  integrity sha512-pfSJJSjZj5jkCJUQZicSpzN8Iz9UKMryPWikZRGObPnJo6cUSoKkjZh6BM3j+D47G4olMBN+YZKYqkFM1L6zNA==
+  dependencies:
+    "@opentelemetry/core" "1.17.1"
+    "@opentelemetry/resources" "1.17.1"
+    "@opentelemetry/semantic-conventions" "1.17.1"
+
+"@opentelemetry/semantic-conventions@1.17.1", "@opentelemetry/semantic-conventions@^1.0.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.17.1.tgz#93d219935e967fbb9aa0592cc96b2c0ec817a56f"
+  integrity sha512-xbR2U+2YjauIuo42qmE8XyJK6dYeRMLJuOlUP5SO4auET4VtOHOzgkRVOq+Ik18N+Xf3YPcqJs9dZMiDddz1eQ==
+
+"@tootallnate/once@2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
 "@types/bluebird@3.5.21":
   version "3.5.21"
@@ -102,10 +265,22 @@
   dependencies:
     "@types/node" "*"
 
-"@vscode/extension-telemetry@0.4.10":
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/@vscode/extension-telemetry/-/extension-telemetry-0.4.10.tgz#be960c05bdcbea0933866346cf244acad6cac910"
-  integrity sha512-XgyUoWWRQExTmd9DynIIUQo1NPex/zIeetdUAXeBjVuW9ioojM1TcDaSqOa/5QLC7lx+oEXwSU1r0XSBgzyz6w==
+"@vscode/extension-telemetry@0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@vscode/extension-telemetry/-/extension-telemetry-0.7.5.tgz#bf965731816e08c3f146f96d901ec67954fc913b"
+  integrity sha512-fJ5y3TcpqqkFYHneabYaoB4XAhDdVflVm+TDKshw9VOs77jkgNS4UA7LNXrWeO0eDne3Sh3JgURf+xzc1rk69w==
+  dependencies:
+    "@microsoft/1ds-core-js" "^3.2.8"
+    "@microsoft/1ds-post-js" "^3.2.8"
+    "@microsoft/applicationinsights-web-basic" "^2.8.9"
+    applicationinsights "2.4.1"
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.12.3:
   version "6.12.6"
@@ -127,6 +302,23 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==
 
+applicationinsights@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.4.1.tgz#4de4c4dd3c7c4a44445cfbf3d15808fc0dcc423d"
+  integrity sha512-0n0Ikd0gzSm460xm+M0UTWIwXrhrH/0bqfZatcJjYObWyefxfAxapGEyNnSGd1Tg90neHz+Yhf+Ff/zgvPiQYA==
+  dependencies:
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-rest-pipeline" "^1.10.0"
+    "@microsoft/applicationinsights-web-snippet" "^1.0.1"
+    "@opentelemetry/api" "^1.0.4"
+    "@opentelemetry/core" "^1.0.1"
+    "@opentelemetry/sdk-trace-base" "^1.0.1"
+    "@opentelemetry/semantic-conventions" "^1.0.1"
+    cls-hooked "^4.2.2"
+    continuation-local-storage "^3.2.1"
+    diagnostic-channel "1.1.0"
+    diagnostic-channel-publishers "1.0.5"
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -144,6 +336,21 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
+  dependencies:
+    stack-chain "^1.3.7"
+
+async-listener@^0.6.0:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
+  integrity sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==
+  dependencies:
+    semver "^5.3.0"
+    shimmer "^1.1.0"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -159,12 +366,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
   integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
 
-axios@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
-  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
-    follow-redirects "^1.14.7"
+    follow-redirects "^1.14.8"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -353,6 +560,15 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
+
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -364,6 +580,14 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+continuation-local-storage@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
+  integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
+  dependencies:
+    async-listener "^0.6.0"
+    emitter-listener "^1.1.1"
 
 convert-source-map@^1.5.1:
   version "1.9.0"
@@ -387,6 +611,13 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+debug@4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -406,6 +637,18 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+diagnostic-channel-publishers@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.5.tgz#df8c317086c50f5727fdfb5d2fce214d2e4130ae"
+  integrity sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg==
+
+diagnostic-channel@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz#6985e9dfedfbc072d91dc4388477e4087147756e"
+  integrity sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==
+  dependencies:
+    semver "^5.3.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -413,6 +656,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+emitter-listener@^1.0.1, emitter-listener@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
+  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
+  dependencies:
+    shimmer "^1.2.0"
 
 escape-string-regexp@^1.0.2:
   version "1.0.5"
@@ -449,10 +699,10 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-follow-redirects@^1.14.7:
-  version "1.14.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
-  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+follow-redirects@^1.14.8:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -472,6 +722,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -533,6 +792,15 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -541,6 +809,14 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -721,6 +997,11 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -854,6 +1135,16 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+semver@^5.3.0, semver@^5.4.1:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
+shimmer@^1.1.0, shimmer@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -886,6 +1177,11 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==
+
 stream-buffers@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-3.0.2.tgz#5249005a8d5c2d00b3a32e6e0a6ea209dc4f3521"
@@ -915,12 +1211,12 @@ tar@^6.1.11:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tas-client@0.1.30:
-  version "0.1.30"
-  resolved "https://registry.yarnpkg.com/tas-client/-/tas-client-0.1.30.tgz#f7f03df5d336104db8e8a6eb8269d279eebb0bc7"
-  integrity sha512-4JINL2r0m7UWU8nIsfWI97SPxjnqz6nk0JtS5ajL5SCksPK8Yjx9yik4DbwwbsbXLJu9C2jasEKnDY40UxEh1g==
+tas-client@0.1.58:
+  version "0.1.58"
+  resolved "https://registry.yarnpkg.com/tas-client/-/tas-client-0.1.58.tgz#67d66bf0e27df5276ebc751105e6ad47791c36d8"
+  integrity sha512-fOWii4wQXuo9Zl0oXgvjBzZWzKc5MmUR6XQWX93WU2c1SaP1plPo/zvXP8kpbZ9fvegFOHdapszYqMTRq/SRtg==
   dependencies:
-    axios "^0.25.0"
+    axios "^0.26.1"
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -945,7 +1241,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==
 
-tslib@^2.4.1:
+tslib@^2.2.0, tslib@^2.4.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -998,12 +1294,12 @@ vscode-nls@^5.0.0:
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
 
-vscode-tas-client@^0.1.31:
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/vscode-tas-client/-/vscode-tas-client-0.1.31.tgz#fec4a36a10214f8af652b4a1f47aed16b22a01df"
-  integrity sha512-GbvRil0TFdWtG0hvROi/haZkuKNkC/aVjhXWNCKBnS5VwpKtTRnt+o9M5FSETkW7dhfDTK/Jmv53372WtLnVSA==
+vscode-tas-client@^0.1.47:
+  version "0.1.63"
+  resolved "https://registry.yarnpkg.com/vscode-tas-client/-/vscode-tas-client-0.1.63.tgz#df89e67e9bf7ecb46471a0fb8a4a522d2aafad65"
+  integrity sha512-TY5TPyibzi6rNmuUB7eRVqpzLzNfQYrrIl/0/F8ukrrbzOrKVvS31hM3urE+tbaVrnT+TMYXL16GhX57vEowhA==
   dependencies:
-    tas-client "0.1.30"
+    tas-client "0.1.58"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"

--- a/code/extensions/github-authentication/package.json
+++ b/code/extensions/github-authentication/package.json
@@ -17,7 +17,9 @@
     "ui",
     "workspace"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "*"
+  ],
   "capabilities": {
     "virtualWorkspaces": true,
     "untrustedWorkspaces": {
@@ -25,27 +27,6 @@
       "restrictedConfigurations": [
         "github-enterprise.uri"
       ]
-    }
-  },
-  "contributes": {
-    "authentication": [
-      {
-        "label": "GitHub",
-        "id": "github"
-      },
-      {
-        "label": "GitHub Enterprise Server",
-        "id": "github-enterprise"
-      }
-    ],
-    "configuration": {
-      "title": "GitHub Enterprise Server Authentication Provider",
-      "properties": {
-        "github-enterprise.uri": {
-          "type": "string",
-          "description": "GitHub Enterprise Server URI"
-        }
-      }
     }
   },
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",

--- a/code/extensions/github-authentication/src/device-flow.ts
+++ b/code/extensions/github-authentication/src/device-flow.ts
@@ -1,0 +1,101 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+import * as vscode from 'vscode';
+import { Log } from './common/logger';
+import { ExtensionHost, GitHubTarget, getFlows } from './flows';
+import { AuthProviderType, UriEventHandler } from './github';
+import { crypto } from './node/crypto';
+
+interface FlowTriggerOptions {
+	scopes: string;
+	baseUri: vscode.Uri;
+	logger: Log;
+	redirectUri: vscode.Uri;
+	nonce: string;
+	callbackUri: vscode.Uri;
+	uriHandler: UriEventHandler;
+	enterpriseUri?: vscode.Uri;
+}
+
+interface Flow {
+	label: string;
+	trigger(options: FlowTriggerOptions): Promise<string>;
+}
+
+let logger: Log;
+let deviceCodeFlow: Flow | undefined;
+let flowOptions: FlowTriggerOptions;
+
+export async function initialize(context: vscode.ExtensionContext): Promise<void> {
+	logger = new Log(AuthProviderType.github);
+	deviceCodeFlow = await getDeviceCodeFlow();
+
+	if (deviceCodeFlow) {
+		vscode.commands.executeCommand('setContext', 'github-authentication.device-code-flow.enabled', true);
+		logger.info('Device Code flow is enabled');
+		
+		context.subscriptions.push(
+			vscode.commands.registerCommand('github-authentication.device-code-flow', (scopes: string) => {
+				return getToken(scopes);
+			}),
+		);
+	} else {
+		logger.info('Device Code flow is not available');
+	}
+}
+
+async function getFlowTriggerOptions(scopes?: string): Promise<FlowTriggerOptions> {
+	if (flowOptions) {
+		return scopes ? { ...flowOptions, scopes } : flowOptions;
+	}
+
+	const nonce: string = crypto.getRandomValues(new Uint32Array(2)).reduce((prev, curr) => prev += curr.toString(16), '');
+	const callbackUri = await vscode.env.asExternalUri(vscode.Uri.parse(`${vscode.env.uriScheme}://vscode.github-authentication/did-authenticate?nonce=${encodeURIComponent(nonce)}`));
+
+	flowOptions = {
+		logger,
+		nonce,
+		callbackUri,
+		scopes: scopes ? scopes : 'user:email',
+		uriHandler: new UriEventHandler(),
+		baseUri: vscode.Uri.parse('https://github.com/'),
+		redirectUri: vscode.Uri.parse('https://vscode.dev/redirect'),
+	}
+	return flowOptions;
+}
+
+async function getDeviceCodeFlow(): Promise<Flow | undefined> {
+	const flows = getFlows({ target: GitHubTarget.DotCom, extensionHost: ExtensionHost.Remote, isSupportedClient: true });
+	const filteredFlows = flows.filter(flow => {
+		const deviceCodeLabel = vscode.l10n.t('device code');
+		return flow.label === deviceCodeLabel;
+	});
+
+	return filteredFlows.length > 0 ? filteredFlows[0] : undefined;
+}
+
+export async function getToken(scopes: string): Promise<string> {
+	if (!deviceCodeFlow) {
+		throw new Error('Device Code Flow is not available');
+	}
+
+	const flowOptions = await getFlowTriggerOptions(scopes);
+	logger.info(`using ${deviceCodeFlow.label} flow  with ${flowOptions.scopes} scopes to get token...`);
+
+	const token = await deviceCodeFlow.trigger(flowOptions);
+
+	logger.info(`the token was provided successfully!`);
+	return token;
+}
+
+

--- a/code/extensions/github-authentication/src/extension.ts
+++ b/code/extensions/github-authentication/src/extension.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+let enableExtension = false;
+import { initialize } from './device-flow';
 import { GitHubAuthenticationProvider, UriEventHandler } from './github';
 
 function initGHES(context: vscode.ExtensionContext, uriHandler: UriEventHandler) {
@@ -27,6 +29,11 @@ function initGHES(context: vscode.ExtensionContext, uriHandler: UriEventHandler)
 }
 
 export function activate(context: vscode.ExtensionContext) {
+	if (!enableExtension) {
+		initialize(context);
+		return;
+	}
+
 	const uriHandler = new UriEventHandler();
 	context.subscriptions.push(uriHandler);
 	context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));

--- a/code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -25,7 +25,6 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
-import { excludedExtensions } from 'vs/platform/extensionManagement/common/extensionsScannerService';
 
 export type ExtensionVerificationStatus = boolean | string;
 export type InstallableExtension = { readonly manifest: IExtensionManifest; extension: IGalleryExtension | URI; options: InstallOptions & InstallVSIXOptions };
@@ -259,9 +258,6 @@ export abstract class AbstractExtensionManagementService extends Disposable impl
 					const installed = await this.getInstalled(undefined, installExtensionTaskOptions.profileLocation);
 					const options: InstallExtensionTaskOptions = { ...installExtensionTaskOptions, donotIncludePackAndDependencies: true, context: { ...installExtensionTaskOptions.context, [EXTENSION_INSTALL_DEP_PACK_CONTEXT]: true } };
 					for (const { gallery, manifest } of distinct(allDepsAndPackExtensionsToInstall, ({ gallery }) => gallery.identifier.id)) {
-						if (excludedExtensions.includes(gallery.name)) {
-							continue;
-						}
 						installExtensionHasDependents = installExtensionHasDependents || !!manifest.extensionDependencies?.some(id => areSameExtensions({ id }, installExtensionTask.identifier));
 						const key = getInstallExtensionTaskKey(gallery);
 						const existingInstallingExtension = this.installingExtensions.get(key);

--- a/code/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
+++ b/code/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
@@ -529,10 +529,6 @@ type NlsConfiguration = {
 	translations: Translations;
 };
 
-export const excludedExtensions = [
-	'github-authentication',
-];
-
 class ExtensionsScanner extends Disposable {
 
 	constructor(
@@ -563,9 +559,7 @@ class ExtensionsScanner extends Disposable {
 			return [];
 		}
 		const extensions = await Promise.all<IRelaxedScannedExtension | null>(
-			stat.children
-			.filter(c => !excludedExtensions.includes(c.name))
-			.map(async c => {
+			stat.children.map(async c => {
 				if (!c.isDirectory) {
 					return null;
 				}

--- a/code/src/vs/workbench/api/common/extHostExtensionActivator.ts
+++ b/code/src/vs/workbench/api/common/extHostExtensionActivator.ts
@@ -11,7 +11,6 @@ import { ExtensionIdentifier, ExtensionIdentifierMap } from 'vs/platform/extensi
 import { ExtensionActivationReason, MissingExtensionDependency } from 'vs/workbench/services/extensions/common/extensions';
 import { ILogService } from 'vs/platform/log/common/log';
 import { Barrier } from 'vs/base/common/async';
-import { excludedExtensions } from 'vs/platform/extensionManagement/common/extensionsScannerService';
 
 /**
  * Represents the source code (module) of an extension.
@@ -273,10 +272,6 @@ export class ExtensionsActivator implements IDisposable {
 		const deps: ActivationOperation[] = [];
 		const depIds = (typeof currentExtension.extensionDependencies === 'undefined' ? [] : currentExtension.extensionDependencies);
 		for (const depId of depIds) {
-			if (excludedExtensions.includes(depId.substring('vscode.'.length))) {
-				continue;
-			}
-
 			if (this._isResolvedExtension(depId)) {
 				// This dependency is already resolved
 				continue;


### PR DESCRIPTION
### What does this PR do?
- Adds `Github:  Device Authentication` command
- Adds `Github: Remove Device Authentication Token` command
- Stores `Device Authentication` token to a separate secret
- Resolves a problem when there are few tokens in the `.git-credential/credentials` file, see https://github.com/eclipse/che/issues/22433.
 

https://github.com/che-incubator/che-code/assets/5676062/2fc017cd-bc56-466a-93e3-fecc43c679c8

- Adds a logger to the `Eclipse Che API` and `Che Github Authentication` extensions, so logs are available in the corresponding channels of the `Output` view
<img width="1306" alt="image" src="https://github.com/che-incubator/che-code/assets/5676062/018c1e75-9ba0-4a9d-adaa-e0f2f60cc802">


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/22139

### How to test this PR?
#### Use case 1 - an extension authorization
- Start a workspace 
- Install an extension for testing that requires `Device Authentication` flow for authorization
- `F1 => Device Authentication` => follow the flow
- Reload the window to clean up cached sessions
- Sign In
- Try to use the extension

#### Use case 2 - Git related operations should work correctly when a Device Authentication token is used 
- Steps from the use case 1
- `F1` => `Git Clone` => follow the flow
- check that a project is cloned successfully

#### Use case 3 - Git related operations should work correctly after removing a Device Authentication token 
- Steps from the use case 1
- `F1` => `Github: Remove Device Authentication Token`
- Click the button `Accounts` on the left panel => `Github Sign Out`
- Try to test use case 2 - the `Git Clone` command should work correctly, using a token from the `.git-credential/credentials` file (if it's present)

#### Use case 4 - the changes should fix `Error: Invalid character in header content` problem when there are few tokens
- Create a workspace from the `gitlab` repo - the `gitlab` token should be added to the `.git-credential/credentials` file
- Stop the workspace ^.
- Create a workspace from the `github` repo - the `github` token should be added to the `.git-credential/credentials` file
- Check that `.git-credential/credentials` file contains both tokens
- `F1` => `Git Clone` => follow the flow
- check that a project is cloned successfully
- so, the following issue should be fixed https://github.com/eclipse/che/issues/22433

#### Use case 5 - Device Authentication flow can be used for authentication when there is no git-credential secrets/tokens
- Delete all `git-credential` secrets
- Start a workspace without authentication on the Github at the starting workspace step
- Check that the `.git-credential/credentials` file is empty
- `F1` => `Git Clone` => follow the flow => you should get an error - there is no token 
-  `F1` => `Device Authentication` => follow the flow
- Try to use `F1` => `Git Clone` again - now the `Github Service` should use `Device Authentication` token and the operation should be completed successfully