### PR TITLE
fix: Fix build for ppc64le platform

### DIFF
--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -103,39 +103,45 @@ RUN ./node_modules/.bin/gulp compile-extension:vscode-api-tests \
 
 # Compile test suites
 # https://github.com/microsoft/vscode/blob/cdde5bedbf3ed88f93b5090bb3ed9ef2deb7a1b4/test/integration/browser/README.md#compile
-RUN [[ $(uname -m) == "x86_64" ]] && yarn --cwd test/smoke compile && yarn --cwd test/integration/browser compile
+RUN if [ "$(uname -m)" = "x86_64" ]; then yarn --cwd test/smoke compile && yarn --cwd test/integration/browser compile; fi
 
 # install test dependencies
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
-RUN [[ $(uname -m) == "x86_64" ]] &&  yarn playwright-install 
+RUN if [ "$(uname -m)" = "x86_64" ]; then yarn playwright-install; fi
 # Install procps to manage to kill processes and centos stream repository
-RUN [[ $(uname -m) == "x86_64" ]] && \
-    ARCH=$(uname -m) && \
-    yum install --nobest -y procps \
-        https://vault.centos.org/centos/8/extras/${ARCH}/os/Packages/epel-release-8-11.el8.noarch.rpm \
-        https://vault.centos.org/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm \
-        https://vault.centos.org/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+      ARCH=$(uname -m) && \
+      yum install --nobest -y procps \
+          https://vault.centos.org/centos/8/extras/${ARCH}/os/Packages/epel-release-8-11.el8.noarch.rpm \
+          https://vault.centos.org/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm \
+          https://vault.centos.org/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm; \
+    fi
 
-RUN [[ $(uname -m) == "x86_64" ]] \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
-    && yum install -y chromium \
-    && PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) \
-    && rm "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" \
-    && ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+      sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+      && yum install -y chromium \
+      && PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) \
+      && rm "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" \
+      && ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"; \
+    fi
 
 # use of retry and timeout
 COPY /build/scripts/helper/retry.sh /opt/app-root/src/retry.sh
 RUN chmod u+x /opt/app-root/src/retry.sh
 
 # Run integration tests (Browser)
-RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
-    VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
-    /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m ./scripts/test-web-integration.sh --browser chromium
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+      NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+      VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
+      /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m ./scripts/test-web-integration.sh --browser chromium; \
+    fi
 
 # Run smoke tests (Browser)
-RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
-    VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
-    /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+      NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+      VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
+      /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"; \
+    fi
 
 # Do not change line below! It is used to cut this section to skip tests
 ### Ending of tests

--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -42,6 +42,9 @@ RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
     && { if [[ $(uname -m) == "x86_64" ]]; then LIBKEYBOARD="\
       https://vault.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/libxkbfile-1.1.0-1.el8.x86_64.rpm \
       https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/libxkbfile-devel-1.1.0-1.el8.x86_64.rpm"; \
+    elif [[ $(uname -m) == "ppc64le" ]]; then LIBKEYBOARD="\
+      https://vault.centos.org/8-stream/AppStream/ppc64le/os/Packages/libxkbfile-1.1.0-1.el8.ppc64le.rpm \
+      https://vault.centos.org/8-stream/PowerTools/ppc64le/os/Packages/libxkbfile-devel-1.1.0-1.el8.ppc64le.rpm"; \
     elif [[ $(uname -m) == "aarch64" ]]; then LIBKEYBOARD="\
       https://vault.centos.org/centos/8-stream/AppStream/aarch64/os/Packages/libxkbfile-1.1.0-1.el8.aarch64.rpm \
       https://vault.centos.org/centos/8-stream/PowerTools/aarch64/os/Packages/libxkbfile-devel-1.1.0-1.el8.aarch64.rpm"; \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -42,6 +42,9 @@ RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
     && { if [[ $(uname -m) == "x86_64" ]]; then LIBKEYBOARD="\
       https://rpmfind.net/linux/centos-stream/9-stream/AppStream/x86_64/os/Packages/libxkbfile-1.1.0-8.el9.x86_64.rpm \
       https://rpmfind.net/linux/centos-stream/9-stream/CRB/x86_64/os/Packages/libxkbfile-devel-1.1.0-8.el9.x86_64.rpm"; \
+    elif [[ $(uname -m) == "ppc64le" ]]; then LIBKEYBOARD="\
+      https://rpmfind.net/linux/centos-stream/9-stream/AppStream/ppc64le/os/Packages/libxkbfile-1.1.0-8.el9.ppc64le.rpm \
+      https://rpmfind.net/linux/centos-stream/9-stream/CRB/ppc64le/os/Packages/libxkbfile-devel-1.1.0-8.el9.ppc64le.rpm"; \
     elif [[ $(uname -m) == "aarch64" ]]; then LIBKEYBOARD="\
       https://rpmfind.net/linux/centos-stream/9-stream/AppStream/aarch64/os/Packages/libxkbfile-1.1.0-8.el9.aarch64.rpm \
       https://rpmfind.net/linux/centos-stream/9-stream/CRB/aarch64/os/Packages/libxkbfile-devel-1.1.0-8.el9.aarch64.rpm"; \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -104,37 +104,44 @@ RUN ./node_modules/.bin/gulp compile-extension:vscode-api-tests \
 
 # # Compile test suites
 # https://github.com/microsoft/vscode/blob/cdde5bedbf3ed88f93b5090bb3ed9ef2deb7a1b4/test/integration/browser/README.md#compile
-RUN [[ $(uname -m) == "x86_64" ]] && yarn --cwd test/smoke compile && yarn --cwd test/integration/browser compile
+RUN if [ "$(uname -m)" = "x86_64" ]; then yarn --cwd test/smoke compile && yarn --cwd test/integration/browser compile; fi
 
 # install test dependencies
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
-RUN [[ $(uname -m) == "x86_64" ]] &&  yarn playwright-install 
+RUN if [ "$(uname -m)" = "x86_64" ]; then yarn playwright-install; fi
 # Install procps to manage to kill processes and centos stream repository
-RUN [[ $(uname -m) == "x86_64" ]] && \
-    ARCH=$(uname -m) && \
-    yum install --nobest -y procps \
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+      ARCH=$(uname -m) && \
+      yum install --nobest -y procps \
         https://rpmfind.net/linux/epel/9/Everything/${ARCH}/Packages/e/epel-release-9-7.el9.noarch.rpm \
         https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-23.el9.noarch.rpm \
-        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-23.el9.noarch.rpm
+        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-23.el9.noarch.rpm; \
+    fi
 
-RUN [[ $(uname -m) == "x86_64" ]] && yum install -y chromium && \
-    PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) && \
-    rm "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" && \
-    ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"
+RUN if [ "$(uname -m)" = "x86_64" ]; then \ 
+      yum install -y chromium && \
+      PLAYWRIGHT_CHROMIUM_PATH=$(echo /opt/app-root/src/.cache/ms-playwright/chromium-*/) && \
+      rm "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome" && \
+      ln -s /usr/bin/chromium-browser "${PLAYWRIGHT_CHROMIUM_PATH}/chrome-linux/chrome"; \
+    fi
 
 # use of retry and timeout
 COPY /build/scripts/helper/retry.sh /opt/app-root/src/retry.sh
 RUN chmod u+x /opt/app-root/src/retry.sh
 
 # Run integration tests (Browser)
-RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
-    VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
-    /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m ./scripts/test-web-integration.sh --browser chromium
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+      NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+      VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
+      /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m ./scripts/test-web-integration.sh --browser chromium; \
+    fi
 
 # Run smoke tests (Browser)
-RUN [[ $(uname -m) == "x86_64" ]] && NODE_ARCH=$(echo "console.log(process.arch)" | node) \
-    VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
-    /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+      NODE_ARCH=$(echo "console.log(process.arch)" | node) \
+      VSCODE_REMOTE_SERVER_PATH="$(pwd)/../vscode-reh-web-linux-${NODE_ARCH}" \
+      /opt/app-root/src/retry.sh -v -t 3 -s 2 -- timeout -v 5m yarn smoketest-no-compile --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"; \
+    fi
 
 # Do not change line below! It is used to cut this section to skip tests
 ### Ending of tests


### PR DESCRIPTION
### What does this PR do?
Fixes podman/docker build for `ppc64le` platform

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/22998

### How to test this PR?
Run podman/docker build for `ubi8` and `ubi9` assemblies.
See https://github.com/che-incubator/che-code?tab=readme-ov-file#image-build

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED
