### PR TITLE
fix: Allow GitHub clone when credentials file contains several tokens

### DIFF
--- a/code/extensions/che-api/tests/_data/.git-credentials/credentials
+++ b/code/extensions/che-api/tests/_data/.git-credentials/credentials
@@ -1,1 +1,0 @@
-https://oauth2:token@github.com

--- a/code/extensions/che-api/tests/github-service-impl.spec.ts
+++ b/code/extensions/che-api/tests/github-service-impl.spec.ts
@@ -12,45 +12,66 @@
 import 'reflect-metadata';
 
 import * as fs from 'fs-extra';
-import * as path from 'path';
-
 import { Container } from 'inversify';
 import { GithubServiceImpl } from '../src/impl/github-service-impl';
-import * as os from 'os';
 import { GithubUser } from '../src/api/github-service';
+
+const CREDENTIALS = 'https://oauth2:token@github.com';
+
+const MULTIHOST_CREDENTIALS = `
+    https://oauth2:5761d0b375d627ca5a@gitlab.com
+    https://oauth2:gho_dbi6YDyjyNrkO0ag354@github.com
+  `;
 
 describe('Test GithubServiceImpl', () => {
   let container: Container;
-
-  let githubServiceImpl: GithubServiceImpl;
 
   const axiosGetMock = jest.fn();
   const axiosMock = {
     get: axiosGetMock,
   } as any;
 
+  let readFileSyncMock = jest.fn();
+  let existsSyncMock = jest.fn();
+
   beforeEach(async () => {
     jest.restoreAllMocks();
     jest.resetAllMocks();
+
+    Object.assign(fs, {
+      readFileSync: readFileSyncMock,
+      existsSync: existsSyncMock
+    });
+
     container = new Container();
     container.bind(GithubServiceImpl).toSelf().inSingletonScope();
     container.bind(Symbol.for('AxiosInstance')).toConstantValue(axiosMock);
+  });
 
-    jest.spyOn(os, 'homedir').mockReturnValue(path.resolve(__dirname, '_data'));
-    githubServiceImpl = container.get(GithubServiceImpl);
+  test('throw error when token is not setup', async () => {
+    const service = container.get(GithubServiceImpl);
+    await expect(service.getToken()).rejects.toThrow('GitHub authentication token is not setup');
   });
 
   test('get token', async () => {
-    const token = await githubServiceImpl.getToken();
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue(CREDENTIALS);
+
+    const service = container.get(GithubServiceImpl);
+    const token = await service.getToken();
 
     expect(token).toEqual('token');
   });
 
   test('get user', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue(CREDENTIALS);
+
     const data: GithubUser = { id: 1, name: 'name', login: 'login', email: 'email' };
     axiosGetMock.mockResolvedValue({ data });
 
-    const user = await githubServiceImpl.getUser();
+    const service = container.get(GithubServiceImpl);
+    const user = await service.getUser();
 
     expect(axiosGetMock).toBeCalledWith('https://api.github.com/user', {
       headers: { Authorization: 'Bearer token' },
@@ -58,13 +79,16 @@ describe('Test GithubServiceImpl', () => {
     expect(user).toEqual(data);
   });
 
-  test('throw error when token is not setup', async () => {
-    container.rebind(GithubServiceImpl).toSelf().inSingletonScope();
-    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+  test('should return token for github', async () => {
+    existsSyncMock.mockReturnValue(true);
 
-    githubServiceImpl = container.get(GithubServiceImpl);
+    readFileSyncMock.mockImplementation(path => {
+      return '/.git-credentials/credentials' === path ? MULTIHOST_CREDENTIALS : '';
+    });
 
-    await expect(githubServiceImpl.getToken()).rejects.toThrow('GitHub authentication token is not setup');
+    const service = container.get(GithubServiceImpl);
+    const token = await service.getToken();
+    expect(token).toEqual('gho_dbi6YDyjyNrkO0ag354');
   });
 
 });


### PR DESCRIPTION
### What does this PR do?
Allows to clone from GitHub when `/.git-credentials/credentials` contains several different tokens.

![Screenshot from 2023-09-28 20-55-31](https://github.com/che-incubator/che-code/assets/1655894/e67a5315-5312-4f7c-bdb4-d9505667dd69)

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/22433

### How to test this PR?
- Create a workspace from this branch ( due to resource limitations works for dogfooding instance only )
- Ensure you have several tokens in `/.git-credentials/credentials`.
  If no, delete this workspace, create any workspace using GitLab repository, then stop created workspace and create a workspace from this branch again
- Run `devfile: prepare` task to install node dependencies
- Run `devfile: build` task and then run `devfile: run` tack
- A new browser tab should be opened, try GitHub clone

---
The code change were made using Che only :sunglasses: