### PR TITLE
Set SHELL env var in launcher if unset to avoid issues in Code's shell detection

### DIFF
--- a/launcher/src/code-workspace.ts
+++ b/launcher/src/code-workspace.ts
@@ -23,7 +23,7 @@ export class CodeWorkspace {
    *
    *****************************************************************************************************************/
   async generate(): Promise<void> {
-    console.log("# Generaing Workspace file...");
+    console.log("# Generating Workspace file...");
 
     if (!env.PROJECTS_ROOT) {
       console.log("  > env.PROJECTS_ROOT is not set, skip this step");

--- a/launcher/src/vscode-launcher.ts
+++ b/launcher/src/vscode-launcher.ts
@@ -66,6 +66,17 @@ export class VSCodeLauncher {
       env.NODE_EXTRA_CA_CERTS = NODE_EXTRA_CERTIFICATE;
     }
 
+    if (!env.SHELL) {
+      // The SHELL env var is not set. In this case, Code will attempt to read the appropriate shell from /etc/passwd,
+      // which can cause issues when cri-o injects /sbin/nologin when starting containers. Instead, we'll check if bash
+      // is installed, and use that.
+      const shell = this.detectShell();
+      console.log(
+        `  > SHELL environment variable is not set. Setting it to ${shell}`
+      );
+      env.SHELL = shell;
+    }
+
     console.log(`  > Running: ${node}`);
     console.log(`  > Params: ${params}`);
 
@@ -82,5 +93,18 @@ export class VSCodeLauncher {
     run.on("close", (code: string) => {
       console.log(`VS Code process exited with code ${code}`);
     });
+  }
+
+  detectShell(): string {
+    try {
+      // Check if bash is installed
+      child_process.execSync("command -v /bin/bash", {
+        timeout: 500,
+      });
+      return "/bin/bash";
+    } catch (error) {
+      // bash not installed, fallback blindly to sh since it's at least better than /sbin/nologin
+      return "/bin/sh";
+    }
   }
 }

--- a/launcher/src/vscode-launcher.ts
+++ b/launcher/src/vscode-launcher.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import { userInfo } from "os";
 import { env } from "process";
 import * as fs from "./fs-extra";
 
@@ -66,7 +67,7 @@ export class VSCodeLauncher {
       env.NODE_EXTRA_CA_CERTS = NODE_EXTRA_CERTIFICATE;
     }
 
-    if (!env.SHELL) {
+    if (!env.SHELL && userInfo().shell === "/sbin/nologin") {
       // The SHELL env var is not set. In this case, Code will attempt to read the appropriate shell from /etc/passwd,
       // which can cause issues when cri-o injects /sbin/nologin when starting containers. Instead, we'll check if bash
       // is installed, and use that.


### PR DESCRIPTION
### What does this PR do?
If the SHELL environment variable is unset when running the Code launcher, set it:
* If we detect that bash is installed, to `/bin/bash`
* Otherwise, fallback to setting it to `/bin/sh`

This is necessary due to shell-detection logic within Code itself, which will fallback to parsing /etc/passwd when SHELL is not set (see [[1]](https://github.com/che-incubator/che-code/blob/a2bf97a1322166c72127a5b17a5eced40e803fbf/code/src/vs/base/node/shell.ts#L42-L48)). When running on e.g. OpenShift with a normal container, cri-o will add an /etc/passwd entry for the current user with `/sbin/nologin`, which results the terminal failing to launch.

### What issues does this PR fix?
Closes https://github.com/eclipse/che/issues/22524

### How to test this PR?
Changes from this PR are built into `quay.io/amisevsk/che-code:dev` via the following Dockerfile:
```dockerfile
FROM registry.access.redhat.com/ubi8/nodejs-18:1-71 as launcher-builder

USER root

COPY . /checode-launcher
WORKDIR /checode-launcher

RUN npm install -g yarn@1.22.17

RUN yarn \
    && mkdir /test-launcher \
    && cp -r out/src/*.js /test-launcher \
    && chgrp -R 0 /test-launcher && chmod -R g+rwX /test-launcher

FROM quay.io/che-incubator/che-code:next
COPY --from=launcher-builder --chown=0:0 /test-launcher /checode-linux-libc/launcher
```

To test the changes on an existing workspace, edit the DevWorkspace yaml on the cluster, updating the `.spec.contributions` field:
```diff
  spec:
    contributions:
      - name: editor
        kubernetes:
          name: che-code-java-maven
+       components:
+         - container:
+             image: 'quay.io/amisevsk/che-code:dev'
+           name: che-code-injector
```
(This will use quay.io/amisevsk/che-code:dev in place of the default injector image)

We should verify three cases before merging:
1. Samples that do not set the `SHELL` environment variable have https://github.com/eclipse/che/issues/22524 resolved.
     * To make this easier (since links to raw devfiles in registry.devfile.io do not seem to work in Che), you should be able to use the raw link on this gist and paste it into the dashboard: https://gist.github.com/amisevsk/c4ffd5185d81420be2d8e73cc1db9d45 (taken from https://registry.devfile.io/viewer/devfiles/community/java-maven), then update the DevWorkspace as above
2. It's still possible to override the shell by setting the SHELL env var in the devfile or container
3. Default Che samples are unimpacted