### PR TITLE
Fix installation of VS Code extensions in airgap cluster

### DIFF
--- a/code/product.json
+++ b/code/product.json
@@ -52,8 +52,8 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.83.1",
-			"sha256": "1452fdbab8d0d83ca5765bb66170d50b005c97ca4dcd13e154c3401d842a92d4",
+			"version": "1.84.0",
+			"sha256": "a57691eb4440e549edba7472c0313e94f24d46ebe1ede18784b552fc5d11e596",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
### What does this PR do?
- updates `ms-vscode.js-debug` version
- fixes installation of VS Code extensions in airgap cluster

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-5346

### How to test this PR?
please see steps to reproduce in the issue
