### PR TITLE
Fix handling of paths in generating extension callback URLs

### DIFF
--- a/.rebase/replace/code/src/vs/code/browser/workbench/workbench.ts.json
+++ b/.rebase/replace/code/src/vs/code/browser/workbench/workbench.ts.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "return URI.parse(mainWindow.location.href).with({ path: this._callbackRoute, query: queryParams.join('&') });",
+    "by": "const windowURI = URI.parse(mainWindow.location.href);\\\n\\\t\\\tconst fullPath = windowURI.path.replace(/\\\\/$/, '') + this._callbackRoute;\\\n\\\t\\\treturn windowURI.with({ path: fullPath, query: queryParams.join('\\&') });"
+  }
+]

--- a/code/src/vs/code/browser/workbench/workbench.ts
+++ b/code/src/vs/code/browser/workbench/workbench.ts
@@ -305,7 +305,9 @@ class LocalStorageURLCallbackProvider extends Disposable implements IURLCallback
 			this.startListening();
 		}
 
-		return URI.parse(mainWindow.location.href).with({ path: this._callbackRoute, query: queryParams.join('&') });
+		const windowURI = URI.parse(mainWindow.location.href);
+		const fullPath = windowURI.path.replace(/\/$/, '') + this._callbackRoute;
+		return windowURI.with({ path: fullPath, query: queryParams.join('&') });
 	}
 
 	private startListening(): void {

--- a/rebase.sh
+++ b/rebase.sh
@@ -300,6 +300,20 @@ apply_code_vs_workbench_contrib_webview_browser_pre_index_no_csp_html_changes() 
   git add code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html > /dev/null 2>&1
 }
 
+# Apply changes on code/src/vs/code/browser/workbench/workbench.ts file
+apply_code_src_vs_code_browser_workbench_workbench_changes() {
+
+  echo "  ⚙️ reworking code/src/vs/code/browser/workbench/workbench.ts..."
+  # reset the file from what is upstream
+  git checkout --theirs code/src/vs/code/browser/workbench/workbench.ts > /dev/null 2>&1
+  
+  # now apply again the changes
+  apply_replace code/src/vs/code/browser/workbench/workbench.ts
+  
+  # resolve the change
+  git add code/src/vs/code/browser/workbench/workbench.ts > /dev/null 2>&1
+}
+
 # Apply changes for the given file
 apply_changes() {
   local filePath="$1"
@@ -355,6 +369,8 @@ resolve_conflicts() {
       apply_code_vs_workbench_contrib_webview_browser_pre_index_html_changes
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html" ]]; then
       apply_code_vs_workbench_contrib_webview_browser_pre_index_no_csp_html_changes
+    elif [[ "$conflictingFile" == "code/src/vs/code/browser/workbench/workbench.ts" ]]; then
+      apply_code_src_vs_code_browser_workbench_workbench_changes
     elif [[ "$conflictingFile" == "code/src/vs/base/common/product.ts" ]]; then
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts" ]]; then


### PR DESCRIPTION
### What does this PR do?
Code assumes the browser workbench is being served on a URL at path `/`. As a result, when generating extension callback URLs, it
1. Takes the current URL
2. Changes the path to `/oss-dev/callback?<params>` (the path components here are configurable, but it's not relevant right now)

Since we serve Code through the gateway -- one URL with different workspaces distinguished by path components -- this causes extension callback URLs to lead to 404s, since they're 
```
https://<che-gateway>/oss-dev/callback
```

To fix this, we need to change the workbench to use the existing path when generating callback URLs. 

### What issues does this PR fix?
Resolves https://issues.redhat.com/browse/CRW-5334
See also: https://github.com/ansible/vscode-ansible/issues/938

### How to test this PR?
@TamiTakamiya provided a sample extension to verify this functionality: https://github.com/TamiTakamiya/external-uri-sample

Installing the vsix from this repository adds the "External URI sample" action to Code, which generates a toast notification for the callback URL Code has generated. Prior to this change, this is e.g.
```yaml
URI: checode://tamitakamiya.external-uri-sample 
External URI: https://<cluster>.openshiftapps.com/oss-dev/callback?vscode-reqid%3D2%26vscode-scheme%3Dchecode%26vscode-authority%3DTamiTakamiya.external-uri-sample
```
(this URL leads to a 404 on the gateway)

With this change, the external URI is now
```yaml
URI: checode://tamitakamiya.external-uri-sample 
External URI: https://<cluster>.openshiftapps.com/<namespace>/che-code/3100/oss-dev/callback?vscode-reqid%3D1%26vscode-scheme%3Dchecode%26vscode-authority%3DTamiTakamiya.external-uri-sample
```
(note the addition of `/<namespace>/che-code/3100/` to the path -- this URL leads to a page saying "you can close this window now").

Changes for this PR are pushed to `quay.io/amisevsk/che-code:callback-url`. To patch an existing workspace to use these changes, execute:
```bash
oc get dwt che-code-$DEVWORKSPACE_NAME -o yaml \
  | sed 's|quay.io/che-incubator/che-code.*|quay.io/amisevsk/che-code:callback-url|' \
  | oc apply -f -
```