### PR TITLE
chore: Pass the pluginRegistryUrl at a new Devfile Context generation

### DIFF
--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "vscode-nls": "^5.0.0",
     "axios": "0.21.2",
-    "@eclipse-che/che-devworkspace-generator": "0.0.1-96cdbb4"
+    "@eclipse-che/che-devworkspace-generator": "0.0.1-96cdbb4",
+    "https": "^1.0.0"
   },
   "devDependencies": {
     "jest": "27.3.1",

--- a/code/extensions/che-remote/src/axios-certificate-authority.ts
+++ b/code/extensions/che-remote/src/axios-certificate-authority.ts
@@ -12,8 +12,8 @@
 
 import * as axios from 'axios';
 import * as fs from 'fs-extra';
-import https from 'https';
-import path from 'path';
+import * as https from 'https';
+import * as path from 'path';
 
 const DEFAULT_CHE_SELF_SIGNED_MOUNT_PATH = '/public-certs';
 const CHE_SELF_SIGNED_MOUNT_PATH = process.env.CHE_SELF_SIGNED_MOUNT_PATH;

--- a/code/extensions/che-remote/src/axios-certificate-authority.ts
+++ b/code/extensions/che-remote/src/axios-certificate-authority.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable header/header */
+
+import * as axios from 'axios';
+import * as fs from 'fs-extra';
+import https from 'https';
+import path from 'path';
+
+const DEFAULT_CHE_SELF_SIGNED_MOUNT_PATH = '/public-certs';
+const CHE_SELF_SIGNED_MOUNT_PATH = process.env.CHE_SELF_SIGNED_MOUNT_PATH;
+
+const certificateAuthority = getCertificateAuthority(
+	CHE_SELF_SIGNED_MOUNT_PATH ? CHE_SELF_SIGNED_MOUNT_PATH : DEFAULT_CHE_SELF_SIGNED_MOUNT_PATH,
+);
+
+export const axiosInstance = certificateAuthority
+	? axios.default.create({
+		httpsAgent: new https.Agent({
+			ca: certificateAuthority,
+		}),
+	})
+	: axios.default;
+
+function getCertificateAuthority(certPath: string): Buffer[] | undefined {
+	if (!fs.existsSync(certPath)) {
+		return undefined;
+	}
+
+	const certificateAuthority: Buffer[] = [];
+	searchCertificate(certPath, certificateAuthority);
+
+	return certificateAuthority.length > 0 ? certificateAuthority : undefined;
+}
+
+function searchCertificate(
+	certPath: string,
+	certificateAuthority: Buffer[],
+	subdirLevel = 1,
+): void {
+	const maxSubdirQuantity = 10;
+	const maxSubdirLevel = 5;
+
+	const tmpPaths: string[] = [];
+	try {
+		const publicCertificates = fs.readdirSync(certPath);
+		for (const publicCertificate of publicCertificates) {
+			const newPath = path.join(certPath, publicCertificate);
+			if (fs.lstatSync(newPath).isDirectory()) {
+				if (tmpPaths.length < maxSubdirQuantity) {
+					tmpPaths.push(newPath);
+				}
+			} else {
+				const fullPath = path.join(certPath, publicCertificate);
+				certificateAuthority.push(fs.readFileSync(fullPath));
+			}
+		}
+	} catch (e) {
+		// no-op
+	}
+
+	if (subdirLevel < maxSubdirLevel) {
+		for (const path of tmpPaths) {
+			searchCertificate(path, certificateAuthority, ++subdirLevel);
+		}
+	}
+}

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -12,9 +12,9 @@
 
 // local import to find the correct type
 import { Main as DevWorkspaceGenerator } from '@eclipse-che/che-devworkspace-generator/lib/main';
-import * as axios from 'axios';
 import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
+import { axiosInstance } from './axios-certificate-authority';
 
 const DEVFILE_NAME = 'devfile.yaml';
 const DOT_DEVFILE_NAME = '.devfile.yaml';
@@ -120,7 +120,7 @@ async function updateDevfile(cheApi: any): Promise<void> {
   const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
   
   console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
-  const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axios.default);
+  const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axiosInstance);
   if (newContent) {
     newContent.devWorkspace.spec!.template!.projects = projects;
     await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -117,7 +117,10 @@ async function updateDevfile(cheApi: any): Promise<void> {
 
   const currentDevfile = await devfileService.get();
   const projects = currentDevfile.projects || [];
-  const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, projects: [] }, axios.default);
+  const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
+  
+  console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
+  const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axios.default);
   if (newContent) {
     newContent.devWorkspace.spec!.template!.projects = projects;
     await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);

--- a/code/extensions/che-remote/yarn.lock
+++ b/code/extensions/che-remote/yarn.lock
@@ -1654,6 +1654,11 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https/-/https-1.0.0.tgz#3c37c7ae1a8eeb966904a2ad1e975a194b7ed3a4"
+  integrity sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"


### PR DESCRIPTION
### What does this PR do?
Pass the `pluginRegistryUrl` parameter using the `CHE_PLUGIN_REGISTRY_INTERNAL_URL` env variable.
It should fix problems related to Devfile Context generation by the devWorkspaceGenerator. 

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->

https://github.com/eclipse/che/issues/22388

### How to test this PR?
See the corresponding issues above.
