### PR TITLE
ripgrep 1.15.6 -> 1.15.7

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -72,7 +72,7 @@
     "@vscode/iconv-lite-umd": "0.7.0",
     "@vscode/policy-watcher": "^1.1.4",
     "@vscode/proxy-agent": "^0.18.1",
-    "@vscode/ripgrep": "^1.15.6",
+    "@vscode/ripgrep": "^1.15.7",
     "@vscode/spdlog": "^0.13.12",
     "@vscode/sqlite3": "5.1.6-vscode",
     "@vscode/sudo-prompt": "9.3.1",

--- a/code/remote/package.json
+++ b/code/remote/package.json
@@ -8,7 +8,7 @@
     "@parcel/watcher": "2.1.0",
     "@vscode/iconv-lite-umd": "0.7.0",
     "@vscode/proxy-agent": "^0.18.1",
-    "@vscode/ripgrep": "^1.15.6",
+    "@vscode/ripgrep": "^1.15.7",
     "@vscode/spdlog": "^0.13.12",
     "@vscode/vscode-languagedetection": "1.0.21",
     "@vscode/windows-process-tree": "^0.5.0",

--- a/code/remote/yarn.lock
+++ b/code/remote/yarn.lock
@@ -72,10 +72,10 @@
   optionalDependencies:
     "@vscode/windows-ca-certs" "^0.3.1"
 
-"@vscode/ripgrep@^1.15.6":
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.6.tgz#17bdffc1fd0c4a034dc3e1e8203b8d07add96c0d"
-  integrity sha512-mCtfHqZ/g+75qDDeIPB9ST1xyJDaJornaSujuRKkB0SMZ6FMVtuKUdvvvOITR+DcKo5KOwUVuOUUpt75jOY+Yw==
+"@vscode/ripgrep@^1.15.7":
+  version "1.15.7"
+  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.7.tgz#bee27fd60387fd74981c266f046532ea018be64e"
+  integrity sha512-3B5dqNljRLtNhKQ0ZOO8uFffF3TJ+ecnfN9PQH8iVvXtzlbPkh5R48/L2XRM+lFUm5mYCLbym/Ee+P19UePDDA==
   dependencies:
     https-proxy-agent "^7.0.2"
     proxy-from-env "^1.1.0"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -1418,10 +1418,10 @@
   optionalDependencies:
     "@vscode/windows-ca-certs" "^0.3.1"
 
-"@vscode/ripgrep@^1.15.6":
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.6.tgz#17bdffc1fd0c4a034dc3e1e8203b8d07add96c0d"
-  integrity sha512-mCtfHqZ/g+75qDDeIPB9ST1xyJDaJornaSujuRKkB0SMZ6FMVtuKUdvvvOITR+DcKo5KOwUVuOUUpt75jOY+Yw==
+"@vscode/ripgrep@^1.15.7":
+  version "1.15.7"
+  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.7.tgz#bee27fd60387fd74981c266f046532ea018be64e"
+  integrity sha512-3B5dqNljRLtNhKQ0ZOO8uFffF3TJ+ecnfN9PQH8iVvXtzlbPkh5R48/L2XRM+lFUm5mYCLbym/Ee+P19UePDDA==
   dependencies:
     https-proxy-agent "^7.0.2"
     proxy-from-env "^1.1.0"


### PR DESCRIPTION
### What does this PR do?
This PR bumps the version of ripgrep from 1.15.6 to the latest version 1.15.7

### What issues does this PR fix?
Fixes the issue related to search function for Power.
https://issues.redhat.com/browse/CRW-4938
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?
In the container for Power, `/checode-linux-libc/node_modules/@vscode/ripgrep/bin/rg --version` shouldn't give an error.
