### PR TITLE
Override the ssh-askpass.sh script from the git extension to respect the workspace ssh key

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -84,3 +84,9 @@ https://github.com/che-incubator/che-code/pull/353
 
 - code/src/vs/server/node/extensionHostConnection.ts
 ---
+
+#### @vinokurig
+https://github.com/che-incubator/che-code/pull/400
+
+- code/extensions/git/src/ssh-askpass.sh
+---

--- a/code/extensions/git/src/ssh-askpass.sh
+++ b/code/extensions/git/src/ssh-askpass.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
-VSCODE_GIT_ASKPASS_PIPE=`mktemp`
-ELECTRON_RUN_AS_NODE="1" VSCODE_GIT_ASKPASS_PIPE="$VSCODE_GIT_ASKPASS_PIPE" VSCODE_GIT_ASKPASS_TYPE="ssh" "$VSCODE_GIT_ASKPASS_NODE" "$VSCODE_GIT_ASKPASS_MAIN" $VSCODE_GIT_ASKPASS_EXTRA_ARGS $*
-cat $VSCODE_GIT_ASKPASS_PIPE
-rm $VSCODE_GIT_ASKPASS_PIPE
+# see https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#configuring-devworkspaces-to-use-ssh-keys-for-git-operations
+cat /etc/ssh/passphrase

--- a/rebase.sh
+++ b/rebase.sh
@@ -314,6 +314,17 @@ apply_code_src_vs_code_browser_workbench_workbench_changes() {
   git add code/src/vs/code/browser/workbench/workbench.ts > /dev/null 2>&1
 }
 
+# Apply changes on code/extensions/git/src/ssh-askpass.sh file
+apply_code_extensions_git_src_ssh-askpass_changes() {
+
+  echo "  ⚙️ reworking code/extensions/git/src/ssh-askpass.sh..."
+  # reset the file from local
+  git checkout --ours code/extensions/git/src/ssh-askpass.sh > /dev/null 2>&1
+
+  # resolve the change
+  git add code/extensions/git/src/ssh-askpass.sh > /dev/null 2>&1
+}
+
 # Apply changes for the given file
 apply_changes() {
   local filePath="$1"
@@ -371,6 +382,8 @@ resolve_conflicts() {
       apply_code_vs_workbench_contrib_webview_browser_pre_index_no_csp_html_changes
     elif [[ "$conflictingFile" == "code/src/vs/code/browser/workbench/workbench.ts" ]]; then
       apply_code_src_vs_code_browser_workbench_workbench_changes
+    elif [[ "$conflictingFile" == "code/extensions/git/src/ssh-askpass.sh" ]]; then
+      apply_code_extensions_git_src_ssh-askpass_changes
     elif [[ "$conflictingFile" == "code/src/vs/base/common/product.ts" ]]; then
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts" ]]; then


### PR DESCRIPTION
### What does this PR do?
Override the `ssh-askpass.sh` script from the `git` extension to read the passphrase mounted to workspace by the ssh secret.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/devfile/devworkspace-operator/issues/1295

### How to test this PR?
1. [Add an ssh key secret](https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#configuring-devworkspaces-to-use-ssh-keys-for-git-operations)
2. Start a workspace from the [sample repository](https://github.com/vinokurig/test.git). The repository contains a devfile with a project source of the ssh url and `DISPLAY` environment variable. The env variable is needed to invoke the ssh askpass script flow. This variable will be added as permanent in the upcoming DWO pull request.
3. Try any git operation with remote using the git extension, e.g. `Git: Pull`

See: the command executes without asking the ssh passphrase.
### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
