### PR TITLE
fix: configure pod name for resource monitor

### DIFF
--- a/code/extensions/che-api/src/api/workspace-service.ts
+++ b/code/extensions/che-api/src/api/workspace-service.ts
@@ -14,6 +14,7 @@ export const WorkspaceService = Symbol('WorkspaceService');
 export interface WorkspaceService {
     getNamespace(): Promise<string>;
     getWorkspaceId(): Promise<string>;
+    getPodName(): Promise<string>;
     updateWorkspaceActivity(): Promise<void>;
     stop(): Promise<void>;
 }

--- a/code/extensions/che-api/src/impl/k8s-devworkspace-env-variables.ts
+++ b/code/extensions/che-api/src/impl/k8s-devworkspace-env-variables.ts
@@ -77,9 +77,6 @@ export class K8sDevWorkspaceEnvVariables {
       this.workspaceName = process.env.DEVWORKSPACE_NAME;
     }
 
-    // temporary patch
-    process.env.DEVWORKSPACE_POD_NAME = process.env.HOSTNAME;
-
     if (process.env.DEVWORKSPACE_POD_NAME === undefined) {
       console.error('Environment variable DEVWORKSPACE_POD_NAME is not set');
     } else {

--- a/code/extensions/che-api/src/impl/k8s-devworkspace-env-variables.ts
+++ b/code/extensions/che-api/src/impl/k8s-devworkspace-env-variables.ts
@@ -26,38 +26,36 @@ export class K8sDevWorkspaceEnvVariables {
   /**
    * workspaceName - workspace name taken from environment variable, always the same at workspace lifecycle
    */
-
   private readonly workspaceName!: string;
-
 
   /**
    * workspaceNamespace - workspace namespace taken from environment variable, always the same at workspace lifecycle
    */
-
   private readonly workspaceNamespace!: string;
+
+  /**
+   * workspacePodName - workspace POD name taken from environment variable, changes every time the workspace is started
+   */
+  private readonly workspacePodName!: string;
 
   /**
    * devWorkspaceFlattenedDevfilePath - environment variable holding the path to the flattened devworkspace template spec
    */
-
   private readonly devWorkspaceFlattenedDevfilePath!: string;
 
   /**
    * projectsRoot - Root directory for projects, default being /projects
    */
-
   private readonly projectsRoot!: string;
 
   /**
    * pluginRegistryURL - Plugin registry public URL
    */
-
   private readonly pluginRegistryURL!: string;
 
   /**
    * dashboardURL - Dashboard URL
    */
-
   private readonly dashboardURL!: string;
 
   constructor() {
@@ -77,6 +75,15 @@ export class K8sDevWorkspaceEnvVariables {
       console.error('Environment variable DEVWORKSPACE_NAME is not set');
     } else {
       this.workspaceName = process.env.DEVWORKSPACE_NAME;
+    }
+
+    // temporary patch
+    process.env.DEVWORKSPACE_POD_NAME = process.env.HOSTNAME;
+
+    if (process.env.DEVWORKSPACE_POD_NAME === undefined) {
+      console.error('Environment variable DEVWORKSPACE_POD_NAME is not set');
+    } else {
+      this.workspacePodName = process.env.DEVWORKSPACE_POD_NAME;
     }
 
     if (process.env.DEVWORKSPACE_FLATTENED_DEVFILE === undefined) {
@@ -114,6 +121,10 @@ export class K8sDevWorkspaceEnvVariables {
 
   getWorkspaceNamespace(): string {
     return this.workspaceNamespace;
+  }
+
+  getWorkspacePodName(): string {
+    return this.workspacePodName;
   }
 
   getDevWorkspaceFlattenedDevfilePath(): string {

--- a/code/extensions/che-api/src/impl/k8s-devworkspace-env-variables.ts
+++ b/code/extensions/che-api/src/impl/k8s-devworkspace-env-variables.ts
@@ -34,7 +34,7 @@ export class K8sDevWorkspaceEnvVariables {
   private readonly workspaceNamespace!: string;
 
   /**
-   * workspacePodName - workspace POD name taken from environment variable, changes every time the workspace is started
+   * workspacePodName - workspace pod name taken from environment variable, changes every time the workspace is started
    */
   private readonly workspacePodName!: string;
 

--- a/code/extensions/che-api/src/impl/k8s-workspace-service-impl.ts
+++ b/code/extensions/che-api/src/impl/k8s-workspace-service-impl.ts
@@ -19,61 +19,72 @@ import { WorkspaceService } from '../api/workspace-service';
 
 @injectable()
 export class K8sWorkspaceServiceImpl implements WorkspaceService {
-    @inject(K8SServiceImpl)
-    private k8SService!: K8SServiceImpl;
-  
-    @inject(K8sDevWorkspaceEnvVariables)
-    private env!: K8sDevWorkspaceEnvVariables;
+  @inject(K8SServiceImpl)
+  private k8SService!: K8SServiceImpl;
 
-    @inject(Symbol.for('AxiosInstance'))
-    private axiosInstance!: AxiosInstance;
-  
-    public async getNamespace(): Promise<string> {
-      return this.env.getWorkspaceNamespace();
-    }
-  
-    public async getWorkspaceId(): Promise<string> {
-      return this.env.getWorkspaceId();
-    }
+  @inject(K8sDevWorkspaceEnvVariables)
+  private env!: K8sDevWorkspaceEnvVariables;
 
-    public async updateWorkspaceActivity(): Promise<void> {
-      if (!process.env.MACHINE_EXEC_PORT) {
-        throw new Error('Environment variable MACHINE_EXEC_PORT not found.');
-      }
+  @inject(Symbol.for('AxiosInstance'))
+  private axiosInstance!: AxiosInstance;
 
-      const requestUrl = `http://127.0.0.1:${process.env.MACHINE_EXEC_PORT}/activity/tick`;
-      await this.axiosInstance.post(requestUrl);
-    }
-  
-   // stopping the workspace is changing the started state to false
-    public async stop(): Promise<void> {
-  
-      const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
-      const group = 'workspace.devfile.io';
-      const version = 'v1alpha2';
-      const namespace = this.env.getWorkspaceNamespace();
-      const plural = 'devworkspaces';
-      const name = this.env.getWorkspaceName();
-      const patch = [
-        {
-          op: 'replace',
-          path: '/spec/started',
-          value: false,
-        },
-      ];
-  
-      const options = { headers: { 'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH } };
-      await customObjectsApi.patchNamespacedCustomObject(
-        group,
-        version,
-        namespace,
-        plural,
-        name,
-        patch,
-        undefined,
-        undefined,
-        undefined,
-        options
-      );
-    }
+  public async getNamespace(): Promise<string> {
+    return this.env.getWorkspaceNamespace();
   }
+
+  public async getWorkspaceId(): Promise<string> {
+    return this.env.getWorkspaceId();
+  }
+
+  public async getPodName(): Promise<string> {
+    return this.env.getWorkspacePodName();
+  }
+
+  private machineExecPortFault = false;
+
+  public async updateWorkspaceActivity(): Promise<void> {
+    if (this.machineExecPortFault) {
+      // no need to check the environment variable again
+      return;
+    }
+
+    if (!process.env.MACHINE_EXEC_PORT) {
+      this.machineExecPortFault = true;
+      throw new Error('Environment variable MACHINE_EXEC_PORT not found.');
+    }
+
+    const requestUrl = `http://127.0.0.1:${process.env.MACHINE_EXEC_PORT}/activity/tick`;
+    await this.axiosInstance.post(requestUrl);
+  }
+
+  // stopping the workspace is changing the started state to false
+  public async stop(): Promise<void> {
+    const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
+    const group = 'workspace.devfile.io';
+    const version = 'v1alpha2';
+    const namespace = this.env.getWorkspaceNamespace();
+    const plural = 'devworkspaces';
+    const name = this.env.getWorkspaceName();
+    const patch = [
+      {
+        op: 'replace',
+        path: '/spec/started',
+        value: false,
+      },
+    ];
+
+    const options = { headers: { 'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH } };
+    await customObjectsApi.patchNamespacedCustomObject(
+      group,
+      version,
+      namespace,
+      plural,
+      name,
+      patch,
+      undefined,
+      undefined,
+      undefined,
+      options
+    );
+  }
+}

--- a/code/extensions/che-resource-monitor/src/extension.ts
+++ b/code/extensions/che-resource-monitor/src/extension.ts
@@ -22,21 +22,22 @@ let resourceMonitorPLugin: ResourceMonitor;
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const inversifyBinding = new InversifyBinding();
   const container = await inversifyBinding.initBindings();
-  const namespace = await getNamespace();
+  
+  const workspaceService = await getWorkspaceService();
+  const namespace = await workspaceService.getNamespace();
+  const podName = await workspaceService.getPodName();
+  
   resourceMonitorPLugin = container.get(ResourceMonitor);
-  resourceMonitorPLugin.start(context, namespace);
+  resourceMonitorPLugin.start(context, namespace, podName);
 }
 
-
-
-export async function getNamespace(): Promise<string> {
+export async function getWorkspaceService(): Promise<any> {
   const extensionApi = vscode.extensions.getExtension('eclipse-che.api');
   if (!extensionApi) {
     throw new Error("Extension 'eclipse-che.api' is not installed");
   }
-    await extensionApi.activate();
-    const cheApi: any = extensionApi?.exports;
-    const workspaceService = cheApi.getWorkspaceService();
-    return workspaceService.getNamespace();
-  }
 
+  await extensionApi.activate();
+  const cheApi: any = extensionApi?.exports;
+  return cheApi.getWorkspaceService();
+}

--- a/launcher/src/vscode-launcher.ts
+++ b/launcher/src/vscode-launcher.ts
@@ -79,16 +79,16 @@ export class VSCodeLauncher {
     }
 
     if (env.HOSTNAME) {
-      // The HOSTNAME env var is used to store the name of current POD.
+      // The HOSTNAME env var is used to store name of the current pod.
       // But sometime it gets overwritten or even initialized to an empty value by the VS Code itself.
-      // To get the POD name when needed, we have to copy its value to another env var.
+      // To get the pod name when needed, we have to copy its value to another env var.
       env.DEVWORKSPACE_POD_NAME = env.HOSTNAME;
       console.log(
         `  > Setting DEVWORKSPACE_POD_NAME environment variable to ${env.DEVWORKSPACE_POD_NAME}`
       );
     } else {
       console.log(
-        `  > HOSTNAME environment variable is not set. It can lead to issues when getting the information about the current POD.`
+        `  > HOSTNAME environment variable is not set. Getting the information about the current pod may not be possible.`
       );
     }
 

--- a/launcher/src/vscode-launcher.ts
+++ b/launcher/src/vscode-launcher.ts
@@ -78,6 +78,20 @@ export class VSCodeLauncher {
       env.SHELL = shell;
     }
 
+    if (env.HOSTNAME) {
+      // The HOSTNAME env var is used to store the name of current POD.
+      // But sometime it gets overwritten or even initialized to an empty value by the VS Code itself.
+      // To get the POD name when needed, we have to copy its value to another env var.
+      env.DEVWORKSPACE_POD_NAME = env.HOSTNAME;
+      console.log(
+        `  > Setting DEVWORKSPACE_POD_NAME environment variable to ${env.DEVWORKSPACE_POD_NAME}`
+      );
+    } else {
+      console.log(
+        `  > HOSTNAME environment variable is not set. It can lead to issues when getting the information about the current POD.`
+      );
+    }
+
     console.log(`  > Running: ${node}`);
     console.log(`  > Params: ${params}`);
 

--- a/launcher/tests/flattened-devfile.spec.ts
+++ b/launcher/tests/flattened-devfile.spec.ts
@@ -15,6 +15,8 @@ import { FlattenedDevfile } from "../src/flattened-devfile";
 
 describe("Test operating wih DevWorkspace Flattened Devfile:", () => {
   test("should not return che-code endpoint if env.DEVWORKSPACE_FLATTENED_DEVFILE is not set", async () => {
+    delete env.DEVWORKSPACE_FLATTENED_DEVFILE;
+
     const devfile = new FlattenedDevfile();
 
     try {

--- a/launcher/tests/vscode-launcher.spec.ts
+++ b/launcher/tests/vscode-launcher.spec.ts
@@ -24,6 +24,8 @@ describe("Test VS Code launcher:", () => {
     delete env.VSCODE_DEFAULT_WORKSPACE;
     delete env.NODE_EXTRA_CA_CERTS;
     delete env.SHELL;
+    delete env.HOSTNAME;
+    delete env.DEVWORKSPACE_POD_NAME;
   });
 
   afterEach(() => {
@@ -516,5 +518,71 @@ describe("Test VS Code launcher:", () => {
     ]);
 
     expect(env.SHELL).toBe(undefined);
+  });
+
+  test("should set DEVWORKSPACE_POD_NAME env var if HOSTNAME env var is set", async () => {
+    env.VSCODE_NODEJS_RUNTIME_DIR = "/tmp/vscode-nodejs-runtime";
+    env.PROJECTS_ROOT = "/tmp/projects";
+    env.PROJECT_SOURCE = "/tmp/projects/sample-project";
+    env.SHELL = "/bin/testshell";
+
+    env.HOSTNAME = "test-host";
+
+    const pathExistsMock = jest.fn();
+    Object.assign(fs, {
+      pathExists: pathExistsMock,
+    });
+
+    const spawnMock = jest.fn();
+    Object.assign(child_process, {
+      spawn: spawnMock,
+    });
+
+    spawnMock.mockImplementation(() => ({
+      on: jest.fn(),
+      stdout: {
+        on: jest.fn(),
+      },
+      stderr: {
+        on: jest.fn(),
+      },
+    }));
+
+    const launcher = new VSCodeLauncher();
+    await launcher.launch();
+
+    expect(env.DEVWORKSPACE_POD_NAME).toBe("test-host");
+  });
+
+  test("should not set DEVWORKSPACE_POD_NAME env var if HOSTNAME env var is missing", async () => {
+    env.VSCODE_NODEJS_RUNTIME_DIR = "/tmp/vscode-nodejs-runtime";
+    env.PROJECTS_ROOT = "/tmp/projects";
+    env.PROJECT_SOURCE = "/tmp/projects/sample-project";
+    env.SHELL = "/bin/testshell";
+
+    const pathExistsMock = jest.fn();
+    Object.assign(fs, {
+      pathExists: pathExistsMock,
+    });
+
+    const spawnMock = jest.fn();
+    Object.assign(child_process, {
+      spawn: spawnMock,
+    });
+
+    spawnMock.mockImplementation(() => ({
+      on: jest.fn(),
+      stdout: {
+        on: jest.fn(),
+      },
+      stderr: {
+        on: jest.fn(),
+      },
+    }));
+
+    const launcher = new VSCodeLauncher();
+    await launcher.launch();
+
+    expect(env.DEVWORKSPACE_POD_NAME).toBe(undefined);
   });
 });


### PR DESCRIPTION
### What does this PR do?
To get the metrics, resource monitor extension needs to know the pod name, which is provided by `HOSTNAME` environment variable.

Sometimes VS Code overwrites the variable with different value ( it looks like it's not VS Code, but someone from dependencies ).

To avoid losing the pod name, it was decided to copy `HOSTNAME` env var to `DEVWORKSPACE_POD_NAME` env var before launching the editor, and take the pod name from new variable when necessary.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-3526

### How to test this PR?
- create workspace with https://github.com/che-incubator/che-code/tree/fix-resource-monitor-test
- ensure resource monitor is working
- open a terminal, ensure `DEVWORKSPACE_POD_NAME` environment variable is set