### PR TITLE
Install the dependencies for the `che-activity-tracker` extension on the pre-install phase to update its yarn.lock automatically

### DIFF
--- a/code/build/npm/dirs.js
+++ b/code/build/npm/dirs.js
@@ -10,6 +10,7 @@ const dirs = [
 	'',
 	'build',
 	'extensions',
+	'extensions/che-activity-tracker',
 	'extensions/che-api',
 	'extensions/che-commands',
 	'extensions/che-port',

--- a/code/extensions/che-activity-tracker/yarn.lock
+++ b/code/extensions/che-activity-tracker/yarn.lock
@@ -612,10 +612,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
   integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
-"@types/node@14.x":
-  version "14.18.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.21.tgz#0155ee46f6be28b2ff0342ca1a9b9fd4468bef41"
-  integrity sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==
+"@types/node@18.x":
+  version "18.18.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.0.tgz#bd19d5133a6e5e2d0152ec079ac27c120e7f1763"
+  integrity sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==
 
 "@types/prettier@^2.1.5":
   version "2.6.3"


### PR DESCRIPTION
### What does this PR do?
Installs the dependencies for the `che-activity-tracker` extension on the pre-install phase to update its yarn.lock automatically. It fixes the downstream build.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
for https://issues.redhat.com/browse/CRW-3160

### How to test this PR?

