### PR TITLE
Cleans up the root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,5 @@
     "build:min": "cd code && yarn gulp vscode-reh-web-linux-x64-min",
     "rebuild-native-modules": "cd code && npm rebuild"
   },
-  "license": "EPL-2.0",
-  "dependencies": {
-    "node-gyp": "^9.4.1"
-  },
-  "engines": {
-    "node": ">= 18.18.2",
-    "npm": ">= 9.8.1",
-    "yarn": ">= 1.22.19"
-  }
+  "license": "EPL-2.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,3 @@
 # yarn lockfile v1
 
 
-node-gyp@9.4.1:
-  version "9.4.1"
-  resolved "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz#8a1023e0d6766ecb52764cc3a734b36ff275e185"
-  integrity sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==
-  dependencies:
-    env-paths "^2.2.0"
-    exponential-backoff "^3.1.1"
-    glob "^7.1.4"
-    graceful-fs "^4.2.6"
-    make-fetch-happen "^10.0.3"
-    nopt "^6.0.0"
-    npmlog "^6.0.0"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.2"
-    which "^2.0.2"
-


### PR DESCRIPTION
### What does this PR do?
In this PR, I suggest removing the redundant fields from the root `package.json` that I overlooked while reviewing [the recently merged patch](https://github.com/che-incubator/che-code/pull/305/files). See the details in the inlined code comments below ⬇️ 

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
fixes https://github.com/eclipse/che/issues/22686

### How to test this PR?
Actually, the PR changes nothing except cleaning up the part of the root `package.json` that may confuse the developer.
