### PR TITLE
Add dummy changes for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # che-code
 
+Test changes
 Deploy `Code-OSS` (https://github.com/microsoft/vscode) on a Kubernetes cluster and connect with your Browser.
 
 This repository is hosting the changes to have the `Code-OSS` running inside a browser and connecting to a remote HTTP(s) server (instead of using desktop mode).

--- a/code/extensions/che-api/src/extension.ts
+++ b/code/extensions/che-api/src/extension.ts
@@ -31,7 +31,7 @@ import { Logger } from './logger';
 
 
 export async function activate(_extensionContext: vscode.ExtensionContext): Promise<Api> {
-
+    // dummy changes for testing 
     const container = new Container();
     container.bind(K8sDevfileServiceImpl).toSelf().inSingletonScope();
     container.bind(DevfileService).to(K8sDevfileServiceImpl).inSingletonScope();


### PR DESCRIPTION
### What does this PR do?
Adds dummy changes to check Smoke test.
There is an error:
```
[18:07:14] Wait for Dev Workspace operator ready [started]
[18:09:35] Wait for Dev Workspace operator ready [failed]
[18:09:35] → ERR_TIMEOUT: Timeout set to pod ready timeout 120000
[18:09:35] Install Dev Workspace operator [failed]
[18:09:35] → ERR_TIMEOUT: Timeout set to pod ready timeout 120000
[18:09:35] Deploy Eclipse Che operator [failed]
[18:09:35] → ERR_TIMEOUT: Timeout set to pod ready timeout 120000
Error: Command server:deploy failed with the error: ERR_TIMEOUT: Timeout set to pod ready timeout 120000 See details: /home/runner/.cache/chectl/error.log. Eclipse Che logs: /tmp/chectl-logs/1720202774722.
    at newError (/usr/local/lib/chectl/lib/utils/utls.js:39:19)
    at wrapCommandError (/usr/local/lib/chectl/lib/utils/command-utils.js:54:32)
    at Deploy.<anonymous> (/usr/local/lib/chectl/lib/commands/server/deploy.js:82:65)
    at Generator.throw (<anonymous>)
    at rejected (/usr/local/lib/chectl/node_modules/tslib/tslib.js:167:69)
Cause: Error: ERR_TIMEOUT: Timeout set to pod ready timeout 120000
    at KubeClient.<anonymous> (/usr/local/lib/chectl/lib/api/kube-client.js:826:19)
    at Generator.next (<anonymous>)
    at fulfilled (/usr/local/lib/chectl/node_modules/tslib/tslib.js:166:62)
Error: Process completed with exit code 2.
```

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

