### PR TITLE
Download chectl install script from che-incubator.github.io in tests

### DIFF
--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -93,7 +93,7 @@ jobs:
           minikube-version: v1.23.2
 
       - name: Install chectl
-        run: bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
+        run: bash <(curl -sL https://che-incubator.github.io/chectl/install.sh) --channel=next
 
       - name: Deploy Che
         run: |


### PR DESCRIPTION
### What does this PR do?
Fix URL where E2E tests is downloading chectl install script from.

### What issues does this PR fix?
https://github.com/eclipse-che/che/issues/22925
https://github.com/eclipse-che/che/issues/22926

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
