### PR TITLE
fix: should not fail if code-workspace file has extra commas

### DIFF
--- a/launcher/src/code-workspace.ts
+++ b/launcher/src/code-workspace.ts
@@ -117,8 +117,17 @@ export class CodeWorkspace {
 
   // finds and removes each comma, after which there is no any attribute, object or array
   sanitize(content: string): string {
+    console.log('Content Before:');
+    console.log(content);
+
     const regex = /\,(?!\s*?[\{\[\"\'\w])/g;
-    return content.replace(regex, '');
+
+    const result = content.replace(regex, '');
+    console.log('Content After:');
+    console.log(result);
+
+    return result;
+    // return content.replace(regex, '');
   }
 
   async fileExists(file: string | undefined): Promise<boolean> {

--- a/launcher/src/code-workspace.ts
+++ b/launcher/src/code-workspace.ts
@@ -140,16 +140,18 @@ export class CodeWorkspace {
 
     let synchronized = false;
 
-    projects.forEach(async (project) => {
-      if (!workspace.folders.some((folder) => folder.name === project.name)) {
-        workspace.folders.push({
-          name: project.name,
-          path: `${env.PROJECTS_ROOT}/${project.name}`,
-        });
+    for (const project of projects) {
+      if (await fs.pathExists(`${env.PROJECTS_ROOT}/${project.name}`)) {
+        if (!workspace.folders.some((folder) => folder.name === project.name)) {
+          workspace.folders.push({
+            name: project.name,
+            path: `${env.PROJECTS_ROOT}/${project.name}`,
+          });
 
-        synchronized = true;
+          synchronized = true;
+        }
       }
-    });
+    }
 
     return synchronized;
   }

--- a/launcher/src/code-workspace.ts
+++ b/launcher/src/code-workspace.ts
@@ -50,7 +50,7 @@ export class CodeWorkspace {
           console.log(`  > Using workspace file ${env.VSCODE_DEFAULT_WORKSPACE}`);
 
           path = env.VSCODE_DEFAULT_WORKSPACE;
-          workspace = JSON.parse(this.sanitize(await fs.readFile(path)));
+          workspace = await this.readWorkspaceFile(path);
         } else {
           console.log(`  > ERROR: failure to read workspace file ${env.VSCODE_DEFAULT_WORKSPACE}`);
           return;
@@ -75,7 +75,7 @@ export class CodeWorkspace {
             console.log(`  > Using workspace file ${toFind}`);
 
             path = toFind;
-            workspace = JSON.parse(this.sanitize(await fs.readFile(path)));
+            workspace = await this.readWorkspaceFile(path);
           }
         } catch (err) {
           console.error(`Failure to read workspace file. ${err.message}`);
@@ -88,7 +88,7 @@ export class CodeWorkspace {
         if (await this.fileExists(path)) {
           console.log(`  > Using workspace file ${path}`);
           try {
-            workspace = JSON.parse(this.sanitize(await fs.readFile(path)));
+            workspace = await this.readWorkspaceFile(path);
           } catch (readErr) {
             console.error(`Failure to read workspace file. ${readErr.message}`);
             return;
@@ -124,10 +124,13 @@ export class CodeWorkspace {
     }
   }
 
-  // finds and removes each comma, after which there is no any attribute, object or array
-  sanitize(content: string): string {
+  // reads workspace file from the file system
+  // in the read content finds and removes each comma, after which there is no any attribute, object or array
+  async readWorkspaceFile(path: string): Promise<Workspace> {
+    const content = await fs.readFile(path);
     const regex = /\,(?!\s*?[\{\[\"\'\w])/g;
-    return content.replace(regex, '');
+    const sanitized = content.replace(regex, '');
+    return JSON.parse(sanitized);
   }
 
   async fileExists(file: string | undefined): Promise<boolean> {

--- a/launcher/src/code-workspace.ts
+++ b/launcher/src/code-workspace.ts
@@ -126,17 +126,8 @@ export class CodeWorkspace {
 
   // finds and removes each comma, after which there is no any attribute, object or array
   sanitize(content: string): string {
-    console.log('Content Before:');
-    console.log(content);
-
     const regex = /\,(?!\s*?[\{\[\"\'\w])/g;
-
-    const result = content.replace(regex, '');
-    console.log('Content After:');
-    console.log(result);
-
-    return result;
-    // return content.replace(regex, '');
+    return content.replace(regex, '');
   }
 
   async fileExists(file: string | undefined): Promise<boolean> {

--- a/launcher/tests/_data/test.code-workspace
+++ b/launcher/tests/_data/test.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"name": "che-code",
+			"path": "/tmp/projects/che-code",
+		},
+	]
+}

--- a/launcher/tests/code-workspace.spec.ts
+++ b/launcher/tests/code-workspace.spec.ts
@@ -508,7 +508,7 @@ describe('Test generating VS Code Workspace file:', () => {
     expect(readFileMock).toBeCalledWith(env.VSCODE_DEFAULT_WORKSPACE);
     expect(readFileMock).toBeCalledWith(env.DEVWORKSPACE_FLATTENED_DEVFILE);
 
-    // shpuld update existing workspace file
+    // should update existing workspace file
     expect(writeFileMock).toBeCalledWith(env.VSCODE_DEFAULT_WORKSPACE, WORKSPACE_JSON);
   });
 
@@ -561,7 +561,7 @@ describe('Test generating VS Code Workspace file:', () => {
     expect(readFileMock).toBeCalledWith(env.VSCODE_DEFAULT_WORKSPACE);
     expect(readFileMock).toBeCalledWith(env.DEVWORKSPACE_FLATTENED_DEVFILE);
 
-    // shpuld update existing workspace file
+    // should update existing workspace file
     expect(writeFileMock).toBeCalledWith(env.VSCODE_DEFAULT_WORKSPACE, WORKSPACE_WITH_TWO_PROJECTS);
   });
 });

--- a/launcher/tests/code-workspace.spec.ts
+++ b/launcher/tests/code-workspace.spec.ts
@@ -87,7 +87,6 @@ const WORKSPACE_WITH_DEPENDENT_PROJECTS = `{
 }`;
 
 describe('Test generating VS Code Workspace file:', () => {
-
   const originalReadFile = fs.readFile;
 
   beforeEach(() => {


### PR DESCRIPTION
### What does this PR do?
Fixes an error when parsing a workspace file that contains extra commas like below
```json
{
	"folders": [
		{
			"name": "che-code",
			"path": "/projects/che-code",
		},
	]
}
```

Fixes a bug with displaying projects in the Explorer view in a case when a devfile describes several starter projects, but only one is cloned to `/projects` directory.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-6250
https://github.com/eclipse-che/che/issues/22941

### How to test this PR?

Testing https://issues.redhat.com/browse/CRW-6250

- create a workspace with https://github.com/vitaliy-guliy/vscode-test-extension/tree/wrong-workspace-file?editor-image=quay.io/che-incubator-pull-requests/che-code:pr-360-amd64
- workspace should be created without any errors, `Kimbie Dark` theme should be applied
- open `/checode/entrypoint-logs.txt`, ensure `/projects/vscode-test-extension/.code-workspace` is used
```
# Generating Workspace file...
  > Using workspace file /projects/vscode-test-extension/.code-workspace
```

Testing https://github.com/eclipse-che/che/issues/22941

- create a workspace with https://gist.githubusercontent.com/vitaliy-guliy/b9917e949e59cb9507655221b835dd41/raw/e75b11723d7d2e9290dbeb8c46a69e2c0381f502/devfile.yaml?editor-image=quay.io/che-incubator-pull-requests/che-code:pr-360-amd64
- open `/devworkspace-metadata/flattened.devworkspace.yaml`, ensure it contains two starer projects
-  open a terminal and run `ls -la /projects`. The `/projects` directory should have only one `projects-1` directory
- ensure there is only one project in the Explorer view

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
