### PR TITLE
feat: add devfile walkthrough extension to built-ins

### DIFF
--- a/code/product.json
+++ b/code/product.json
@@ -83,7 +83,7 @@
 		},
 		{
 			"name": "devfile.vscode-devfile",
-			"version": "latest",
+			"version": "0.0.2",
 			"repo": "https://github.com/devfile/vscode-walkthrough-extension"
 		}
 	],

--- a/code/product.json
+++ b/code/product.json
@@ -83,7 +83,7 @@
 		},
 		{
 			"name": "devfile.vscode-devfile",
-			"version": "0.0.2",
+			"version": "latest",
 			"repo": "https://github.com/devfile/vscode-walkthrough-extension"
 		}
 	],

--- a/code/product.json
+++ b/code/product.json
@@ -83,6 +83,7 @@
 		},
 		{
 			"name": "devfile.vscode-devfile",
+			"version": "0.0.2",
 			"repo": "https://github.com/devfile/vscode-walkthrough-extension"
 		}
 	],

--- a/code/product.json
+++ b/code/product.json
@@ -80,6 +80,10 @@
 				},
 				"publisherDisplayName": "Microsoft"
 			}
+		},
+		{
+			"name": "devfile.vscode-devfile",
+			"repo": "https://github.com/devfile/vscode-walkthrough-extension"
 		}
 	],
 	"extensionEnabledApiProposals": {


### PR DESCRIPTION
### What does this PR do?
Adds vscode devfile extension to built-ins.

![Screenshot from 2024-02-01 12-46-15](https://github.com/che-incubator/che-code/assets/1655894/3b438b85-e1ef-4f7b-9846-e799602827b5)

![Screenshot from 2024-02-01 12-46-34](https://github.com/che-incubator/che-code/assets/1655894/401ecd75-2932-41b1-919a-c0da5674757d)

![Screenshot from 2024-02-01 12-47-06](https://github.com/che-incubator/che-code/assets/1655894/f1fd0bd0-af43-43ab-a0b3-860d1c9d78cc)

! Please note my comment in PR https://github.com/devfile/vscode-walkthrough-extension/pull/3#issuecomment-1919056818

There is a regression in VS Code.
I will provide a small test extension and file the issue to the VS Code.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse/che/issues/21606

### How to test this PR?
- create a workspace with https://github.com/vitaliy-guliy/recommended-extensions-sample/tree/test-pr-326
- open Welcome, go to `Get Started with the Devfile`
