### PR TITLE
fix: keep projects when restarting the workspace from local devfile

### DIFF
--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -33,7 +33,8 @@
     "vscode-nls": "^5.0.0",
     "axios": "1.6.0",
     "@eclipse-che/che-devworkspace-generator": "7.86.0",
-    "https": "^1.0.0"
+    "https": "^1.0.0",
+    "js-yaml": "^4.0.0"
   },
   "devDependencies": {
     "jest": "27.3.1",

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -209,18 +209,11 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   try {
     let projects: V1alpha2DevWorkspaceSpecTemplateProjects[] | undefined = devfileContext.devWorkspace.spec!.template!.projects;
     if (!projects || projects.length === 0) {
-      projects = [];
-  
       const flattenedDevfileContent = await fs.readFile(process.env.DEVWORKSPACE_FLATTENED_DEVFILE!, 'utf8');
       const flattenedDevfile = jsYaml.load(flattenedDevfileContent) as any;
-
       if (flattenedDevfile.projects) {
-        for (const project of flattenedDevfile.projects) {
-          projects.push(project);
-        }
+        devfileContext.devWorkspace.spec!.template!.projects = flattenedDevfile.projects;
       }
-  
-      devfileContext.devWorkspace.spec!.template!.projects = projects;
     }
   } catch (error) {
     await vscode.window.showErrorMessage(`Failed to read Devfile. ${error}`);

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -187,20 +187,11 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
   console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
 
-  // let devfileContent: string;
-  // try {
-  //   devfileContent = await fs.readFile(devfilePath, "utf-8");
-  // } catch (error) {
-  //   await vscode.window.showErrorMessage(`Failed to read Devfile. ${error}`);
-  //   return false;
-  // }
-  
   let devfileContext: DevfileContext | undefined = undefined;
   try {
     devfileContext = await devWorkspaceGenerator.generateDevfileContext(
       {
         devfilePath,
-        // devfileContent,
         editorContent: EDITOR_CONTENT_STUB,
         pluginRegistryUrl,
         projects: []
@@ -214,58 +205,25 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
     return false;
   }
 
-  // if new devfile context does not contain project, add the existing one
+  // if new Devfile does not contain project, copy them from the flattened Devfile
   try {
     let projects: V1alpha2DevWorkspaceSpecTemplateProjects[] | undefined = devfileContext.devWorkspace.spec!.template!.projects;
     if (!projects || projects.length === 0) {
       projects = [];
   
       const flattenedDevfileContent = await fs.readFile(process.env.DEVWORKSPACE_FLATTENED_DEVFILE!, 'utf8');
-      console.log(flattenedDevfileContent);
       const flattenedDevfile = jsYaml.load(flattenedDevfileContent) as any;
-      console.log('>>>>> devfile has been parsed successfully');
 
       if (flattenedDevfile.projects) {
-        console.log('>>>>> here1');
-
         for (const project of flattenedDevfile.projects) {
-          console.log(`  > adding project [${project.name}]`);
           projects.push(project);
-
-          const ps = JSON.stringify(project, null, '\t');
-          console.log('>> Project: ', '\n', ps);
         }
       }
-
-      // - git:
-      //     remotes:
-      //       origin: https://github.com/che-incubator/che-code.git
-      //   name: che-code
-
-      // projects.push({
-      //   name: 'che-code',
-      //   git: {
-      //     remotes: {
-      //       "origin": "https://github.com/che-incubator/che-code.git"
-      //     }
-      //   }
-      // });
   
       devfileContext.devWorkspace.spec!.template!.projects = projects;
     }
-  
   } catch (error) {
     await vscode.window.showErrorMessage(`Failed to read Devfile. ${error}`);
-    return false;
-  }
-
-  const serialized = JSON.stringify(devfileContext, null, '\t');
-  await vscode.workspace.openTextDocument({
-    content: serialized
-  });
-
-  const permit = await vscode.window.showInformationMessage('Review the devfile and permit the reboot', 'Continue');
-  if (permit !== 'Continue') {
     return false;
   }
 

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -205,7 +205,7 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
     return false;
   }
 
-  // if new Devfile does not contain project, copy them from the flattened Devfile
+  // if a new Devfile does not contain projects, copy them from flattened Devfile
   try {
     let projects: V1alpha2DevWorkspaceSpecTemplateProjects[] | undefined = devfileContext.devWorkspace.spec!.template!.projects;
     if (!projects || projects.length === 0) {

--- a/code/package.json
+++ b/code/package.json
@@ -27,7 +27,7 @@
     "watch-client": "node --max-old-space-size=4095 ./node_modules/gulp/bin/gulp.js watch-client",
     "watch-clientd": "deemon yarn watch-client",
     "kill-watch-clientd": "deemon --kill yarn watch-client",
-    "watch-extensions": "node --max-old-space-size=6143 ./node_modules/gulp/bin/gulp.js watch-extensions watch-extension-media",
+    "watch-extensions": "node --max-old-space-size=4095 ./node_modules/gulp/bin/gulp.js watch-extensions watch-extension-media",
     "watch-extensionsd": "deemon yarn watch-extensions",
     "kill-watch-extensionsd": "deemon --kill yarn watch-extensions",
     "precommit": "node build/hygiene.js",

--- a/code/package.json
+++ b/code/package.json
@@ -27,7 +27,7 @@
     "watch-client": "node --max-old-space-size=4095 ./node_modules/gulp/bin/gulp.js watch-client",
     "watch-clientd": "deemon yarn watch-client",
     "kill-watch-clientd": "deemon --kill yarn watch-client",
-    "watch-extensions": "node --max-old-space-size=4095 ./node_modules/gulp/bin/gulp.js watch-extensions watch-extension-media",
+    "watch-extensions": "node --max-old-space-size=6143 ./node_modules/gulp/bin/gulp.js watch-extensions watch-extension-media",
     "watch-extensionsd": "deemon yarn watch-extensions",
     "kill-watch-extensionsd": "deemon --kill yarn watch-extensions",
     "precommit": "node build/hygiene.js",


### PR DESCRIPTION
### What does this PR do?


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23014

### How to test this PR?
- create workspace from https://github.com/Nykredit/openshift-test/tree/single_root but use the editor image provided by this PR
- once worksace created, open the terminal and check for `PROJECTS_ROOT` and `PROJECT_SOURCE` environment variables
- restart workspace from local devfile
- open the terminal again and check for the variables. Their values should be unshanged
- ensure the color theme is kept

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
