### PR TITLE
fix: Do not ignore processEnv.PATH variable 

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -51,3 +51,9 @@ https://github.com/che-incubator/che-code/pull/193
 
 - code/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
 ---
+
+#### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/353
+
+- code/src/vs/server/node/extensionHostConnection.ts
+---

--- a/.rebase/replace/code/src/vs/server/node/extensionHostConnection.ts.json
+++ b/.rebase/replace/code/src/vs/server/node/extensionHostConnection.ts.json
@@ -1,0 +1,10 @@
+[
+    {
+        "from": "import { getNLSConfiguration } from 'vs/server/node/remoteLanguagePacks';",
+        "by": "import { getNLSConfiguration } from 'vs/server/node/remoteLanguagePacks';\\\nimport { getResolvedPathEnvVar } from 'vs/server/node/che/utils';"
+    },
+    {
+        "from": "setCaseInsensitive(env, 'PATH', PATH);",
+        "by": "PATH = getResolvedPathEnvVar(PATH, processEnv.PATH);\\\n\\\tsetCaseInsensitive(env, 'PATH', PATH);"
+    }
+]

--- a/code/src/vs/server/node/che/utils.ts
+++ b/code/src/vs/server/node/che/utils.ts
@@ -11,6 +11,22 @@
 
 import { delimiter } from 'vs/base/common/path';
 
+/**
+ * Merges the provided values. The first parameter is taken as the basis.
+ * Items from the second parameter are appended to the main value, duplicates are filtered out.
+ * For example:
+ * - the first parameter is: "/checode/checode-linux-libc/ubi9/bin/remote-cli:/usr/local/bin:/usr/bin" 
+ * - the second parameter is: "/go/bin:/usr/bin"
+ * - the function returns: "/checode/checode-linux-libc/ubi9/bin/remote-cli:/usr/local/bin:/usr/bin:/go/bin",
+ * - note: "/usr/bin" is filtered out to avoud duplicates in the returned value 
+ * 
+ * @param currentPath current value of the PATH env variable
+ * @param processEnvPath value of the process.env.PATH env variable 
+ * @returns
+ * - merged value for the given parameters 
+ * - currentPath if processEnvPath is not provided (undefined or empty string) 
+ */
+
 export function getResolvedPathEnvVar(currentPath: string, processEnvPath?: string): string {
     if (processEnvPath) {
         const currentPathArray: string[] = currentPath.split(delimiter);

--- a/code/src/vs/server/node/che/utils.ts
+++ b/code/src/vs/server/node/che/utils.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable header/header */
+
+import { delimiter } from 'vs/base/common/path';
+
+export function getResolvedPathEnvVar(currentPath: string, processEnvPath?: string): string {
+    if (processEnvPath) {
+        const currentPathArray: string[] = currentPath.split(delimiter);
+        const processEnvPathArray: string[] = processEnvPath.split(delimiter);
+        const processPathUniqueItems = processEnvPathArray.filter(path => !currentPathArray.includes(path));
+        return processPathUniqueItems.length > 0 ? currentPath + delimiter + processPathUniqueItems.join(delimiter) : currentPath;
+    }
+    return currentPath;
+}

--- a/code/src/vs/server/node/extensionHostConnection.ts
+++ b/code/src/vs/server/node/extensionHostConnection.ts
@@ -6,6 +6,7 @@
 import * as cp from 'child_process';
 import * as net from 'net';
 import { getNLSConfiguration } from 'vs/server/node/remoteLanguagePacks';
+import { getResolvedPathEnvVar } from 'vs/server/node/che/utils';
 import { FileAccess } from 'vs/base/common/network';
 import { join, delimiter } from 'vs/base/common/path';
 import { VSBuffer } from 'vs/base/common/buffer';
@@ -57,6 +58,7 @@ export async function buildUserEnvironment(startParamsEnv: { [key: string]: stri
 	} else {
 		PATH = remoteCliBinFolder;
 	}
+	PATH = getResolvedPathEnvVar(PATH, processEnv.PATH);
 	setCaseInsensitive(env, 'PATH', PATH);
 
 	if (!environmentService.args['without-browser-env-var']) {

--- a/rebase.sh
+++ b/rebase.sh
@@ -375,6 +375,8 @@ resolve_conflicts() {
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts" ]]; then
       apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/server/node/extensionHostConnection.ts" ]]; then
+      apply_changes "$conflictingFile"
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"
       exit 1


### PR DESCRIPTION
### What does this PR do?
Before my changes value of `process.env.PATH` is overridden by `userShellEnv.PATH` env variable.
I propose to merge values of `process.env.PATH` and `userShellEnv.PATH` env variables.  

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/22878

### How to test this PR?
1. Start a workspace: https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/l0rd/cloud-dev-images?image=quay.io/mloriedo/cloud-dev-images:golang&che-editor=che-incubator/che-code/insiders&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-353-amd64
2. Open a terminal
3. Type `go version`
4. Check the output: it should return `go` version

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

