### PR TITLE
Replace `Stop Workspace` command behavior with `Stop Workspace and Redirect to Dashboard`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ The following example shows all of the properties that you can customize by usin
         "openDocumentationCommand": "Branded IDE: Open Documentation",
         "openDashboardCommand": "Branded IDE: Open Dashboard",
         "openOpenShiftConsoleCommand": "Branded IDE: Open OpenShift Console",
-        "stopWorkspaceCommand": "Branded IDE: Stop Workspace",
-        "stopWorkspaceAndRedirectToDashboard": "Branded IDE: Stop Workspace and Redirect to Dashboard",
+        "stopWorkspaceAndRedirectToDashboard": "Branded IDE: Stop Workspace",
         "restartWorkspaceCommand": "Branded IDE: Restart Workspace",
         "restartWorkspaceFromLocalDevfileCommand": "Branded IDE: Restart Workspace from Local Devfile"
     },

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -49,11 +49,6 @@
   "contributes": {
     "commands": [
       {
-        "command": "che-remote.command.stopWorkspace",
-        "title": "%stopWorkspaceCommand%",
-        "enablement": "che-remote.workspace-enabled"
-      },
-      {
         "command": "che-remote.command.stopWorkspaceAndRedirectToDashboard",
         "title": "%stopWorkspaceAndRedirectToDashboard%",
         "enablement": "che-remote.workspace-enabled"
@@ -85,11 +80,6 @@
     ],
     "menus": {
       "statusBar/remoteIndicator": [
-        {
-          "command": "che-remote.command.stopWorkspace",
-          "group": "remote_40_che_navigation@10",
-          "when": "che-remote.workspace-enabled"
-        },
         {
           "command": "che-remote.command.stopWorkspaceAndRedirectToDashboard",
           "group": "remote_40_che_navigation@11",

--- a/code/extensions/che-remote/package.nls.json
+++ b/code/extensions/che-remote/package.nls.json
@@ -4,8 +4,7 @@
 	"openDocumentationCommand": "Eclipse Che: Open Documentation",
 	"openDashboardCommand": "Eclipse Che: Open Dashboard",
 	"openOpenShiftConsoleCommand": "Eclipse Che: Open OpenShift Console",
-	"stopWorkspaceCommand": "Eclipse Che: Stop Workspace",
-	"stopWorkspaceAndRedirectToDashboard": "Eclipse Che: Stop Workspace and Redirect to Dashboard",
+	"stopWorkspaceAndRedirectToDashboard": "Eclipse Che: Stop Workspace",
 	"restartWorkspaceCommand": "Eclipse Che: Restart Workspace",
 	"restartWorkspaceFromLocalDevfileCommand": "Eclipse Che: Restart Workspace from Local Devfile"
 }


### PR DESCRIPTION
### What does this PR do?
This PR replaces `Stop Workspace` command behavior with `Stop Workspace and Redirect to Dashboard`. `Stop Workspace` command will be removed from package.json but still exists for using by other commands.

### What issues does this PR fix?
https://github.com/eclipse/che/issues/22269

### How to test this PR?
Open Command Palette and start `Eclipse Che: Stop Workspace` command. Wait that workspace is stopped and web page redirected to Dashboard. The workspace has Stopped status.
