### PR TITLE
fix: che-22646 use gh instead of hub

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -66,8 +66,7 @@ bump_version () {
         git checkout "${PR_BRANCH}"
         git pull origin "${PR_BRANCH}"
         git push origin "${PR_BRANCH}"
-        lastCommitComment="$(git log -1 --pretty=%B)"
-        hub pull-request -f -m "${lastCommitComment}" -b "${BUMP_BRANCH}" -h "${PR_BRANCH}"
+        gh pr create -f -B "${CURRENT_BRANCH}" -H "${PR_BRANCH}"
     fi
     set -e
   fi


### PR DESCRIPTION
### What does this PR do?
Use `gh` instead of `hub` that was removed from ubuntu runner

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?
https://github.com/eclipse/che/issues/22646
