### PR TITLE
fix: Use 'replace' operation to provide Che-specific env variables to the extension context

### DIFF
--- a/code/extensions/che-api/src/extension.ts
+++ b/code/extensions/che-api/src/extension.ts
@@ -70,10 +70,10 @@ export async function activate(_extensionContext: vscode.ExtensionContext): Prom
 	const workspaceName = k8sDevWorkspaceEnvVariables.getWorkspaceName();
 	const projectsRoot = k8sDevWorkspaceEnvVariables.getProjectsRoot();
 	
-	_extensionContext.environmentVariableCollection.append('DASHBOARD_URL', dashboardUrl);
-	_extensionContext.environmentVariableCollection.append('WORKSPACE_NAME', workspaceName);
-	_extensionContext.environmentVariableCollection.append('WORKSPACE_NAMESPACE', workspaceNamespace);
-	_extensionContext.environmentVariableCollection.append('PROJECTS_ROOT', projectsRoot);
+	_extensionContext.environmentVariableCollection.replace('DASHBOARD_URL', dashboardUrl);
+	_extensionContext.environmentVariableCollection.replace('WORKSPACE_NAME', workspaceName);
+	_extensionContext.environmentVariableCollection.replace('WORKSPACE_NAMESPACE', workspaceNamespace);
+	_extensionContext.environmentVariableCollection.replace('PROJECTS_ROOT', projectsRoot);
 
     return api;
 }


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

### What does this PR do?
`append` operation is used to add env variables to the extension context, but it leads to the bug like:
`PROJECTS_ROOT` variable already exists, its value is `/projects` => `append` operation is applied => the value is:  `/projects/projects`

So, let's use `replace` operation to add Che-specific variables to the extension context.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-6025

### How to test this PR?
**Use case 1: Che-specific env variables should have correct value**
- start a workspace with a project
- open a terminal
- check values for `PROJECTS_ROOT`, `WORKSPACE_NAMESPACE`, `WORKSPACE_NAME`, `DASHBOARD_URL` variables
- also see https://issues.redhat.com/browse/CRW-6025 for the context

**Use case 2: terminal should use '/projects' as default directory**
- start an empty workspace
- open a terminal
- check that `pwd` => `/projects`
- also see https://github.com/eclipse-che/che/issues/22819 for the context

**Use case 3: 'Stop Workspace' and 'Restart Workspace' actions work as expected**
- Che-specific env variables are used for those actions, so let's check that the actions still work as expected 
- start a workspace
- `F1` => `Restart Workspace` => the workspace should be restarted
- `F1` => `Stop Workspace` => the workspace should be stopped


### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
