### PR TITLE
fix: apply .bashrc when running a task

### DIFF
--- a/code/extensions/che-terminal/src/machine-exec-client.ts
+++ b/code/extensions/che-terminal/src/machine-exec-client.ts
@@ -139,8 +139,7 @@ export class MachineExecClient implements vscode.Disposable {
 	 */
 	async createTerminalSession(component: string, commandLine?: string, workdir?: string, columns: number = 80, rows: number = 24): Promise<TerminalSession> {
 		if (commandLine) {
-			const bashrc = join(env.HOME!, '.bashrc');
-			commandLine = `test -f ${bashrc} >> /dev/null 2>&1 && source ${bashrc};${commandLine}`;
+			commandLine = "test -f ${HOME}/.bashrc >> /dev/null 2>&1 && source ${HOME}/.bashrc >> /dev/null 2>&1;" + commandLine;
 		}
 
 		const createTerminalSessionCall = {

--- a/code/extensions/che-terminal/src/machine-exec-client.ts
+++ b/code/extensions/che-terminal/src/machine-exec-client.ts
@@ -16,6 +16,8 @@ import * as vscode from 'vscode';
 import * as WS from 'ws';
 import { WebSocket } from 'ws';
 import { getOutputChannel } from './extension';
+import { env } from 'process';
+import { join } from 'path';
 
 /** Client for the machine-exec server. */
 export class MachineExecClient implements vscode.Disposable {
@@ -136,6 +138,11 @@ export class MachineExecClient implements vscode.Disposable {
 	 * @returns a TerminalSession object to manage the created terminal session
 	 */
 	async createTerminalSession(component: string, commandLine?: string, workdir?: string, columns: number = 80, rows: number = 24): Promise<TerminalSession> {
+		if (commandLine) {
+			const bashrc = join(env.HOME!, '.bashrc');
+			commandLine = `test -f ${bashrc} >> /dev/null 2>&1 && source ${bashrc};${commandLine}`;
+		}
+
 		const createTerminalSessionCall = {
 			identifier: {
 				machineName: component

--- a/code/extensions/che-terminal/src/machine-exec-client.ts
+++ b/code/extensions/che-terminal/src/machine-exec-client.ts
@@ -16,8 +16,6 @@ import * as vscode from 'vscode';
 import * as WS from 'ws';
 import { WebSocket } from 'ws';
 import { getOutputChannel } from './extension';
-import { env } from 'process';
-import { join } from 'path';
 
 /** Client for the machine-exec server. */
 export class MachineExecClient implements vscode.Disposable {


### PR DESCRIPTION
### What does this PR do?
This is alternative to https://github.com/che-incubator/che-code/pull/383

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23009

### How to test this PR?

- create a workspace using following
   repository https://github.com/vitaliy-guliy/vscode-test-extension/tree/test-sh-terminal
   editor [quay.io/che-incubator-pull-requests/che-code:pr-395-amd64](https://quay.io/che-incubator-pull-requests/che-code:pr-395-amd64)

- launch test tasks to check the variables for `tools` and `mongo` containers

- check PATH environment variable

The variable seems to be different because of different .bashrs files in both containers.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
