### PR TITLE
[ports-plugin] don't prompt user to redirect endpoints with `exposure: none`

### DIFF
--- a/code/extensions/che-port/src/devfile-handler-devworkspace-impl.ts
+++ b/code/extensions/che-port/src/devfile-handler-devworkspace-impl.ts
@@ -84,27 +84,6 @@ export class DevWorkspaceDevfileHandlerImpl implements DevfileHandler {
       } as Endpoint;
     });
 
-    // Add private JWT proxy ports
-    const jwtProxyEnv: string[] = Object.keys(process.env).filter(key =>
-      key.includes('_JWTPROXY_SERVICE_PORT_SERVER_')
-    );
-    jwtProxyEnv.forEach((key, index) => {
-      const value = process.env[key]!.toLocaleLowerCase() || '';
-      const port = parseInt(value);
-      if (!isNaN(port)) {
-        const endpoint: Endpoint = {
-          name: `jwt-proxy-${index + 1}`,
-          exposure: EndpointExposure.FROM_DEVFILE_PRIVATE,
-          url: '',
-          targetPort: port,
-          protocol: 'tcp',
-          type: 'jwt-proxy',
-          category: EndpointCategory.PLUGINS,
-        };
-        endpoints.push(endpoint);
-      }
-    });
-
     return endpoints;
   }
 }

--- a/code/extensions/che-port/src/ports-plugin.ts
+++ b/code/extensions/che-port/src/ports-plugin.ts
@@ -172,11 +172,19 @@ export class PortsPlugin {
     // check now if the port is in workspace definition ?
     const matchingEndpoint = this.devfileEndpoints.find(endpoint => endpoint.targetPort === port.portNumber);
 
-    if (matchingEndpoint && matchingEndpoint.exposure === EndpointExposure.FROM_DEVFILE_PRIVATE) {
-      this.outputChannel.appendLine(
-        `Endpoint ${matchingEndpoint.name} on port ${matchingEndpoint.targetPort} is defined as Private. Do not prompt to open it.`
-      );
-      return;
+    if (matchingEndpoint) {
+      if (matchingEndpoint.exposure === EndpointExposure.FROM_DEVFILE_PRIVATE) {
+        this.outputChannel.appendLine(
+          `Endpoint ${matchingEndpoint.name} on port ${matchingEndpoint.targetPort} is defined as exposure: internal. Do not prompt to open it.`
+        );
+        return;
+      }
+      if (matchingEndpoint.exposure === EndpointExposure.FROM_DEVFILE_NONE) {
+        this.outputChannel.appendLine(
+          `Endpoint ${matchingEndpoint.name} on port ${matchingEndpoint.targetPort} is defined as exposure: none. Do not prompt to open it.`
+        );
+        return;
+      }
     }
 
     // if not listening on 0.0.0.0 then raise a prompt to add a port redirect

--- a/code/extensions/che-port/src/ports-plugin.ts
+++ b/code/extensions/che-port/src/ports-plugin.ts
@@ -189,11 +189,19 @@ export class PortsPlugin {
 
     // if not listening on 0.0.0.0 then raise a prompt to add a port redirect
     if (port.interfaceListen !== PortsPlugin.LISTEN_ALL_IPV4 && port.interfaceListen !== PortsPlugin.LISTEN_ALL_IPV6) {
-      const desc = `A new process is now listening on port ${port.portNumber} but is listening on interface ${port.interfaceListen} which is internal.
-        You should change to be remotely available. Would you want to add a redirect for this port so it becomes available ?`;
-      const err = `A new process is now listening on port ${port.portNumber} but is listening on interface ${port.interfaceListen} which is internal.
-        This port is not available outside. You should change the code to listen on 0.0.0.0 for example.`;
-      await this.askRedirect(port, desc, err);
+      if (matchingEndpoint && matchingEndpoint.exposure === EndpointExposure.FROM_DEVFILE_PUBLIC) {
+        const desc = `Process ${matchingEndpoint.name} is now listening on port ${matchingEndpoint.targetPort}, but it is listening on ${port.interfaceListen},
+          which is internal. You should change the code to listen on port 0.0.0.0 instead. Would you like to add a redirect to make this process available anyway?`;
+        const err = `Process ${matchingEndpoint.name} is now listening on port ${matchingEndpoint.targetPort}, but it is listening on ${port.interfaceListen},
+          which is internal. You should change the code to listen on port 0.0.0.0 instead.`;
+        await this.askRedirect(port, desc, err);
+      } else {
+        const desc = `A new process is now listening on port ${port.portNumber} but is listening on interface ${port.interfaceListen} which is internal.
+          You should change to be remotely available. Would you want to add a redirect for this port so it becomes available ?`;
+        const err = `A new process is now listening on port ${port.portNumber} but is listening on interface ${port.interfaceListen} which is internal.
+          This port is not available outside. You should change the code to listen on 0.0.0.0 for example.`;
+        await this.askRedirect(port, desc, err);
+      }
       return;
     }
 


### PR DESCRIPTION
### What does this PR do?
Updates how endpoints are handled in the ports plugin:

* If a process starts listening internally (i.e. on localhost) to a port that matches an endpoint with `exposure: none`, do **not** prompt the user to redirect this port
* If a process starts listening internally (i.e. on localhost) to a port that matches an endpoint with `exposure: public`, change the redirect prompt to mention this specifically, as it may indicate unexpected behavior in the editor (redirecting a process rather than serving it over the defined endpoint in the devfile)

This PR also removes some old JWT handling code, since we don't use JWT anymore.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
Closes https://github.com/eclipse/che/issues/22655

### How to test this PR?
The easiest way to test this PR is via this devfile https://gist.github.com/amisevsk/2f11f0e282b93dc6413b0dd360437a7b and the following simple script (`test.js`):
```javascript
var http = require('http');
http.createServer(function (req, res) {}).listen(1110); // public endpoint, listening on all addresses
http.createServer(function (req, res) {}).listen(1111); // internal endpoint, listening on all addresses
http.createServer(function (req, res) {}).listen(1112); // none endpoint, listening on all addresses

http.createServer(function (req, res) {}).listen(2220, "localhost"); // public endpoint, listening on localhost
http.createServer(function (req, res) {}).listen(2221, "localhost"); // internal endpoint, listening on localhost
http.createServer(function (req, res) {}).listen(2222, "localhost"); // none endpoint, listening on localhost
```

The devfile has six endpoints:
* `1110`, `1111`, and `1112` are `public`, `internal`, and `none` endpoints (in that order) for testing "listen on 0.0.0.0"
* `2220`, `2221`, and `2222` are `public`, `internal`, and `none` endpoints (in that order) for testing "listen on localhost"

If you run the `test.js` script, you should see:
* Two prompts -- one for the public endpoint and one warning/prompt for the public-internal endpoint
    ![2023-11-14-13:34:11](https://github.com/che-incubator/che-code/assets/16168279/1310ecda-6284-45e2-b1ee-2f911526bb4b)

* Four logs in the ports plugins output pane:
    ```
    Endpoint test-none on port 1112 is defined as exposure: none. Do not prompt to open it.
    Endpoint test-internal on port 1111 is defined as exposure: internal. Do not prompt to open it.
    Endpoint test-local-internal on port 2221 is defined as exposure: internal. Do not prompt to open it.
    Endpoint test-local-none on port 2222 is defined as exposure: none. Do not prompt to open it.
    ```