### PR TITLE
22407 - Remove Mattermost notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,15 +61,15 @@ jobs:
           git config --global pull.rebase true
           export GITHUB_TOKEN=${{ secrets.CHE_INCUBATOR_BOT_TOKEN }}
           /bin/bash make-release.sh --version ${{ github.event.inputs.version }} --tag-release
-      - name: Create failure MM message
-        if: failure()
-        run: |
-          echo "{\"text\":\":no_entry_sign: Che Code ${{ env.BRANCH_NAME }} release has failed: https://github.com/che-incubator/che-code/actions/workflows/release.yml\"}" > mattermost.json
-      - name: Send MM message
+      #- name: Create failure MM message
+        #if: failure()
+        #run: |
+          #echo "{\"text\":\":no_entry_sign: Che Code ${{ env.BRANCH_NAME }} release has failed: https://github.com/che-incubator/che-code/actions/workflows/release.yml\"}" > mattermost.json
+      #- name: Send MM message
         # only notify for failure, success message will be sent at the end of image-publish job
-        if: failure()
-        uses: mattermost/action-mattermost-notify@1.1.0
-        env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          MATTERMOST_CHANNEL: eclipse-che-releases
-          MATTERMOST_USERNAME: che-bot
+        #if: failure()
+        #uses: mattermost/action-mattermost-notify@1.1.0
+        #env:
+          #MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          #MATTERMOST_CHANNEL: eclipse-che-releases
+          #MATTERMOST_USERNAME: che-bot


### PR DESCRIPTION
https://github.com/eclipse/che/issues/22407
Comment out the mattermost notification so it doesn't fail the release workflow, but leaving it in the file so I remember to replace it.


