### PR TITLE
fix: add delay before auto installing the recommendations

### DIFF
--- a/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
@@ -113,7 +113,16 @@ export class ExtensionRecommendationsService extends Disposable implements IExte
 			this.remoteRecommendations.activate()
 		]);
 
-		this._register(Event.any(this.workspaceRecommendations.onDidChangeRecommendations, this.configBasedRecommendations.onDidChangeRecommendations, this.extensionRecommendationsManagementService.onDidChangeIgnoredRecommendations)(() => this._onDidChangeRecommendations.fire()));
+		// this._register(Event.any(
+		// 	this.workspaceRecommendations.onDidChangeRecommendations, 
+		// 	this.configBasedRecommendations.onDidChangeRecommendations, 
+		// 	this.extensionRecommendationsManagementService.onDidChangeIgnoredRecommendations)(() => this._onDidChangeRecommendations.fire()));
+
+		this._register(Event.any(
+			this.workspaceRecommendations.onDidChangeRecommendations, 
+			this.configBasedRecommendations.onDidChangeRecommendations, 
+			this.extensionRecommendationsManagementService.onDidChangeIgnoredRecommendations)(() => this.handleChangeRecommendations()));
+	
 		this._register(this.extensionRecommendationsManagementService.onDidChangeGlobalIgnoredRecommendation(({ extensionId, isRecommended }) => {
 			if (!isRecommended) {
 				const reason = this.getAllRecommendationsWithReason()[extensionId];
@@ -123,7 +132,22 @@ export class ExtensionRecommendationsService extends Disposable implements IExte
 			}
 		}));
 
+		console.log('>> ExtensionRecommendationsService :: sleeping...');
+		await this.sleep(3000);
+		console.log('>> ExtensionRecommendationsService :: process');
+
 		this.promptWorkspaceRecommendations();
+	}
+
+	private async handleChangeRecommendations(): Promise<void> {
+		console.log('>> ExtensionRecommendationsService :: handleChangeRecommendations');
+		this._onDidChangeRecommendations.fire();
+	}
+
+	private async sleep(milliseconds: number): Promise<void> {
+		return new Promise(resolve => {
+			setTimeout(resolve, milliseconds);
+		});
 	}
 
 	private isEnabled(): boolean {

--- a/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
@@ -113,16 +113,11 @@ export class ExtensionRecommendationsService extends Disposable implements IExte
 			this.remoteRecommendations.activate()
 		]);
 
-		// this._register(Event.any(
-		// 	this.workspaceRecommendations.onDidChangeRecommendations, 
-		// 	this.configBasedRecommendations.onDidChangeRecommendations, 
-		// 	this.extensionRecommendationsManagementService.onDidChangeIgnoredRecommendations)(() => this._onDidChangeRecommendations.fire()));
-
 		this._register(Event.any(
 			this.workspaceRecommendations.onDidChangeRecommendations, 
 			this.configBasedRecommendations.onDidChangeRecommendations, 
-			this.extensionRecommendationsManagementService.onDidChangeIgnoredRecommendations)(() => this.handleChangeRecommendations()));
-	
+			this.extensionRecommendationsManagementService.onDidChangeIgnoredRecommendations)(() => this._onDidChangeRecommendations.fire()));
+
 		this._register(this.extensionRecommendationsManagementService.onDidChangeGlobalIgnoredRecommendation(({ extensionId, isRecommended }) => {
 			if (!isRecommended) {
 				const reason = this.getAllRecommendationsWithReason()[extensionId];
@@ -133,21 +128,10 @@ export class ExtensionRecommendationsService extends Disposable implements IExte
 		}));
 
 		console.log('>> ExtensionRecommendationsService :: sleeping...');
-		await this.sleep(3000);
+		await new Promise(resolve => setTimeout(resolve, 3000));
 		console.log('>> ExtensionRecommendationsService :: process');
 
 		this.promptWorkspaceRecommendations();
-	}
-
-	private async handleChangeRecommendations(): Promise<void> {
-		console.log('>> ExtensionRecommendationsService :: handleChangeRecommendations');
-		this._onDidChangeRecommendations.fire();
-	}
-
-	private async sleep(milliseconds: number): Promise<void> {
-		return new Promise(resolve => {
-			setTimeout(resolve, milliseconds);
-		});
 	}
 
 	private isEnabled(): boolean {

--- a/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
@@ -127,10 +127,7 @@ export class ExtensionRecommendationsService extends Disposable implements IExte
 			}
 		}));
 
-		console.log('>> ExtensionRecommendationsService :: sleeping...');
 		await new Promise(resolve => setTimeout(resolve, 3000));
-		console.log('>> ExtensionRecommendationsService :: process');
-
 		this.promptWorkspaceRecommendations();
 	}
 

--- a/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
@@ -113,11 +113,7 @@ export class ExtensionRecommendationsService extends Disposable implements IExte
 			this.remoteRecommendations.activate()
 		]);
 
-		this._register(Event.any(
-			this.workspaceRecommendations.onDidChangeRecommendations, 
-			this.configBasedRecommendations.onDidChangeRecommendations, 
-			this.extensionRecommendationsManagementService.onDidChangeIgnoredRecommendations)(() => this._onDidChangeRecommendations.fire()));
-
+		this._register(Event.any(this.workspaceRecommendations.onDidChangeRecommendations, this.configBasedRecommendations.onDidChangeRecommendations, this.extensionRecommendationsManagementService.onDidChangeIgnoredRecommendations)(() => this._onDidChangeRecommendations.fire()));
 		this._register(this.extensionRecommendationsManagementService.onDidChangeGlobalIgnoredRecommendation(({ extensionId, isRecommended }) => {
 			if (!isRecommended) {
 				const reason = this.getAllRecommendationsWithReason()[extensionId];


### PR DESCRIPTION
### What does this PR do?
Adds delay in a few seconds before checking the list of recommended extensions.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
It will potentially fix the bug https://issues.redhat.com/browse/CRW-4576

### How to test this PR?
- create a workspace with https://github.com/vitaliy-guliy/recommended-extensions-sample/tree/test-install-recommendations
- ensure all the recommended extensions are installed
