### PR TITLE
fix: install missing modules for kerberos authentication

### DIFF
--- a/build/dockerfiles/dev.Dockerfile
+++ b/build/dockerfiles/dev.Dockerfile
@@ -21,7 +21,7 @@ RUN ARCH=$(uname -m) && yum install --installroot /mnt/rootfs libsecret curl mak
                  "http://mirror.centos.org/centos/8/extras/${ARCH}/os/Packages/epel-release-8-11.el8.noarch.rpm" \
                  "http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm" \
                  "http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm" \
-                libX11-devel libxkbcommon bash tar gzip rsync patch pkg-config glib2-devel coreutils-single glibc-minimal-langpack which util-linux-user --releasever 8 --nodocs -y && yum --installroot /mnt/rootfs clean all
+                libX11-devel libxkbcommon krb5-devel bash tar gzip rsync patch pkg-config glib2-devel coreutils-single glibc-minimal-langpack which util-linux-user --releasever 8 --nodocs -y && yum --installroot /mnt/rootfs clean all
 # node-gyp will search for python
 RUN cd /mnt/rootfs && ln -s /usr/bin/python3 ./usr/bin/python
                 

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -8,6 +8,7 @@
 
 # Make an assembly including both musl and libc variant to be able to run on all linux systems
 FROM docker.io/node:16.17.1-alpine3.15 as linux-musl-builder
+
 RUN apk add --update --no-cache \
     # Download some files
     curl \
@@ -20,7 +21,9 @@ RUN apk add --update --no-cache \
     # some lib to compile 'native-keymap' npm mpdule
     libx11-dev libxkbfile-dev \
     # requirements for keytar
-    libsecret libsecret-dev
+    libsecret libsecret-dev \
+    # kerberos authentication
+    krb5-dev
 
 COPY code /checode-compilation
 WORKDIR /checode-compilation
@@ -31,8 +34,10 @@ RUN git init .
 
 # change network timeout (slow using multi-arch build)
 RUN yarn config set network-timeout 600000 -g
+
 # Grab dependencies
-RUN yarn 
+RUN yarn
+
 # Rebuild platform specific dependencies
 RUN npm rebuild
 
@@ -77,8 +82,6 @@ RUN [[ $(uname -m) == "x86_64" ]] && \
     ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" && \
     ls -la /checode-compilation/extensions/vscode-api-tests/ && \
     ls -la /checode-compilation/extensions/vscode-api-tests/out/
-
-
 
 # Run integration tests (Browser)
 RUN [[ $(uname -m) == "x86_64" ]] && VSCODE_REMOTE_SERVER_PATH="/vscode-reh-web-linux-alpine" \


### PR DESCRIPTION
### What does this PR do?
Fixes build of `linux-musl-amd64` image by adding missing `kerberos` library. 

The dependency was added by this commit https://github.com/microsoft/vscode/commit/6ae441b56fc9ca54b53a4d38810619f326b56bec

I did nothing for `linux-libc-amd64` as we do not have issues with it right now, but remember for future that it may require the dependency as well.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/22390

### How to test this PR?
...
