### PR TITLE
fix: restore back pr-check actions

### DIFF
--- a/.github/workflows/pull-request-check-publish.yml
+++ b/.github/workflows/pull-request-check-publish.yml
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: Publish Image PR check
+
+on:
+  workflow_run:
+    workflows: ["Pull Request Check"]
+    types:
+      - completed
+
+jobs:
+
+  publish-images:
+    name: publish image from the pull request
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Download Pull Request Number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pull-request-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Grab Pull Request number
+        run: |
+          pr_number=$(cat "PR_NUMBER")
+          echo "Pull Request: ${pr_number}"
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "Wrong Pull Request number"
+            exit 1
+          fi
+          echo "_PR_NUMBER=$pr_number" >> $GITHUB_ENV
+
+      - name: Cleanup docker images
+        run: |
+          docker system prune -af
+
+      - name: Download che-code docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: che-*
+          merge-multiple: true
+          path: .
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: List downloaded files
+        run: |
+          ls -lahR
+
+      - name: Load Docker images
+        run: |
+          docker load -i che-code.tgz
+          docker load -i che-dev.tgz
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_PULL_REQUESTS_USERNAME }}
+          password: ${{ secrets.QUAY_PULL_REQUESTS_PASSWORD }}
+
+      - name: Push che-code docker image
+        run: |
+          export IMAGE=quay.io/che-incubator-pull-requests/che-code:pr-${{env._PR_NUMBER}}-amd64
+          docker tag che-code ${IMAGE}
+          docker push ${IMAGE}
+          echo "_CHE_CODE_IMAGE=${IMAGE}" >> $GITHUB_ENV
+
+      - name: Push che-dev docker image
+        run: |
+          export IMAGE=quay.io/che-incubator-pull-requests/che-code-dev:pr-${{env._PR_NUMBER}}-dev-amd64
+          docker tag che-dev ${IMAGE}
+          docker push ${IMAGE}
+          echo "_CHE_DEV_IMAGE=${IMAGE}" >> $GITHUB_ENV
+
+      - name: 'Comment PR'
+        uses: actions/github-script@v7
+        with:
+         script: |
+           const { repo: { owner, repo } } = context;
+           await github.rest.issues.createComment({
+              issue_number: process.env._PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Pull Request images published ✨\n\nEditor: [${process.env._CHE_CODE_IMAGE}](https://${process.env._CHE_CODE_IMAGE})\nDev image: [${process.env._CHE_DEV_IMAGE}](https://${process.env._CHE_DEV_IMAGE})`
+            })


### PR DESCRIPTION
### What does this PR do?
Restores/updates previously removed action to publish che-code and che-dev images for pull requests that has been made from a fork.

A link to the original action https://github.com/che-incubator/che-code/blob/7.75.0/.github/workflows/pr-check-image-publish.yml

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/22660

### How to test this PR?
We cannot test it until it has been merged to the main branch.

But I can give a links to a jobs demonstrating how does it work in a fork

The first PR-check action is running builds both che-code and che-dev images and uploads them to the artifacts
https://github.com/vitaliy-guliy/che-code/actions/workflows/pull-request-check.yml

Then the action provided withing this PR will download che-code and che-dev artifacts and will push them to the quay.io
https://github.com/vitaliy-guliy/che-code/actions/workflows/pull-request-check-publish.yml

After pushing the images, the action will comment to the PR
https://github.com/vitaliy-guliy/che-code/pull/12#issuecomment-2167692870

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
