### PR TITLE
Add remote settings.json to injector and copy it on start.

### DIFF
--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -34,6 +34,7 @@ RUN for f in "/mnt/rootfs/bin/" "/mnt/rootfs/home/che" "/mnt/rootfs/etc/passwd" 
 
 COPY --from=machine-exec --chown=0:0 /go/bin/che-machine-exec /mnt/rootfs/bin/machine-exec
 COPY --chmod=755 /build/scripts/*.sh /mnt/rootfs/
+COPY --chmod=755 /build/remote-config /mnt/rootfs/remote/data/Machine/
 
 # Create all-in-one image
 FROM scratch

--- a/build/remote-config/settings.json
+++ b/build/remote-config/settings.json
@@ -1,0 +1,5 @@
+{
+  // Note: settings in this file will override user-level settings in the workspace.
+  //       Any setting that may be changed by the user should not be set here.
+  "git.defaultCloneDirectory": "/projects/"
+}

--- a/build/scripts/entrypoint-init-container.sh
+++ b/build/scripts/entrypoint-init-container.sh
@@ -16,8 +16,12 @@ cp -r /checode-* /checode/
 # Copy machine-exec as well
 mkdir -p /checode/bin
 cp /bin/machine-exec /checode/bin/
-# copy entrypoint
+# Copy entrypoint
 cp /entrypoint-volume.sh /checode/
+# Copy remote configuration
+mkdir -p /checode/remote
+cp -r /remote /checode
+
 echo "listing all files copied"
 ls -la /checode
 


### PR DESCRIPTION
### What does this PR do?
Add settings.json file (`/remote/data/Machine/settings.json`) to the injector, to be copied in to the checode volume on start.

This settings.json file can be used to configure options for Code, taking precendence over user/in-browser settings, and can be used to set required configuration for running the code editor in Che.

Currently, it is only used to set `"git.defaultCloneDirectory": "/projects/"`

### What issues does this PR fix?
Closes https://github.com/eclipse/che/issues/22653

### How to test this PR?
I've pushed changes to `quay.io/amisevsk/che-code:dev`. Updating a workspace's DevWorkspaceTemplate to reference this image instead of the default injector should result in file `/checode/remote/data/Machine/settings.json` existing on start.

If you use Code to clone a project, it should default the path to `/projects`
