### PR TITLE
fix: projects are ignored when restarting workspace from local devfile

### DIFF
--- a/code/extensions/che-api/src/impl/k8s-devfile-service-impl.ts
+++ b/code/extensions/che-api/src/impl/k8s-devfile-service-impl.ts
@@ -71,8 +71,6 @@ export class K8sDevfileServiceImpl implements DevfileService {
 
 
   async updateDevfile(devfile: V1alpha2DevWorkspaceSpecTemplate): Promise<void> {
-    console.log('>>> update devfile...');
-
     // Grab custom resource object
     const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
     const group = 'workspace.devfile.io';
@@ -90,25 +88,17 @@ export class K8sDevfileServiceImpl implements DevfileService {
         'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH,
       },
     };
-
-    try {
-      await customObjectsApi.patchNamespacedCustomObject(
-        group,
-        version,
-        this.env.getWorkspaceNamespace(),
-        'devworkspaces',
-        this.env.getWorkspaceName(),
-        patch,
-        undefined,
-        undefined,
-        undefined,
-        options
-      );
-
-    } catch (err) {
-      console.log('ERROR', err);
-      throw err;
-    }
-
+    await customObjectsApi.patchNamespacedCustomObject(
+      group,
+      version,
+      this.env.getWorkspaceNamespace(),
+      'devworkspaces',
+      this.env.getWorkspaceName(),
+      patch,
+      undefined,
+      undefined,
+      undefined,
+      options
+    );
   }
 }

--- a/code/extensions/che-api/src/impl/k8s-devfile-service-impl.ts
+++ b/code/extensions/che-api/src/impl/k8s-devfile-service-impl.ts
@@ -71,6 +71,8 @@ export class K8sDevfileServiceImpl implements DevfileService {
 
 
   async updateDevfile(devfile: V1alpha2DevWorkspaceSpecTemplate): Promise<void> {
+    console.log('>>> update devfile...');
+
     // Grab custom resource object
     const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
     const group = 'workspace.devfile.io';
@@ -88,17 +90,25 @@ export class K8sDevfileServiceImpl implements DevfileService {
         'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH,
       },
     };
-    await customObjectsApi.patchNamespacedCustomObject(
-      group,
-      version,
-      this.env.getWorkspaceNamespace(),
-      'devworkspaces',
-      this.env.getWorkspaceName(),
-      patch,
-      undefined,
-      undefined,
-      undefined,
-      options
-    );
+
+    try {
+      await customObjectsApi.patchNamespacedCustomObject(
+        group,
+        version,
+        this.env.getWorkspaceNamespace(),
+        'devworkspaces',
+        this.env.getWorkspaceName(),
+        patch,
+        undefined,
+        undefined,
+        undefined,
+        options
+      );
+
+    } catch (err) {
+      console.log('ERROR', err);
+      throw err;
+    }
+
   }
 }

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -84,12 +84,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           return;
         }
 
-        try {
-          await vscode.commands.executeCommand('che-remote.command.restartWorkspace');
-        } catch (error) {
-          console.error(`Failed to restart the workspace: ${error}`);
-          vscode.window.showErrorMessage(`Failed to restart the workpace: ${error}`);
-        }
+        // try {
+        //   await vscode.commands.executeCommand('che-remote.command.restartWorkspace');
+        // } catch (error) {
+        //   console.error(`Failed to restart the workspace: ${error}`);
+        //   vscode.window.showErrorMessage(`Failed to restart the workpace: ${error}`);
+        // }
       })
     );
   }
@@ -150,6 +150,7 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
     getRaw(): Promise<string>;
     updateDevfile(devfile: any): Promise<void>;
   } = cheApi.getDevfileService();
+
   const devWorkspaceGenerator = new DevWorkspaceGenerator();
 
   const devfilePath = await selectDevfile();
@@ -160,9 +161,38 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
   
   console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
-  const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axiosInstance);
+  // const newContent = await devWorkspaceGenerator.generateDevfileContext(
+  //   {
+  //     devfilePath,
+  //     editorContent: EDITOR_CONTENT_STUB,
+  //     pluginRegistryUrl, projects: []
+  //   },
+  //   axiosInstance);
+
+  const devfileContent = await fs.readFile(devfilePath, 'utf8');
+  console.log('------------------------------------------------------------------');
+  console.log(devfileContent);
+  console.log('------------------------------------------------------------------');
+
+  const newContent = await devWorkspaceGenerator.generateDevfileContext(
+    {
+      devfileContent,
+      editorContent: EDITOR_CONTENT_STUB,
+      pluginRegistryUrl, projects: []
+    },
+    axiosInstance);
+
   if (newContent) {
-    await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);
+    console.log('> a devfile has been generated successfully');
+    console.log('==================================================================');
+    console.log(newContent);
+    console.log('==================================================================');
+      
+    let a = 2;
+    if (a === 3) {
+      await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);
+    }
+
     return true;
   } else {
     throw new Error('An error occurred while generating new devfile context');

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -112,8 +112,6 @@ async function isFile(filePath: string): Promise<boolean> {
   return false;
 }
 
-const SELECT_DEVFILE = '/projects/*';
-
 async function selectDevfile(): Promise<string | undefined> {
   const devfileItems: vscode.QuickPickItem[] = [];
 
@@ -137,7 +135,7 @@ async function selectDevfile(): Promise<string | undefined> {
   });
 
   devfileItems.push({
-    label: SELECT_DEVFILE,
+    label: `${process.env.PROJECTS_ROOT!}/*`,
     detail: 'Select a Devfile with a different name'
   });
 
@@ -161,7 +159,7 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   const devWorkspaceGenerator = new DevWorkspaceGenerator();
 
   let devfilePath = await selectDevfile();
-  if (SELECT_DEVFILE === devfilePath) {
+  if (`${process.env.PROJECTS_ROOT!}/*` === devfilePath) {
     const uri = await vscode.window.showOpenDialog({
       canSelectFolders: false
     });

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -79,7 +79,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             return;
           }
         } catch (error) {
-          console.error(`Failed to update Devfile: ${error}`);
           vscode.window.showErrorMessage(`Failed to update Devfile. ${error}`);
           return;
         }
@@ -87,7 +86,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         try {
           await vscode.commands.executeCommand('che-remote.command.restartWorkspace');
         } catch (error) {
-          console.error(`Failed to restart the workspace: ${error}`);
           vscode.window.showErrorMessage(`Failed to restart the workpace: ${error}`);
         }
       })

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -174,8 +174,16 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
     return false;
   }
 
+  const action = await vscode.window.showInformationMessage(
+    'Workspace restart', {
+      modal: true, detail: `Your workspace will be restarted from ${devfilePath}. This action is not revertable.`
+    }, 'Restart');
+  if ('Restart' !== action) {
+    return false;
+  }
+
   const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
-  
+
   console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
   const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axiosInstance);
   if (newContent) {

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -130,6 +130,7 @@ async function updateDevfile(cheApi: any): Promise<void> {
 
   const currentDevfile = await devfileService.get();
   const currentProjects = currentDevfile.projects || [];
+  
   console.log(`>> current projects: ${currentProjects.length}`);
   const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
   
@@ -137,8 +138,7 @@ async function updateDevfile(cheApi: any): Promise<void> {
   const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axiosInstance);
   if (newContent) {
     console.log(`>> new projects: ${newContent.devWorkspace.spec!.template!.projects!.length}`);
-    
-    newContent.devWorkspace.spec!.template!.projects = currentProjects;
+    // newContent.devWorkspace.spec!.template!.projects = currentProjects;
     await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);
   } else {
     throw new Error('An error occurred while generating new devfile context');

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -113,16 +113,12 @@ async function isFile(filePath: string): Promise<boolean> {
 }
 
 async function selectDevfile(): Promise<string | undefined> {
-  if (!process.env.PROJECTS_ROOT) {
-    process.env.PROJECTS_ROOT = '/projects';
-  }
-
   const devfileItems: vscode.QuickPickItem[] = [];
 
   const projects = await fs.readdir(process.env.PROJECTS_ROOT as string);
   for (const project of projects) {
     for (const devfileName of DEVFILE_NAMES) {
-      const devfilePath = path.join(process.env.PROJECTS_ROOT, project, devfileName);
+      const devfilePath = path.join(process.env.PROJECTS_ROOT!, project, devfileName);
       if (await isFile(devfilePath)) {
         devfileItems.push({
           label: devfilePath,

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -17,8 +17,7 @@ import * as vscode from 'vscode';
 import { axiosInstance } from './axios-certificate-authority';
 import * as path from 'path';
 
-// const DOT_DEVFILE_NAME = '.devfile.yaml';
-// const DEVFILE_NAME = 'devfile.yaml';
+const DEVFILE_NAMES = ['.devfile.yaml', 'devfile.yaml'];
 const EDITOR_CONTENT_STUB: string = `
 schemaVersion: 2.2.0
 metadata:
@@ -81,7 +80,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           }
         } catch (error) {
           console.error(`Failed to update Devfile: ${error}`);
-          vscode.window.showErrorMessage(`Failed to update Devfile: ${error}`);
+          vscode.window.showErrorMessage(`Failed to update Devfile. ${error}`);
           return;
         }
 
@@ -102,19 +101,18 @@ export function deactivate(): void {
 
 async function isFile(filePath: string): Promise<boolean> {
   try {
-      if (await fs.pathExists(filePath)) {
-          const stat = await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
-          return stat.type === vscode.FileType.File;
-      }
+    if (await fs.pathExists(filePath)) {
+      const stat = await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
+      return stat.type === vscode.FileType.File;
+    }
   } catch (error) {
-      console.error(error);
+    console.error(error);
   }
 
   return false;
 }
 
 async function selectDevfile(): Promise<string | undefined> {
-  console.log(`> use PROJECTS_ROOT: ${process.env.PROJECTS_ROOT}`);
   if (!process.env.PROJECTS_ROOT) {
     process.env.PROJECTS_ROOT = '/projects';
   }
@@ -123,42 +121,34 @@ async function selectDevfile(): Promise<string | undefined> {
 
   const projects = await fs.readdir(process.env.PROJECTS_ROOT as string);
   for (const project of projects) {
-      const dotDevfilePath = path.join(process.env.PROJECTS_ROOT, project, '.devfile.yaml');
-      if (await isFile(dotDevfilePath)) {
-          devfileItems.push({
-              label: dotDevfilePath,
-              detail: project
-          });
-          continue;
-      }
-
-      const devfilePath = path.join(process.env.PROJECTS_ROOT, project, 'devfile.yaml');
+    for (const devfileName of DEVFILE_NAMES) {
+      const devfilePath = path.join(process.env.PROJECTS_ROOT, project, devfileName);
       if (await isFile(devfilePath)) {
-          devfileItems.push({
-              label: devfilePath,
-              detail: project
-          });
+        devfileItems.push({
+          label: devfilePath,
+          detail: project
+        });
+        break;
       }
+    }
   }
 
   if (devfileItems.length === 1) {
-      return devfileItems[0].label;
+    return devfileItems[0].label;
   } else if (devfileItems.length > 1) {
-      const devfileItem = await vscode.window.showQuickPick(devfileItems, {
-          title: 'Select a Devfile to be applied to the current workspace',
-      });
+    const devfileItem = await vscode.window.showQuickPick(devfileItems, {
+      title: 'Select a Devfile to be applied to the current workspace',
+    });
 
-      if (devfileItem) {
-          return devfileItem.label;
-      }
+    if (devfileItem) {
+      return devfileItem.label;
+    }
   }
 
   return undefined;
 }
 
 async function updateDevfile(cheApi: any): Promise<boolean> {
-  console.log('>> Updating devfile...');
-
   const devfileService: {
     get(): Promise<any>;
     getRaw(): Promise<string>;
@@ -168,30 +158,29 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
 
   const devfilePath = await selectDevfile();
   if (!devfilePath) {
-    console.log('> cancelled!!!');
     return false;
   }
 
-  const currentDevfile = await devfileService.get();
-  const currentProjects = currentDevfile.projects || [];
-  
-  console.log(`>> current projects: ${currentProjects.length}`);
+  // const currentDevfile = await devfileService.get();
+  // const currentProjects = currentDevfile.projects || [];
+  // console.log(`>> current projects: ${currentProjects.length}`);
   const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
   
   console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
   const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axiosInstance);
   if (newContent) {
-    if (newContent.devWorkspace.spec!.template!.projects) {
-      console.log(`>> new projects: ${newContent.devWorkspace.spec!.template!.projects!.length}`);
-    } else {
-      console.log('>> generated devfile does not contain any project');
-    }
+    // if (newContent.devWorkspace.spec!.template!.projects) {
+    //   console.log(`>> new projects: ${newContent.devWorkspace.spec!.template!.projects!.length}`);
+    // } else {
+    //   console.log('>> generated devfile does not contain any project');
+    // }
+
     // newContent.devWorkspace.spec!.template!.projects = currentProjects;
     await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);
 
     return true;
   } else {
-    console.log('>> Unable to generate the devfile for some reasons');
+    // console.log('>> Unable to generate the devfile for some reasons');
     throw new Error('An error occurred while generating new devfile context');
   }
 }

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -137,10 +137,15 @@ async function updateDevfile(cheApi: any): Promise<void> {
   console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
   const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axiosInstance);
   if (newContent) {
-    console.log(`>> new projects: ${newContent.devWorkspace.spec!.template!.projects!.length}`);
+    if (newContent.devWorkspace.spec!.template!.projects) {
+      console.log(`>> new projects: ${newContent.devWorkspace.spec!.template!.projects!.length}`);
+    } else {
+      console.log('>> generated devfile does not contain any project');
+    }
     // newContent.devWorkspace.spec!.template!.projects = currentProjects;
     await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);
   } else {
+    console.log('>> Unable to generate the devfile for some reasons');
     throw new Error('An error occurred while generating new devfile context');
   }
 }

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -161,26 +161,14 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
     return false;
   }
 
-  // const currentDevfile = await devfileService.get();
-  // const currentProjects = currentDevfile.projects || [];
-  // console.log(`>> current projects: ${currentProjects.length}`);
   const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
   
   console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
   const newContent = await devWorkspaceGenerator.generateDevfileContext({ devfilePath, editorContent: EDITOR_CONTENT_STUB, pluginRegistryUrl, projects: [] }, axiosInstance);
   if (newContent) {
-    // if (newContent.devWorkspace.spec!.template!.projects) {
-    //   console.log(`>> new projects: ${newContent.devWorkspace.spec!.template!.projects!.length}`);
-    // } else {
-    //   console.log('>> generated devfile does not contain any project');
-    // }
-
-    // newContent.devWorkspace.spec!.template!.projects = currentProjects;
     await devfileService.updateDevfile(newContent.devWorkspace.spec?.template);
-
     return true;
   } else {
-    // console.log('>> Unable to generate the devfile for some reasons');
     throw new Error('An error occurred while generating new devfile context');
   }
 }


### PR DESCRIPTION
### What does this PR do?
- fixes disappearing the projects after updating the devfile
- proposes the user to select the devfile if workspace contains several projects
- decouples updating the devfile in a separate `try {} catch {}` section to better understanding the cause of the error when restarting the workpace

![Screenshot from 2024-05-14 09-44-35](https://github.com/che-incubator/che-code/assets/1655894/905592dd-0134-483c-9957-3f1708b6ca00)

![Screenshot from 2024-05-14 09-44-45](https://github.com/che-incubator/che-code/assets/1655894/35aea209-978d-49e6-96e8-94fd18aee3c4)

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/22722

### How to test this PR?

1. Create a workspace with factory https://github.com/che-samples/java-spring-petclinic.git?che-editor=https://gist.githubusercontent.com/vitaliy-guliy/a2efd2a2e0f3324e057edab0ed7b2494/raw/05bac72e7318fc1edfe1e72e4e4dcabaa50a0ff3/editor.yaml&new

or just click at

[![Contribute](https://img.shields.io/static/v1?label=Eclipse%20Che%20(nightly)&message=Dev%20cluster%20(for%20maintainers)&logo=eclipseche&color=525C86&labelColor=FDB940)](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com#https://github.com/che-samples/java-spring-petclinic.git?che-editor=https://gist.githubusercontent.com/vitaliy-guliy/a2efd2a2e0f3324e057edab0ed7b2494/raw/05bac72e7318fc1edfe1e72e4e4dcabaa50a0ff3/editor.yaml&new)


2. Open the devfile in `java-spring-petclinic` project, add following section and save
```
projects:
  - name: nodejs-devfile-test
    git:
      remotes:
        origin: https://github.com/vitaliy-guliy/nodejs-devfile-test.git

  - name: lombok-project-sample
    git:
      remotes:
        origin: https://github.com/vitaliy-guliy/lombok-project-sample.git
``` 

3. Run `Eclipse Che: Restart Workspace from Local Devfile` command, select a devfile for `java-spring-petclinic` project and confirm restart. 

Workspace should be restarted, explorer should contain three projects.

4. Install `redhat.vscode-yaml` extension.

5. Open the devfile in `java-spring-petclinic` project, add some environment variable to the `tools` container.
```
      env:
        - name: test
          value: test_value
```

6. Run `Eclipse Che: Restart Workspace from Local Devfile` command.

Select the devfile for `java-spring-petclinic` project and confirm restart to continue.
Once workspace is restarted, open the terminal and verify the environment variable is set.

7. Copy the devfile in `java-spring-petclinic` project to the new file with a different name.
Open newly created devfile, add another one environment variable like above and run `Eclipse Che: Restart Workspace from Local Devfile` command.
In a proposed popup select the last item and then using the popup open the created devfile.
Confirm restart when requested.

The workspace should be restarted. Open a terminal and check for environment variable.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
