### PR TITLE
fix: highlight errors when updating devfile

### DIFF
--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -197,7 +197,7 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
         projects: []
       }, axiosInstance);
   } catch (error) {
-    const action = await vscode.window.showErrorMessage('Failed to generate new Devfile.', {
+    const action = await vscode.window.showErrorMessage('Failed to generate new Devfile Context.', {
       modal: true,
       detail: error.message
     }, 'Open Devfile');

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -185,7 +185,7 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   }
 
   const pluginRegistryUrl = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
-  console.info(`Using ${pluginRegistryUrl} to generate a new Devfile Context`);
+  console.info(`Using ${pluginRegistryUrl} to generate new Devfile Context`);
 
   let devfileContext: DevfileContext | undefined = undefined;
   try {
@@ -197,7 +197,11 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
         projects: []
       }, axiosInstance);
   } catch (error) {
-    const action = await vscode.window.showErrorMessage(`Failed to update Devfile. ${error}`, 'Open Devfile');
+    const action = await vscode.window.showErrorMessage('Failed to generate new Devfile.', {
+      modal: true,
+      detail: error.message
+    }, 'Open Devfile');
+
     if ('Open Devfile' === action) {
       const document = await vscode.workspace.openTextDocument(devfilePath);
       await vscode.window.showTextDocument(document);
@@ -220,6 +224,25 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
     return false;
   }
 
-  await devfileService.updateDevfile(devfileContext.devWorkspace.spec?.template);
+  try {
+    await devfileService.updateDevfile(devfileContext.devWorkspace.spec?.template);
+  } catch (error) {
+    if (error.body && error.body.message) {
+      const action = await vscode.window.showErrorMessage('Failed to update Devfile.', {
+        modal: true,
+        detail: error.body.message
+      }, 'Open Devfile');
+
+      if ('Open Devfile' === action) {
+        const document = await vscode.workspace.openTextDocument(devfilePath);
+        await vscode.window.showTextDocument(document);
+      }
+    } else {
+      vscode.window.showErrorMessage(`Failed to update Devfile. ${error}`);
+    }
+
+    return false;
+  }
+
   return true;
 }


### PR DESCRIPTION
### What does this PR do?
- Improves generating the new devworkspace object from a devfile
- Improves updating the devworkpace object
- uses modal messages instead of notifications to avoid the long messages being truncated 

![Screenshot from 2024-07-22 11-11-24](https://github.com/user-attachments/assets/6edaf22b-b34e-4fb1-b44a-7d84e2427931)

![Screenshot from 2024-07-19 14-26-53](https://github.com/user-attachments/assets/27947323-5a52-460a-8f4f-8fbcd7883114)

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23031

### How to test this PR?
- using the editor image from this PR, create a workspace from any github repository that contains a devfile ( https://github.com/vitaliy-guliy/vscode-test-extension/tree/test-sh-terminal for instance )
- add the following environment variable to the container and restart the workpace from local devfile
```
      env:
        - name: test
          value: false
```
- remove the changes above, add the following command and event, restart the workspace from local devfile
```
commands:

  - id: test
    exec:
      component: dev
      workingDir: ${PROJECTS_ROOT}/che-code
      commandLine: |
        echo test

events:
  preStart:
    - test
```

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
