### PR TITLE
The trustedExtensionAuthAccess env VSCODE_TRUSTED_EXTENSIONS is Case Sensitive

### DIFF
--- a/launcher/src/trusted-extensions.ts
+++ b/launcher/src/trusted-extensions.ts
@@ -28,7 +28,7 @@ export class TrustedExtensions {
       for (const extension of env.VSCODE_TRUSTED_EXTENSIONS.split(',')) {
         if (extension) {
           if (extension.match(/^[A-Za-z0-9][A-Za-z0-9-]*\.[A-Za-z0-9][A-Za-z0-9-.]*$/)) {
-            extensions.push(extension);
+            extensions.push(extension.toLowerCase());
             console.log(`  > add ${extension}`);
           } else {
             console.log(`  > failure to add [${extension}] because of wrong identifier`);

--- a/launcher/src/trusted-extensions.ts
+++ b/launcher/src/trusted-extensions.ts
@@ -27,7 +27,7 @@ export class TrustedExtensions {
 
       for (const extension of env.VSCODE_TRUSTED_EXTENSIONS.split(',')) {
         if (extension) {
-          if (extension.match(/^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-z0-9-.]*$/)) {
+          if (extension.match(/^[A-Za-z0-9][A-Za-z0-9-]*\.[A-Za-z0-9][A-Za-z0-9-.]*$/)) {
             extensions.push(extension);
             console.log(`  > add ${extension}`);
           } else {

--- a/launcher/tests/trusted-extensions.spec.ts
+++ b/launcher/tests/trusted-extensions.spec.ts
@@ -277,11 +277,11 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
     const trust = new TrustedExtensions();
     await trust.configure();
 
-    expect(savedProductJson).toBe(PRODUCT_JSON_TWO_EXTENSIONS);
+    expect(savedProductJson).toBe(PRODUCT_JSON_TWO_EXTENSIONS_UPPERCASE);
 
     expect(spy).toHaveBeenCalledWith('# Configuring Trusted Extensions...');
     expect(spy).toHaveBeenCalledWith(
-      '  > env.VSCODE_TRUSTED_EXTENSIONS is set to [redhat.yaml,redhat.openshift,red hat.java]'
+      '  > env.VSCODE_TRUSTED_EXTENSIONS is set to [RedHat.Yaml,RedHat.OpenShift,red hat.java]'
     );
     expect(spy).toHaveBeenCalledWith('  > add RedHat.Yaml');
     expect(spy).toHaveBeenCalledWith('  > add RedHat.OpenShift');

--- a/launcher/tests/trusted-extensions.spec.ts
+++ b/launcher/tests/trusted-extensions.spec.ts
@@ -46,7 +46,7 @@ const PRODUCT_JSON_WITH_EXTENSIONS_ALTERNATIVE = `{
 		]
 	}
 }`;
-const PRODUCT_JSON_TWO_EXTENSIONS_UPPERCASE = `{
+const PRODUCT_JSON_TWO_EXTENSIONS = `{
 	"version": "1.0.0",
 	"trustedExtensionAuthAccess": [
 		"RedHat.Yaml",
@@ -277,7 +277,7 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
     const trust = new TrustedExtensions();
     await trust.configure();
 
-    expect(savedProductJson).toBe(PRODUCT_JSON_TWO_EXTENSIONS_UPPERCASE);
+    expect(savedProductJson).toBe(PRODUCT_JSON_TWO_EXTENSIONS);
 
     expect(spy).toHaveBeenCalledWith('# Configuring Trusted Extensions...');
     expect(spy).toHaveBeenCalledWith(

--- a/launcher/tests/trusted-extensions.spec.ts
+++ b/launcher/tests/trusted-extensions.spec.ts
@@ -287,5 +287,4 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
     expect(spy).toHaveBeenCalledWith('  > add RedHat.OpenShift');
     expect(spy).toHaveBeenCalledWith('  > failure to add [red hat.java] because of wrong identifier');
   });
-
 });

--- a/launcher/tests/trusted-extensions.spec.ts
+++ b/launcher/tests/trusted-extensions.spec.ts
@@ -235,6 +235,23 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
       },
     });
 
+    const spy = jest.spyOn(console, 'log');
+
+    // test
+    const trust = new TrustedExtensions();
+    await trust.configure();
+
+    expect(savedProductJson).toBe(PRODUCT_JSON_TWO_EXTENSIONS);
+
+    expect(spy).toHaveBeenCalledWith('# Configuring Trusted Extensions...');
+    expect(spy).toHaveBeenCalledWith(
+      '  > env.VSCODE_TRUSTED_EXTENSIONS is set to [redhat.yaml,redhat.openshift,red hat.java]'
+    );
+    expect(spy).toHaveBeenCalledWith('  > add redhat.yaml');
+    expect(spy).toHaveBeenCalledWith('  > add redhat.openshift');
+    expect(spy).toHaveBeenCalledWith('  > failure to add [red hat.java] because of wrong identifier');
+  });
+
   test('should add only two extenions matching the regexp without case-sensitivity', async () => {
     env.VSCODE_TRUSTED_EXTENSIONS = 'RedHat.Yaml,RedHat.OpenShift,red hat.java';
 
@@ -266,8 +283,9 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
     expect(spy).toHaveBeenCalledWith(
       '  > env.VSCODE_TRUSTED_EXTENSIONS is set to [redhat.yaml,redhat.openshift,red hat.java]'
     );
-    expect(spy).toHaveBeenCalledWith('  > add redhat.yaml');
-    expect(spy).toHaveBeenCalledWith('  > add redhat.openshift');
+    expect(spy).toHaveBeenCalledWith('  > add RedHat.Yaml');
+    expect(spy).toHaveBeenCalledWith('  > add RedHat.OpenShift');
     expect(spy).toHaveBeenCalledWith('  > failure to add [red hat.java] because of wrong identifier');
   });
+
 });

--- a/launcher/tests/trusted-extensions.spec.ts
+++ b/launcher/tests/trusted-extensions.spec.ts
@@ -46,6 +46,13 @@ const PRODUCT_JSON_WITH_EXTENSIONS_ALTERNATIVE = `{
 		]
 	}
 }`;
+const PRODUCT_JSON_TWO_EXTENSIONS_UPPERCASE = `{
+	"version": "1.0.0",
+	"trustedExtensionAuthAccess": [
+		"RedHat.Yaml",
+		"RedHat.OpenShift"
+	]
+}`;
 
 describe('Test Configuring of Trusted Extensions Auth Access:', () => {
   const originalReadFile = fs.readFile;
@@ -218,6 +225,25 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
       readFile: async (file: string) => {
         if ('product.json' === file) {
           return PRODUCT_JSON_SIMPLE;
+        }
+      },
+
+      writeFile: async (file: string, data: string) => {
+        if ('product.json' === file) {
+          savedProductJson = data;
+        }
+      },
+    });
+
+  test('should add only two extenions matching the regexp without case-sensitivity', async () => {
+    env.VSCODE_TRUSTED_EXTENSIONS = 'RedHat.Yaml,RedHat.OpenShift,red hat.java';
+
+    let savedProductJson;
+
+    Object.assign(fs, {
+      readFile: async (file: string) => {
+        if ('product.json' === file) {
+          return PRODUCT_JSON_TWO_EXTENSIONS_UPPERCASE;
         }
       },
 

--- a/launcher/tests/trusted-extensions.spec.ts
+++ b/launcher/tests/trusted-extensions.spec.ts
@@ -260,7 +260,7 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
     Object.assign(fs, {
       readFile: async (file: string) => {
         if ('product.json' === file) {
-          return PRODUCT_JSON_TWO_EXTENSIONS_UPPERCASE;
+          return PRODUCT_JSON_SIMPLE;
         }
       },
 

--- a/launcher/tests/trusted-extensions.spec.ts
+++ b/launcher/tests/trusted-extensions.spec.ts
@@ -273,7 +273,7 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
 
     const spy = jest.spyOn(console, 'log');
 
-    // test
+    //test
     const trust = new TrustedExtensions();
     await trust.configure();
 

--- a/launcher/tests/trusted-extensions.spec.ts
+++ b/launcher/tests/trusted-extensions.spec.ts
@@ -46,13 +46,6 @@ const PRODUCT_JSON_WITH_EXTENSIONS_ALTERNATIVE = `{
 		]
 	}
 }`;
-const PRODUCT_JSON_TWO_EXTENSIONS = `{
-	"version": "1.0.0",
-	"trustedExtensionAuthAccess": [
-		"RedHat.Yaml",
-		"RedHat.OpenShift"
-	]
-}`;
 
 describe('Test Configuring of Trusted Extensions Auth Access:', () => {
   const originalReadFile = fs.readFile;
@@ -249,42 +242,6 @@ describe('Test Configuring of Trusted Extensions Auth Access:', () => {
     );
     expect(spy).toHaveBeenCalledWith('  > add redhat.yaml');
     expect(spy).toHaveBeenCalledWith('  > add redhat.openshift');
-    expect(spy).toHaveBeenCalledWith('  > failure to add [red hat.java] because of wrong identifier');
-  });
-
-  test('should add only two extenions matching the regexp without case-sensitivity', async () => {
-    env.VSCODE_TRUSTED_EXTENSIONS = 'RedHat.Yaml,RedHat.OpenShift,red hat.java';
-
-    let savedProductJson;
-
-    Object.assign(fs, {
-      readFile: async (file: string) => {
-        if ('product.json' === file) {
-          return PRODUCT_JSON_SIMPLE;
-        }
-      },
-
-      writeFile: async (file: string, data: string) => {
-        if ('product.json' === file) {
-          savedProductJson = data;
-        }
-      },
-    });
-
-    const spy = jest.spyOn(console, 'log');
-
-    //test
-    const trust = new TrustedExtensions();
-    await trust.configure();
-
-    expect(savedProductJson).toBe(PRODUCT_JSON_TWO_EXTENSIONS);
-
-    expect(spy).toHaveBeenCalledWith('# Configuring Trusted Extensions...');
-    expect(spy).toHaveBeenCalledWith(
-      '  > env.VSCODE_TRUSTED_EXTENSIONS is set to [RedHat.Yaml,RedHat.OpenShift,red hat.java]'
-    );
-    expect(spy).toHaveBeenCalledWith('  > add RedHat.Yaml');
-    expect(spy).toHaveBeenCalledWith('  > add RedHat.OpenShift');
     expect(spy).toHaveBeenCalledWith('  > failure to add [red hat.java] because of wrong identifier');
   });
 });


### PR DESCRIPTION
### What does this PR do?
Makes the trustedExtensionAuthAccess env VSCODE_TRUSTED_EXTENSIONS Case-Insensitive

### What issues does this PR fix?
https://issues.redhat.com/browse/CRW-6573

### How to test this PR?
Use trustedExtensionAuthAccess feature by adding VSCODE_TRUSTED_EXTENSIONS env through ConfigMap or through devfile, the value should contain lower and uppercase letters.
