### PR TITLE
fix: set `/project` as default pah for the terminal

### DIFF
--- a/build/remote-config/settings.json
+++ b/build/remote-config/settings.json
@@ -1,5 +1,6 @@
 {
   // Note: settings in this file will override user-level settings in the workspace.
   //       Any setting that may be changed by the user should not be set here.
-  "git.defaultCloneDirectory": "/projects/"
+  "git.defaultCloneDirectory": "/projects/",
+  "terminal.integrated.cwd": "/projects/"
 }


### PR DESCRIPTION
### What does this PR do?


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?
[![Contribute](https://img.shields.io/static/v1?label=Eclipse%20Che%20(nightly)&message=Dev%20cluster%20(for%20maintainers)&logo=eclipseche&color=525C86&labelColor=FDB940)](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com#https://gist.githubusercontent.com/vitaliy-guliy/ba70794781df730cfd603e8d531cbc42/raw/34594b409d439edd07627b23c570dd9d64bade89/devfile.yaml?che-editor=https://gist.githubusercontent.com/vitaliy-guliy/01d20eb963307c684a2b11089bebd251/raw/89440d6d8a075520150da2fe238f4a5cfd4164f0/devfile.yaml)
