### PR TITLE
Cherry-pick upstream VSCode fix for folder dialog (fba040a) to 7.84.x branch

### DIFF
--- a/code/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/code/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -584,9 +584,9 @@ export class SimpleFileDialog implements ISimpleFileDialog {
 		} else {
 			const newFolderIsOldFolder = resources.extUriIgnorePathCase.isEqual(this.currentFolder, valueUri);
 			const newFolderIsSubFolder = resources.extUriIgnorePathCase.isEqual(this.currentFolder, resources.dirname(valueUri));
-			const newFolderIsParent = !newFolderIsOldFolder && resources.extUriIgnorePathCase.isEqualOrParent(this.currentFolder, resources.dirname(valueUri));
-			const newFolderIsUnrelated = !newFolderIsOldFolder && !newFolderIsParent && !newFolderIsSubFolder;
-			if (this.endsWithSlash(value) || newFolderIsParent || newFolderIsUnrelated) {
+			const newFolderIsParent = resources.extUriIgnorePathCase.isEqualOrParent(this.currentFolder, resources.dirname(valueUri));
+			const newFolderIsUnrelated = !newFolderIsParent && !newFolderIsSubFolder;
+			if (!newFolderIsOldFolder && (this.endsWithSlash(value) || newFolderIsParent || newFolderIsUnrelated)) {
 				let stat: IFileStatWithPartialMetadata | undefined;
 				try {
 					stat = await this.fileService.stat(valueUri);


### PR DESCRIPTION
### What does this PR do?
Cherry-pick https://github.com/che-incubator/che-code/commit/fba040af3249180da3ff861ebc5222ad4ee6169d onto 7.84 branch

### What issues does this PR fix?
Fixes downstream issue: https://issues.redhat.com/browse/CRW-6286


### How to test this PR?
I ended up [testing this in Che](https://github.com/che-incubator/che-code/tree/main?tab=readme-ov-file#developing-with-eclipse-che) by compiling and running the Che Code server on the dogfooding instance. I first compiled and ran while on the 7.84.x branch and reproduced the issue by trying to open /home/user/ in the "child" Che Code instance, then applied the fix commit and recompiled and verified I could no longer reproduce the issue.  

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
