### PR TITLE
Fix Ide not showing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,0 @@
-podman build -f build/dockerfiles/linux-musl.Dockerfile -t linux-musl-amd64 .
-podman build -f build/dockerfiles/linux-libc-ubi8.Dockerfile -t linux-libc-ubi8-amd64 .
-podman build -f build/dockerfiles/linux-libc-ubi9.Dockerfile -t linux-libc-ubi9-amd64 .
-podman build -f build/dockerfiles/assembly.Dockerfile -t harbor.weebo.fr/batleforc/che-code:latest .
-podman push harbor.weebo.fr/batleforc/che-code:latest

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+podman build -f build/dockerfiles/linux-musl.Dockerfile -t linux-musl-amd64 .
+podman build -f build/dockerfiles/linux-libc-ubi8.Dockerfile -t linux-libc-ubi8-amd64 .
+podman build -f build/dockerfiles/linux-libc-ubi9.Dockerfile -t linux-libc-ubi9-amd64 .
+podman build -f build/dockerfiles/assembly.Dockerfile -t harbor.weebo.fr/batleforc/che-code:latest .
+podman push harbor.weebo.fr/batleforc/che-code:latest

--- a/launcher/src/local-storage-key-provider.ts
+++ b/launcher/src/local-storage-key-provider.ts
@@ -61,7 +61,7 @@ export class LocalStorageKeyProvider {
 
     let secret = '';
     for (let i = 0; i < 32; i++) {
-      secret += content.charAt(i * 4);
+      secret += content.charAt(i * 2);
     }
 
     return secret;

--- a/launcher/src/local-storage-key-provider.ts
+++ b/launcher/src/local-storage-key-provider.ts
@@ -28,7 +28,6 @@ export class LocalStorageKeyProvider {
       console.log(`  > found key file ${publicKeyFile}`);
 
       const secret = await this.getPartOfPublicKey(publicKeyFile);
-      console.log(`  > secret: ${secret}`);
       await this.update(FILE_WORKBENCH, SERVER_KEY_MASK, secret);
     } catch (err) {
       console.error(err.message);

--- a/launcher/src/local-storage-key-provider.ts
+++ b/launcher/src/local-storage-key-provider.ts
@@ -28,6 +28,7 @@ export class LocalStorageKeyProvider {
       console.log(`  > found key file ${publicKeyFile}`);
 
       const secret = await this.getPartOfPublicKey(publicKeyFile);
+      console.log(`  > secret: ${secret}`);
       await this.update(FILE_WORKBENCH, SERVER_KEY_MASK, secret);
     } catch (err) {
       console.error(err.message);
@@ -57,7 +58,7 @@ export class LocalStorageKeyProvider {
 
   async getPartOfPublicKey(file: string): Promise<string> {
     let content = await fs.readFile(file);
-    content = content.substring(content.indexOf(' ') + 1);
+    content = content.split(' ')[1];
 
     let secret = '';
     for (let i = 0; i < 32; i++) {

--- a/launcher/tests/local-storage-key-provider.spec.ts
+++ b/launcher/tests/local-storage-key-provider.spec.ts
@@ -19,6 +19,10 @@ const NEW_WORKBENCH_FILE = `
 some code, some code, a mask to be replaced 1234567890ABCDEFGHIJKLMNOPQRSTUV, some code
 `;
 
+const NEW_WORKBENCH_FILE_NEW_LINE = `
+some code, some code, a mask to be replaced ACaZNAIlQqHJOA2XM, some code
+`;
+
 describe('Test setting of Local Storage public key to VS Code', () => {
   beforeEach(() => {
     Object.assign(fs, {
@@ -69,5 +73,48 @@ describe('Test setting of Local Storage public key to VS Code', () => {
     await localStorageKeyProvider.configure();
 
     expect(writeFileMock).toBeCalledWith('out/vs/code/browser/workbench/workbench.js', NEW_WORKBENCH_FILE);
+  });
+
+  test('should work with a public key including new lines', async () => {
+    const pathExistsMock = jest.fn();
+    const readdirMock = jest.fn();
+    const isFileMock = jest.fn();
+    const readFileMock = jest.fn();
+    const writeFileMock = jest.fn();
+    Object.assign(fs, {
+      pathExists: pathExistsMock,
+      readdir: readdirMock,
+      isFile: isFileMock,
+      readFile: readFileMock,
+      writeFile: writeFileMock,
+    });
+
+    pathExistsMock.mockImplementation(async (path: string) => {
+      return '/etc/ssh' === path || '/etc/ssh/first-key.pub' === path;
+    });
+
+    readdirMock.mockImplementation(async (path: string) => {
+      return ['some-file', 'first-key', 'second-key', 'first-key.pub', 'second-key.pub'];
+    });
+
+    isFileMock.mockImplementation(async (path: string) => {
+      return '/etc/ssh/first-key' === path || '/etc/ssh/first-key.pub' === path;
+    });
+
+    readFileMock.mockImplementation(async (file: string) => {
+      switch (file) {
+        case '/etc/ssh/first-key.pub':
+          // This key has new lines, and was randomly generated for this test
+          return `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIObHl2pRQsoCqvF7HrrUJwPcOByIAOtS2ggoX51xMWAQ eclipse@che.com
+          `;
+        case 'out/vs/code/browser/workbench/workbench.js':
+          return ORIGIN_WORKBENCH_FILE;
+      }
+    });
+
+    const localStorageKeyProvider = new LocalStorageKeyProvider();
+    await localStorageKeyProvider.configure();
+
+    expect(writeFileMock).toBeCalledWith('out/vs/code/browser/workbench/workbench.js', NEW_WORKBENCH_FILE_NEW_LINE);
   });
 });

--- a/launcher/tests/local-storage-key-provider.spec.ts
+++ b/launcher/tests/local-storage-key-provider.spec.ts
@@ -16,11 +16,11 @@ some code, some code, a mask to be replaced {{LOCAL-STORAGE}}/{{SECURE-KEY}}, so
 `;
 
 const NEW_WORKBENCH_FILE = `
-some code, some code, a mask to be replaced 1234567890ABCDEFGHIJKLMNOPQRSTUV, some code
+some code, some code, a mask to be replaced 11223344556677889900AABBCCDDEEFF, some code
 `;
 
 const NEW_WORKBENCH_FILE_NEW_LINE = `
-some code, some code, a mask to be replaced ACaZNAIlQqHJOA2XM, some code
+some code, some code, a mask to be replaced AACNa1ZINEAAIblpQoqFHrJPOyAt2gX1, some code
 `;
 
 describe('Test setting of Local Storage public key to VS Code', () => {


### PR DESCRIPTION
### What does this PR do?

It try to fix the case where the Public key injected for the extension contain a newline by only keeping the part of the pubkey that is indeed the key

I ATM can't build the ide in local, the build process stay stuck for like 30 minute 

### What issues does this PR fix?

https://github.com/eclipse-che/che/issues/23055

### How to test this PR?

1. Add priv/pub ssh key with a newline at the end (automatically added when used with fluxCD ?)
2. Start a Workspace, if the IDE show itself it's good to go

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
