### PR TITLE
fix: Fix 'Open in Preview' action for the Endpoints panel

### DIFF
--- a/code/extensions/che-port/src/endpoints-tree-data-provider.ts
+++ b/code/extensions/che-port/src/endpoints-tree-data-provider.ts
@@ -98,7 +98,7 @@ export class EndpointsTreeDataProvider implements vscode.TreeDataProvider<Endpoi
     context.subscriptions.push(
       vscode.commands.registerCommand('portPlugin.preview', (node: EndpointTreeNodeItem) => {
         if (node.endpoint && node.endpoint.url) {
-          vscode.commands.executeCommand('mini-browser.openUrl', node.endpoint.url);
+          vscode.commands.executeCommand('simpleBrowser.show', node.endpoint.url);
         }
       })
     );

--- a/code/extensions/che-port/src/ports-plugin.ts
+++ b/code/extensions/che-port/src/ports-plugin.ts
@@ -98,7 +98,7 @@ export class PortsPlugin {
         const msg = `Redirect is now enabled on port ${port.portNumber}. External URL is ${endpoint.url}`;
         const resultShow = await vscode.window.showInformationMessage(msg, ...redirectInteractions);
         if (resultShow && resultShow.title === 'Open Link') {
-          vscode.commands.executeCommand('mini-browser.openUrl', endpoint.url);
+          vscode.commands.executeCommand('simpleBrowser.show', endpoint.url);
         } else if (resultShow && resultShow.title === 'Open In New Tab') {
           vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(endpoint.url));
         }


### PR DESCRIPTION
### What does this PR do?
Fixes 'Open in Preview' action for the `Endpoints` panel

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->

https://github.com/eclipse-che/che/issues/23015

### How to test this PR?
- see `Steps to reproduce` section of the issue: https://github.com/eclipse-che/che/issues/23015
- see a short demo:

https://github.com/che-incubator/che-code/assets/5676062/07004b26-79b7-46e4-ab63-bf8d8ab4b02e


### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED
