### PR TITLE
feat: Support running VS Code in ubi9-based containers

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: [ 'musl', 'libc' ]
+        dist: [ 'musl', 'libc-ubi8', 'libc-ubi9' ]
         arch: ['amd64']
     runs-on: ubuntu-22.04
     steps:
@@ -54,10 +54,14 @@ jobs:
           echo "BRANCH_NAME=${BRANCH_NAME##*/}" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Download linux-libc-amd64 image
+      - name: Download linux-libc-ubi8-amd64 image
         uses: ishworkh/docker-image-artifact-download@v1
         with:
-          image: "linux-libc-amd64"
+          image: "linux-libc-ubi8-amd64"
+      - name: Download linux-libc-ubi9-amd64 image
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "linux-libc-ubi9-amd64"
       - name: Download linux-musl image
         uses: ishworkh/docker-image-artifact-download@v1
         with:

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022 Red Hat, Inc.
+# Copyright (c) 2021-2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/pr-check-build-che-code-image.yaml
+++ b/.github/workflows/pr-check-build-che-code-image.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: [ 'musl', 'libc' ]
+        dist: [ 'musl', 'libc-ubi8', 'libc-ubi9' ]
         arch: ['amd64']
     steps:
 

--- a/.github/workflows/pr-check-build-che-code-image.yaml
+++ b/.github/workflows/pr-check-build-che-code-image.yaml
@@ -55,10 +55,15 @@ jobs:
         run: |
           docker system prune -af
 
-      - name: Download linux-libc-amd64 image
+      - name: Download linux-libc-ubi8-amd64 image
         uses: ishworkh/docker-image-artifact-download@v1
         with:
-          image: "linux-libc-amd64"
+          image: "linux-libc-ubi8-amd64"
+      
+      - name: Download linux-libc-ubi9-amd64 image
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "linux-libc-ubi9-amd64"
 
       - name: Download linux-musl-amd64 image
         uses: ishworkh/docker-image-artifact-download@v1

--- a/.github/workflows/pr-check-build-che-code-image.yaml
+++ b/.github/workflows/pr-check-build-che-code-image.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Red Hat, Inc.
+# Copyright (c) 2023-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/rebase-insiders.yml
+++ b/.github/workflows/rebase-insiders.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Red Hat, Inc.
+# Copyright (c) 2021-2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/rebase-insiders.yml
+++ b/.github/workflows/rebase-insiders.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/rebase-insiders.yml
+++ b/.github/workflows/rebase-insiders.yml
@@ -50,12 +50,12 @@ jobs:
             --method PUT \
             -H "Accept: application/vnd.github+json" \
             /repos/che-incubator/che-code/actions/workflows/rebase-insiders.yml/disable
-      - name: Validate tests on libc image
+      - name: Validate tests on libc-ubi9 image
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker buildx build --memory-swap -1 --memory 10g --platform linux/amd64 -f build/dockerfiles/linux-libc.Dockerfile .
+          docker buildx build --memory-swap -1 --memory 10g --platform linux/amd64 -f build/dockerfiles/linux-libc-ubi9.Dockerfile .
       - name: push changes
         run: |
           set -e

--- a/.github/workflows/rebase-release-branch.yml
+++ b/.github/workflows/rebase-release-branch.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Red Hat, Inc.
+# Copyright (c) 2021-2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/rebase-release-branch.yml
+++ b/.github/workflows/rebase-release-branch.yml
@@ -48,12 +48,12 @@ jobs:
       - name: rebase
         run: |
           ./rebase.sh
-      - name: Validate tests on libc image
+      - name: Validate tests on libc-ubi9 image
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker buildx build --memory-swap -1 --memory 10g --platform linux/amd64 -f build/dockerfiles/linux-libc.Dockerfile .
+          docker buildx build --memory-swap -1 --memory 10g --platform linux/amd64 -f build/dockerfiles/linux-libc-ubi9.Dockerfile .
       - name: push changes
         run: |
           set -e

--- a/.github/workflows/rebase-release-branch.yml
+++ b/.github/workflows/rebase-release-branch.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -35,23 +35,23 @@ jobs:
           #
           # truncate Dockerfile, remove section that runs tests
           #
-          cp -f build/dockerfiles/linux-libc-ubi9.Dockerfile build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
+          cp -f build/dockerfiles/linux-libc-ubi8.Dockerfile build/dockerfiles/linux-libc-ubi8.no-test.Dockerfile
           REMOVE_FROM="### Beginning of tests"
           REMOVE_TO="### Ending of tests"
-          sed -i "/${REMOVE_FROM}/,/${REMOVE_TO}/{/${REMOVE_FROM}/n;/${REMOVE_TO}/!d;}" build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
+          sed -i "/${REMOVE_FROM}/,/${REMOVE_TO}/{/${REMOVE_FROM}/n;/${REMOVE_TO}/!d;}" build/dockerfiles/linux-libc-ubi8.no-test.Dockerfile
 
           #
           # show the Dockerfile
           #
-          cat build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
+          cat build/dockerfiles/linux-libc-ubi8.no-test.Dockerfile
 
       - name: Compile Che-Code editor
         run: |
           #
-          # build linux-libc-ubi9-amd64:latest docker image
+          # build linux-libc-ubi8-amd64:latest docker image
           #
           docker image prune -a -f
-          docker build --memory-swap -1 --memory 12g -f build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile -t linux-libc-ubi9-amd64 .
+          docker build --memory-swap -1 --memory 12g -f build/dockerfiles/linux-libc-ubi8.no-test.Dockerfile -t linux-libc-ubi8-amd64 .
 
       - name: Build Che-Code Docker image
         run: |
@@ -62,6 +62,10 @@ jobs:
           REPLACE_FROM="FROM linux-musl-amd64 as linux-musl-content"
           sed -i -r -e "s|${REPLACE_FROM}||" build/dockerfiles/assembly.copy.Dockerfile
           REPLACE_FROM="COPY --from=linux-musl-content --chown=0:0 /checode-linux-musl /mnt/rootfs/checode-linux-musl"
+          sed -i -r -e "s|${REPLACE_FROM}||" build/dockerfiles/assembly.copy.Dockerfile
+          REPLACE_FROM="FROM linux-libc-ubi9-amd64 as linux-libc-ubi9-content"
+          sed -i -r -e "s|${REPLACE_FROM}||" build/dockerfiles/assembly.copy.Dockerfile
+          REPLACE_FROM="COPY --from=linux-libc-ubi9-content --chown=0:0 /checode-linux-libc/ubi9 /mnt/rootfs/checode-linux-libc/ubi9"
           sed -i -r -e "s|${REPLACE_FROM}||" build/dockerfiles/assembly.copy.Dockerfile
           
           export DOCKER_BUILDKIT=1

--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -35,23 +35,23 @@ jobs:
           #
           # truncate Dockerfile, remove section that runs tests
           #
-          cp -f build/dockerfiles/linux-libc.Dockerfile build/dockerfiles/linux-libc.no-test.Dockerfile
+          cp -f build/dockerfiles/linux-libc-ubi9.Dockerfile build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
           REMOVE_FROM="### Beginning of tests"
           REMOVE_TO="### Ending of tests"
-          sed -i "/${REMOVE_FROM}/,/${REMOVE_TO}/{/${REMOVE_FROM}/n;/${REMOVE_TO}/!d;}" build/dockerfiles/linux-libc.no-test.Dockerfile
+          sed -i "/${REMOVE_FROM}/,/${REMOVE_TO}/{/${REMOVE_FROM}/n;/${REMOVE_TO}/!d;}" build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
 
           #
           # show the Dockerfile
           #
-          cat build/dockerfiles/linux-libc.no-test.Dockerfile
+          cat build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
 
       - name: Compile Che-Code editor
         run: |
           #
-          # build linux-libc-amd64:latest docker image
+          # build linux-libc-ubi9-amd64:latest docker image
           #
           docker image prune -a -f
-          docker build --memory-swap -1 --memory 12g -f build/dockerfiles/linux-libc.no-test.Dockerfile -t linux-libc-amd64 .
+          docker build --memory-swap -1 --memory 12g -f build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile -t linux-libc-ubi9-amd64 .
 
       - name: Build Che-Code Docker image
         run: |

--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Red Hat, Inc.
+# Copyright (c) 2023-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Upstream `Code-OSS` is stored using Git [subtree](https://git-scm.com/book/en/v2
 ## Image build
 
 1. `docker build -f build/dockerfiles/linux-musl.Dockerfile -t linux-musl-amd64 .`
-2. `docker build -f build/dockerfiles/linux-libc.Dockerfile -t linux-libc-amd64 .`
-3. `export DOCKER_BUILDKIT=1`
-4. `docker build -f build/dockerfiles/assembly.Dockerfile -t che-code .`
+2. `docker build -f build/dockerfiles/linux-libc-ubi8.Dockerfile -t linux-libc-ubi8-amd64 .`
+3. `docker build -f build/dockerfiles/linux-libc-ubi9.Dockerfile -t linux-libc-ubi9-amd64 .`
+4. `export DOCKER_BUILDKIT=1`
+5. `docker build -f build/dockerfiles/assembly.Dockerfile -t che-code .`
 
 ## Developing with Eclipse Che®
 
@@ -242,7 +243,9 @@ $ ./branding/branding.sh
 ```
 $ docker build -f build/dockerfiles/linux-musl.Dockerfile -t linux-musl-amd64 .
 
-$ docker build -f build/dockerfiles/linux-libc.Dockerfile -t linux-libc-amd64 .
+$ docker build -f build/dockerfiles/linux-libc-ubi8.Dockerfile -t linux-libc-ubi8-amd64 .
+
+$ docker build -f build/dockerfiles/linux-libc-ubi9.Dockerfile -t linux-libc-ubi9-amd64 .
 
 $ export DOCKER_BUILDKIT=1
 

--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -7,7 +7,8 @@
 #
 
 # Grab content from previously build images
-FROM linux-libc-amd64 as linux-libc-content
+FROM linux-libc-ubi8-amd64 as linux-libc-ubi8-content
+FROM linux-libc-ubi9-amd64 as linux-libc-ubi9-content
 FROM linux-musl-amd64 as linux-musl-content
 
 # https://quay.io/eclipse/che-machine-exec#^7\.
@@ -22,7 +23,8 @@ RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/
 WORKDIR /mnt/rootfs
 
 COPY --from=linux-musl-content --chown=0:0 /checode-linux-musl /mnt/rootfs/checode-linux-musl
-COPY --from=linux-libc-content --chown=0:0 /checode-linux-libc /mnt/rootfs/checode-linux-libc
+COPY --from=linux-libc-ubi8-content --chown=0:0 /checode-linux-libc/ubi8 /mnt/rootfs/checode-linux-libc/ubi8
+COPY --from=linux-libc-ubi9-content --chown=0:0 /checode-linux-libc/ubi9 /mnt/rootfs/checode-linux-libc/ubi9
 
 RUN mkdir -p /mnt/rootfs/projects && mkdir -p /mnt/rootfs/home/che && mkdir -p /mnt/rootfs/bin/
 RUN cat /mnt/rootfs/etc/passwd | sed s#root:x.*#root:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g > /mnt/rootfs/home/che/.passwd.template \

--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -1,0 +1,149 @@
+# Copyright (c) 2021-2023 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# https://registry.access.redhat.com/ubi8/nodejs-18
+FROM registry.access.redhat.com/ubi8/nodejs-18:1-86 as linux-libc-ubi8-builder
+
+USER root
+
+# Export GITHUB_TOKEN into environment variable
+ARG GITHUB_TOKEN=''
+ENV GITHUB_TOKEN=$GITHUB_TOKEN
+
+# Unset GITHUB_TOKEN environment variable if it is empty.
+# This is needed for some tools which use this variable and will fail with 401 Unauthorized error if it is invalid.
+# For example, vscode ripgrep downloading is an example of such case.
+RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi
+
+# Install libsecret-devel on s390x and ppc64le for keytar build (binary included in npm package for x86)
+RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
+      https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-0.20.4-2.fc34.s390x.rpm \
+      https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-devel-0.20.4-2.fc34.s390x.rpm"; \
+    elif [[ $(uname -m) == "ppc64le" ]]; then LIBSECRET="\
+      libsecret \
+      https://rpmfind.net/linux/centos/8-stream/BaseOS/ppc64le/os/Packages/libsecret-devel-0.18.6-1.el8.ppc64le.rpm"; \
+    elif [[ $(uname -m) == "x86_64" ]]; then LIBSECRET="\
+      https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/libsecret-devel-0.18.6-1.el8.x86_64.rpm \
+      libsecret"; \
+    elif [[ $(uname -m) == "aarch64" ]]; then LIBSECRET="\
+      https://rpmfind.net/linux/centos/8-stream/BaseOS/aarch64/os/Packages/libsecret-devel-0.18.6-1.el8.aarch64.rpm \
+      libsecret"; \
+    else \
+      LIBSECRET=""; echo "Warning: arch $(uname -m) not supported"; \
+    fi; } \
+    && { if [[ $(uname -m) == "x86_64" ]]; then LIBKEYBOARD="\
+      https://rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/libxkbfile-1.1.0-1.el8.x86_64.rpm \
+      https://rpmfind.net/linux/centos/8-stream/PowerTools/x86_64/os/Packages/libxkbfile-devel-1.1.0-1.el8.x86_64.rpm"; \
+    elif [[ $(uname -m) == "aarch64" ]]; then LIBKEYBOARD="\
+      https://rpmfind.net/linux/centos/8-stream/AppStream/aarch64/os/Packages/libxkbfile-1.1.0-1.el8.aarch64.rpm \
+      https://rpmfind.net/linux/centos/8-stream/PowerTools/aarch64/os/Packages/libxkbfile-devel-1.1.0-1.el8.aarch64.rpm"; \
+    else \
+      LIBKEYBOARD=""; echo "Warning: arch $(uname -m) not supported"; \
+    fi; } \
+    && yum install -y $LIBSECRET $LIBKEYBOARD curl make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbcommon bash tar gzip rsync patch \
+    && yum -y clean all && rm -rf /var/cache/yum \
+    && npm install -g yarn@1.22.17 \
+    && npm install -g node-gyp@9.4.1
+
+#########################################################
+#
+# Copy Che-Code to the container
+#
+#########################################################
+COPY code /checode-compilation
+WORKDIR /checode-compilation
+ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
+# Initialize a git repository for code build tools
+RUN git init .
+
+# change network timeout (slow using multi-arch build)
+RUN yarn config set network-timeout 600000 -g
+
+# Grab dependencies (and force to rebuild them)
+RUN yarn install --force
+
+# Compile
+RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+    && NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"') \
+    # cache node from this image to avoid to grab it from within the build
+    && mkdir -p /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH} \
+    && echo "caching /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node" \
+    && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
+    && NODE_OPTIONS="--max_old_space_size=8500" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
+    && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode
+
+RUN chmod a+x /checode/out/server-main.js \
+    && chgrp -R 0 /checode && chmod -R g+rwX /checode
+
+### Beginning of tests
+# Do not change line above! It is used to cut this section to skip tests
+
+# Compile tests
+RUN ./node_modules/.bin/gulp compile-extension:vscode-api-tests \
+	compile-extension:markdown-language-features \
+	compile-extension:typescript-language-features \
+	compile-extension:emmet \
+	compile-extension:git \
+	compile-extension:ipynb \
+	compile-extension-media \
+  compile-extension:configuration-editing
+
+# Compile test suites
+# https://github.com/microsoft/vscode/blob/cdde5bedbf3ed88f93b5090bb3ed9ef2deb7a1b4/test/integration/browser/README.md#compile
+RUN [[ $(uname -m) == "x86_64" ]] && yarn --cwd test/smoke compile && yarn --cwd test/integration/browser compile
+
+# install test dependencies
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
+RUN [[ $(uname -m) == "x86_64" ]] &&  yarn playwright-install 
+# Install procps to manage to kill processes and centos stream repository
+RUN [[ $(uname -m) == "x86_64" ]] && \
+    ARCH=$(uname -m) && \
+    yum install --nobest -y procps \
+        http://mirror.centos.org/centos/8/extras/${ARCH}/os/Packages/epel-release-8-11.el8.noarch.rpm \
+        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm \
+        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm
+
+RUN [[ $(uname -m) == "x86_64" ]] && yum install -y chromium && \
+    PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) && \
+    rm "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" && \
+    ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"
+
+# use of retry and timeout
+COPY /build/scripts/helper/retry.sh /opt/app-root/src/retry.sh
+RUN chmod u+x /opt/app-root/src/retry.sh
+
+# Run integration tests (Browser)
+RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+    VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
+    /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m ./scripts/test-web-integration.sh --browser chromium
+
+# Run smoke tests (Browser)
+RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+    VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
+    /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
+
+# Do not change line below! It is used to cut this section to skip tests
+### Ending of tests
+
+#########################################################
+#
+# Copy VS Code launcher to the container
+#
+#########################################################
+COPY launcher /checode-launcher
+WORKDIR /checode-launcher
+RUN yarn \
+    && mkdir /checode/launcher \
+    && cp -r out/src/*.js /checode/launcher \
+    && chgrp -R 0 /checode && chmod -R g+rwX /checode
+
+# Store the content of the result
+FROM scratch as linux-libc-content
+COPY --from=linux-libc-ubi8-builder /checode /checode-linux-libc/ubi8

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -81,7 +81,7 @@ RUN { \
     } \
     && { \
         if [ -n "$NODE_ARCH" ]; then \
-            NODE_VERSION=18.18.2; \
+            NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"'); \
             NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz"; \
             echo "Downloading Node.js from ${NODE_URL}"; \
             wget -q "${NODE_URL}"; \
@@ -115,7 +115,7 @@ RUN { \
             NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"'); \
             CACHE_NODE_PATH=/checode-compilation/.build/node/v${NODE_VERSION}/linux-${BUILD_ARCH}; \
             mkdir -p $CACHE_NODE_PATH; \
-            echo "caching ${CACHE_NODE_PATH}" \
+            echo "caching ${CACHE_NODE_PATH}/node"; \
             cp /usr/local/nodejs/bin/node ${CACHE_NODE_PATH}/node; \
             # compile assembly
             NODE_OPTIONS="--max_old_space_size=8500" ./node_modules/.bin/gulp vscode-reh-web-linux-${BUILD_ARCH}-min; \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -81,7 +81,7 @@ RUN { \
     } \
     && { \
         if [ -n "$NODE_ARCH" ]; then \
-            NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"'); \
+            NODE_VERSION=18.18.2; \
             NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz"; \
             echo "Downloading Node.js from ${NODE_URL}"; \
             wget -q "${NODE_URL}"; \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -88,48 +88,48 @@ RUN chmod a+x /checode/out/server-main.js \
 # Do not change line above! It is used to cut this section to skip tests
 
 # Compile tests
-RUN ./node_modules/.bin/gulp compile-extension:vscode-api-tests \
-	compile-extension:markdown-language-features \
-	compile-extension:typescript-language-features \
-	compile-extension:emmet \
-	compile-extension:git \
-	compile-extension:ipynb \
-	compile-extension-media \
-  compile-extension:configuration-editing
+# RUN ./node_modules/.bin/gulp compile-extension:vscode-api-tests \
+# 	compile-extension:markdown-language-features \
+# 	compile-extension:typescript-language-features \
+# 	compile-extension:emmet \
+# 	compile-extension:git \
+# 	compile-extension:ipynb \
+# 	compile-extension-media \
+#   compile-extension:configuration-editing
 
-# Compile test suites
-# https://github.com/microsoft/vscode/blob/cdde5bedbf3ed88f93b5090bb3ed9ef2deb7a1b4/test/integration/browser/README.md#compile
-RUN [[ $(uname -m) == "x86_64" ]] && yarn --cwd test/smoke compile && yarn --cwd test/integration/browser compile
+# # Compile test suites
+# # https://github.com/microsoft/vscode/blob/cdde5bedbf3ed88f93b5090bb3ed9ef2deb7a1b4/test/integration/browser/README.md#compile
+# RUN [[ $(uname -m) == "x86_64" ]] && yarn --cwd test/smoke compile && yarn --cwd test/integration/browser compile
 
-# install test dependencies
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
-RUN [[ $(uname -m) == "x86_64" ]] &&  yarn playwright-install 
-# Install procps to manage to kill processes and centos stream repository
-RUN [[ $(uname -m) == "x86_64" ]] && \
-    ARCH=$(uname -m) && \
-    yum install --nobest -y procps \
-        https://rpmfind.net/linux/epel/9/Everything/${ARCH}/Packages/e/epel-release-9-7.el9.noarch.rpm \
-        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-23.el9.noarch.rpm \
-        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-23.el9.noarch.rpm
+# # install test dependencies
+# ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
+# RUN [[ $(uname -m) == "x86_64" ]] &&  yarn playwright-install 
+# # Install procps to manage to kill processes and centos stream repository
+# RUN [[ $(uname -m) == "x86_64" ]] && \
+#     ARCH=$(uname -m) && \
+#     yum install --nobest -y procps \
+#         https://rpmfind.net/linux/epel/9/Everything/${ARCH}/Packages/e/epel-release-9-7.el9.noarch.rpm \
+#         https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-23.el9.noarch.rpm \
+#         https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-23.el9.noarch.rpm
 
-RUN [[ $(uname -m) == "x86_64" ]] && yum install -y chromium && \
-    PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) && \
-    rm "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" && \
-    ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"
+# RUN [[ $(uname -m) == "x86_64" ]] && yum install -y chromium && \
+#     PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) && \
+#     rm "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" && \
+#     ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"
 
-# use of retry and timeout
-COPY /build/scripts/helper/retry.sh /opt/app-root/src/retry.sh
-RUN chmod u+x /opt/app-root/src/retry.sh
+# # use of retry and timeout
+# COPY /build/scripts/helper/retry.sh /opt/app-root/src/retry.sh
+# RUN chmod u+x /opt/app-root/src/retry.sh
 
-# Run integration tests (Browser)
-RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
-    VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
-    /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m ./scripts/test-web-integration.sh --browser chromium
+# # Run integration tests (Browser)
+# RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+#     VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
+#     /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m ./scripts/test-web-integration.sh --browser chromium
 
-# Run smoke tests (Browser)
-RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
-    VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
-    /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
+# # Run smoke tests (Browser)
+# RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+#     VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
+#     /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
 
 # Do not change line below! It is used to cut this section to skip tests
 ### Ending of tests

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -81,12 +81,12 @@ RUN { \
     } \
     && { \
         if [ -n "$NODE_ARCH" ]; then \
-            NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"'); \
-            NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz"; \
-            echo "Downloading Node.js from ${NODE_URL}"; \
-            wget -q "${NODE_URL}"; \
-            tar -xf node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz; \
-            mv node-v${NODE_VERSION}-linux-${NODE_ARCH} /usr/local/nodejs; \
+            NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"') \
+            && NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz" \
+            && echo "Downloading Node.js from ${NODE_URL}" \
+            && wget -q "${NODE_URL}" \
+            && tar -xf node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz \
+            && mv node-v${NODE_VERSION}-linux-${NODE_ARCH} /usr/local/nodejs; \
         else echo "Warning: arch $(uname -m) not supported"; \
         fi; \
        }
@@ -112,14 +112,15 @@ RUN { \
     } \
     && { \
         if [ -n "$BUILD_ARCH" ]; then \
-            NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"'); \
-            CACHE_NODE_PATH=/checode-compilation/.build/node/v${NODE_VERSION}/linux-${BUILD_ARCH}; \
-            mkdir -p $CACHE_NODE_PATH; \
-            echo "caching ${CACHE_NODE_PATH}/node"; \
-            cp /usr/local/nodejs/bin/node ${CACHE_NODE_PATH}/node; \
+            # cache node to avoid to grab it within the build
+            NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"') \
+            && CACHE_NODE_PATH=/checode-compilation/.build/node/v${NODE_VERSION}/linux-${BUILD_ARCH} \
+            && mkdir -p $CACHE_NODE_PATH \
+            && echo "caching ${CACHE_NODE_PATH}/node" \
+            && cp /usr/local/nodejs/bin/node ${CACHE_NODE_PATH}/node \
             # compile assembly
-            NODE_OPTIONS="--max_old_space_size=8500" ./node_modules/.bin/gulp vscode-reh-web-linux-${BUILD_ARCH}-min; \
-            cp -r ../vscode-reh-web-linux-${BUILD_ARCH} /checode; \        
+            && NODE_OPTIONS="--max_old_space_size=8500" ./node_modules/.bin/gulp vscode-reh-web-linux-${BUILD_ARCH}-min \
+            && cp -r ../vscode-reh-web-linux-${BUILD_ARCH} /checode; \        
         else echo "Warning: arch $(uname -m) not supported"; \
         fi; \
     }

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Red Hat, Inc.
+# Copyright (c) 2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Red Hat, Inc.
+# Copyright (c) 2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -6,8 +6,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-# https://registry.access.redhat.com/ubi8/nodejs-18
-FROM registry.access.redhat.com/ubi8/nodejs-18:1-86 as linux-libc-builder
+# https://registry.access.redhat.com/ubi9/nodejs-18
+FROM registry.access.redhat.com/ubi9/nodejs-18:1-80 as linux-libc-ubi9-builder
 
 USER root
 
@@ -23,15 +23,15 @@ RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi
 # Install libsecret-devel on s390x and ppc64le for keytar build (binary included in npm package for x86)
 RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
       https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-0.20.4-2.fc34.s390x.rpm \
-      https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-devel-0.20.4-2.fc34.s390x.rpm"; \
+      https://rpmfind.net/linux/centos-stream/9-stream/AppStream/s390x/os/Packages/libsecret-devel-0.20.4-4.el9.s390x.rpm"; \
     elif [[ $(uname -m) == "ppc64le" ]]; then LIBSECRET="\
       libsecret \
-      https://rpmfind.net/linux/centos/8-stream/BaseOS/ppc64le/os/Packages/libsecret-devel-0.18.6-1.el8.ppc64le.rpm"; \
+      https://rpmfind.net/linux/centos-stream/9-stream/AppStream/ppc64le/os/Packages/libsecret-devel-0.20.4-4.el9.ppc64le.rpm"; \
     elif [[ $(uname -m) == "x86_64" ]]; then LIBSECRET="\
-      https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/libsecret-devel-0.18.6-1.el8.x86_64.rpm \
+      https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages/libsecret-devel-0.20.4-4.el9.x86_64.rpm \
       libsecret"; \
     elif [[ $(uname -m) == "aarch64" ]]; then LIBSECRET="\
-      https://rpmfind.net/linux/centos/8-stream/BaseOS/aarch64/os/Packages/libsecret-devel-0.18.6-1.el8.aarch64.rpm \
+      https://rpmfind.net/linux/centos-stream/9-stream/AppStream/aarch64/os/Packages/libsecret-devel-0.20.4-4.el9.aarch64.rpm \
       libsecret"; \
     else \
       LIBSECRET=""; echo "Warning: arch $(uname -m) not supported"; \
@@ -45,7 +45,7 @@ RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
     else \
       LIBKEYBOARD=""; echo "Warning: arch $(uname -m) not supported"; \
     fi; } \
-    && yum install -y $LIBSECRET $LIBKEYBOARD curl make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbcommon bash tar gzip rsync patch \
+    && yum install -y $LIBSECRET $LIBKEYBOARD make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbcommon krb5-devel bash tar gzip rsync patch npm \
     && yum -y clean all && rm -rf /var/cache/yum \
     && npm install -g yarn@1.22.17 \
     && npm install -g node-gyp@9.4.1
@@ -106,9 +106,9 @@ RUN [[ $(uname -m) == "x86_64" ]] &&  yarn playwright-install
 RUN [[ $(uname -m) == "x86_64" ]] && \
     ARCH=$(uname -m) && \
     yum install --nobest -y procps \
-        http://mirror.centos.org/centos/8/extras/${ARCH}/os/Packages/epel-release-8-11.el8.noarch.rpm \
-        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm \
-        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm
+        https://rpmfind.net/linux/epel/9/Everything/${ARCH}/Packages/e/epel-release-9-7.el9.noarch.rpm \
+        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-23.el9.noarch.rpm \
+        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-23.el9.noarch.rpm
 
 RUN [[ $(uname -m) == "x86_64" ]] && yum install -y chromium && \
     PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) && \
@@ -146,4 +146,4 @@ RUN yarn \
 
 # Store the content of the result
 FROM scratch as linux-libc-content
-COPY --from=linux-libc-builder /checode /checode-linux-libc
+COPY --from=linux-libc-ubi9-builder /checode /checode-linux-libc/ubi9

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -156,7 +156,7 @@ RUN [[ $(uname -m) == "x86_64" ]] && \
         https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-23.el9.noarch.rpm
 
 RUN [[ $(uname -m) == "x86_64" ]] && yum install -y chromium && \
-    PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) && \
+    PLAYWRIGHT_CHROMIUM_PATH=$(echo /root/.cache/ms-playwright/chromium-*) && \
     rm "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" && \
     ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"
 

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -6,8 +6,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-# https://registry.access.redhat.com/ubi9/nodejs-18
-FROM registry.access.redhat.com/ubi9/nodejs-18:1-80 as linux-libc-ubi9-builder
+# TODO - provide the corresponding reference
+FROM registry.access.redhat.com/ubi9:9.3 as linux-libc-ubi9-builder
 
 USER root
 
@@ -45,7 +45,9 @@ RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
     else \
       LIBKEYBOARD=""; echo "Warning: arch $(uname -m) not supported"; \
     fi; } \
-    && yum install -y $LIBSECRET $LIBKEYBOARD make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbcommon krb5-devel bash tar gzip rsync patch npm \
+    && yum install -y $LIBSECRET $LIBKEYBOARD make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbcommon krb5-devel bash tar gzip rsync patch \
+    && curl -sL https://rpm.nodesource.com/setup_18.x | bash - \
+    && yum install -y nodejs \
     && yum -y clean all && rm -rf /var/cache/yum \
     && npm install -g yarn@1.22.17 \
     && npm install -g node-gyp@9.4.1

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -31,9 +31,19 @@ nohup /checode/bin/machine-exec --url "0.0.0.0:${MACHINE_EXEC_PORT}" &
 # detect if we're using alpine/musl
 libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
 if [ -n "$libc" ]; then
-    cd /checode/checode-linux-musl || exit
+  cd /checode/checode-linux-musl || exit
 else
-    cd /checode/checode-linux-libc || exit
+  openssl_major_version=$(openssl version -v | cut -d' ' -f2 | cut -d'.' -f1)
+  echo "OpenSSL major version is $openssl_major_version."
+
+  if [ "$openssl_major_version" = "1" ]; then
+    cd /checode/checode-linux-libc/ubi8 || exit
+  elif [ "$openssl_major_version" = "3" ]; then
+    cd /checode/checode-linux-libc/ubi9 || exit
+  else
+    echo "Error: Unsupported OpenSSL major version $openssl_major_version."
+    exit 1
+  fi
 fi
 
 # Set the default path to the serverDataFolderName

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -31,18 +31,31 @@ nohup /checode/bin/machine-exec --url "0.0.0.0:${MACHINE_EXEC_PORT}" &
 # detect if we're using alpine/musl
 libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
 if [ -n "$libc" ]; then
+  echo "Using linux-musl assembly..."
   cd /checode/checode-linux-musl || exit
 else
-  openssl_major_version=$(openssl version -v | cut -d' ' -f2 | cut -d'.' -f1)
+  
+  # detect openssl version
+  openssl_major_version=""
+  if command -v openssl &> /dev/null; then
+    echo "OpenSSL command is available, the version is: $(openssl version -v)"  
+    openssl_major_version=$(openssl version -v | cut -d' ' -f2 | cut -d'.' -f1)
+  else 
+    echo "OpenSSL command is not available, trying to detect OpenSSL version..."
+    openssl_major_version=$(rpm -qa | grep openssl-libs | cut -d'-' -f3 | cut -d'.' -f1)
+  fi
+  
+  # ubi8- or ubi9-based assembly is used depending on the openssl version
   echo "OpenSSL major version is $openssl_major_version."
-
   if [ "$openssl_major_version" = "1" ]; then
+    echo "Using linux-libc ubi8-based assembly..."
     cd /checode/checode-linux-libc/ubi8 || exit
   elif [ "$openssl_major_version" = "3" ]; then
+    echo "Using linux-libc ubi9-based assembly..."
     cd /checode/checode-linux-libc/ubi9 || exit
   else
-    echo "Error: Unsupported OpenSSL major version $openssl_major_version."
-    exit 1
+    echo "WARNING: Unsupported OpenSSL major version $openssl_major_version, linux-libc ubi8-based assembly will be used by default..."
+    cd /checode/checode-linux-libc/ubi8 || exit
   fi
 fi
 

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2021 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -37,5 +37,6 @@ libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
 if [ -n "$libc" ]; then
     /checode-linux-musl/node /checode-linux-musl/out/server-main.js --host "${CODE_HOST}" --port 3100
 else
+    # TODO: some changes are required here
     /checode-linux-libc/node /checode-linux-libc/out/server-main.js --host "${CODE_HOST}" --port 3100
 fi

--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -37,6 +37,5 @@ libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
 if [ -n "$libc" ]; then
     /checode-linux-musl/node /checode-linux-musl/out/server-main.js --host "${CODE_HOST}" --port 3100
 else
-    # TODO: some changes are required here
-    /checode-linux-libc/node /checode-linux-libc/out/server-main.js --host "${CODE_HOST}" --port 3100
+    /checode-linux-libc/ubi8/node /checode-linux-libc/ubi8/out/server-main.js --host "${CODE_HOST}" --port 3100
 fi

--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2021 Red Hat, Inc.
+# Copyright (c) 2021-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -65,16 +65,16 @@ commands:
 
   - id: podman-compile-libc
     exec:
-      label: Compile che-code in a container using Podman
+      label: Compile che-code in a ubi8-based container using Podman
       component: dev
       workingDir: ${PROJECTS_ROOT}/che-code
       commandLine: |
-        echo "Compile libc mod"
-        cp -f build/dockerfiles/linux-libc.Dockerfile build/dockerfiles/linux-libc.no-test.Dockerfile
+        echo "Compile libc-ubi8 mod"
+        cp -f build/dockerfiles/linux-libc-ubi8.Dockerfile build/dockerfiles/linux-libc-ubi8.no-test.Dockerfile
         REMOVE_FROM="### Beginning of tests"
         REMOVE_TO="### Ending of tests"
-        sed -i "/${REMOVE_FROM}/,/${REMOVE_TO}/d" build/dockerfiles/linux-libc.no-test.Dockerfile
-        podman build -f build/dockerfiles/linux-libc.no-test.Dockerfile -t linux-libc-amd64 .
+        sed -i "/${REMOVE_FROM}/,/${REMOVE_TO}/d" build/dockerfiles/linux-libc-ubi8.no-test.Dockerfile
+        podman build -f build/dockerfiles/linux-libc-ubi8.no-test.Dockerfile -t linux-libc-ubi8-amd64 .
       group:
         kind: run
 
@@ -86,6 +86,10 @@ commands:
       commandLine: |
         echo "Build che-code image"
         cp -f build/dockerfiles/assembly.Dockerfile build/dockerfiles/assembly.libc.Dockerfile
+        REPLACE="FROM linux-libc-ubi9-amd64 as linux-libc-ubi9-content"
+        sed -i -r -e "s|${REPLACE}||" build/dockerfiles/assembly.libc.Dockerfile
+        REPLACE="COPY --from=linux-libc-ubi9-content --chown=0:0 /checode-linux-libc/ubi9 /mnt/rootfs/checode-linux-libc/ubi9"
+        sed -i -r -e "s|${REPLACE}||" build/dockerfiles/assembly.libc.Dockerfile
         REPLACE="FROM linux-musl-amd64 as linux-musl-content"
         sed -i -r -e "s|${REPLACE}||" build/dockerfiles/assembly.libc.Dockerfile
         REPLACE="COPY --from=linux-musl-content --chown=0:0 /checode-linux-musl /mnt/rootfs/checode-linux-musl"

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Red Hat, Inc.
+# Copyright (c) 2022-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
Some adaptation is required for the downstream, so **please do NOT merge the current PR** - I'm going to provide the corresponding changes to the downstream while the current PR is under review.

### What does this PR do?
The current solution works for `ubi8` and `ubi9`-based containers, see `How to test this PR` section.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21778

### How to test this PR?
I tested it for the following images:

| Image  | Workspace starts | Link to start a workspace |
| :-------------: | :-------------: | :-------------: |
| `quay.io/devfile/universal-developer-image:ubi8-latest`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/udi-ubi8-latest-custom-editor)  |
| `registry.access.redhat.com/ubi8`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi8-custom-editor)  |
| `registry.access.redhat.com/ubi8/ubi:8.8-1032.1692772289`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi8-ubi-custom-editor)  |
| `registry.access.redhat.com/ubi8/openjdk-11:latest`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi8-openjdk-11-custom-editor)  |
| `registry.access.redhat.com/ubi8/nodejs-16:1-139`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi8-node16-custom-editor)  |
| `registry.access.redhat.com/ubi8/nodejs-18:1-32`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi8-node18-custom-editor)  |
| `registry.access.redhat.com/ubi9`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi9-custom-editor)  |
| `registry.access.redhat.com/ubi9/ubi:9.3-1476`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi9-ubi-custom-editor)  |
| `registry.access.redhat.com/ubi9/nodejs-18:1-84`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi9-nodejs-custom-editor)  |
| `registry.access.redhat.com/ubi9/python-39:1-161`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi9-python-custom-editor)  |
| `registry.access.redhat.com/ubi9/go-toolset:1.19.13-4.1697647145`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi9-go-custom-editor)  |
| `registry.access.redhat.com/ubi9/openjdk-17:1.17-1`  | +  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubi9-openjdk-17-custom-editor)  |


