### PR TITLE
fix: remove trailing slash from metrics server endpoint

### DIFF
--- a/code/extensions/che-resource-monitor/src/resource-monitor.ts
+++ b/code/extensions/che-resource-monitor/src/resource-monitor.ts
@@ -24,8 +24,8 @@ export class ResourceMonitor {
   @inject(K8sHelper)
   private k8sHelper!: K8sHelper;
 
-  private METRICS_SERVER_ENDPOINT = '/apis/metrics.k8s.io/v1beta1/';
-  private METRICS_REQUEST_URL = `${this.METRICS_SERVER_ENDPOINT}namespaces/`;
+  private METRICS_SERVER_ENDPOINT = '/apis/metrics.k8s.io/v1beta1';
+
   private WARNING_COLOR = '#FFCC00';
   private DEFAULT_COLOR = '#FFFFFF';
   private DEFAULT_TOOLTIP = 'Workspace resources';
@@ -121,9 +121,8 @@ export class ResourceMonitor {
   }
 
   async getMetrics(): Promise<Container[]> {
-    const requestURL = `${this.METRICS_REQUEST_URL}${this.namespace}/pods/${this.podName}`;
-    const opts = { url: this.METRICS_SERVER_ENDPOINT };
-    const response = await this.k8sHelper.sendRawQuery(requestURL, opts);
+    const requestURL = `${this.METRICS_SERVER_ENDPOINT}/namespaces/${this.namespace}/pods/${this.podName}`;
+    const response = await this.k8sHelper.sendRawQuery(requestURL, { url: this.METRICS_SERVER_ENDPOINT });
 
     if (response.statusCode !== 200) {
       // wait when workspace pod's metrics will be available

--- a/code/extensions/che-resource-monitor/src/units-converter.ts
+++ b/code/extensions/che-resource-monitor/src/units-converter.ts
@@ -16,18 +16,18 @@ export function convertToBytes(unit: string | undefined): number {
   if (!unit) {
     return 0;
   }
-  if (unit.substr(unit.length - 2).toUpperCase() === 'MI') {
-    return fromMebibytes(parseInt(unit.substr(0, unit.length - 2)));
-  } else if (unit.substr(unit.length - 2).toUpperCase() === 'KI') {
-    return fromKibibytes(parseInt(unit.substr(0, unit.length - 2)));
-  } else if (unit.substr(unit.length - 2).toUpperCase() === 'GI') {
-    return fromGibibytes(parseInt(unit.substr(0, unit.length - 2)));
-  } else if (unit.substr(unit.length - 1).toUpperCase() === 'M') {
-    return fromMegabytes(parseInt(unit.substr(0, unit.length - 1)));
-  } else if (unit.substr(unit.length - 1).toUpperCase() === 'K') {
-    return fromKilobytes(parseInt(unit.substr(0, unit.length - 1)));
-  } else if (unit.substr(unit.length - 1).toUpperCase() === 'G') {
-    return fromGigabytes(parseInt(unit.substr(0, unit.length - 1)));
+  if (unit.substring(unit.length - 2).toUpperCase() === 'MI') {
+    return fromMebibytes(parseInt(unit.substring(0, unit.length - 2)));
+  } else if (unit.substring(unit.length - 2).toUpperCase() === 'KI') {
+    return fromKibibytes(parseInt(unit.substring(0, unit.length - 2)));
+  } else if (unit.substring(unit.length - 2).toUpperCase() === 'GI') {
+    return fromGibibytes(parseInt(unit.substring(0, unit.length - 2)));
+  } else if (unit.substring(unit.length - 1).toUpperCase() === 'M') {
+    return fromMegabytes(parseInt(unit.substring(0, unit.length - 1)));
+  } else if (unit.substring(unit.length - 1).toUpperCase() === 'K') {
+    return fromKilobytes(parseInt(unit.substring(0, unit.length - 1)));
+  } else if (unit.substring(unit.length - 1).toUpperCase() === 'G') {
+    return fromGigabytes(parseInt(unit.substring(0, unit.length - 1)));
   } else {
     return parseInt(unit);
   }
@@ -66,6 +66,7 @@ export function convertToMilliCPU(unit: string | undefined): number {
     return parseInt(unit.substring(0, unit.length - 1));
   } else if (unit.substring(unit.length - 1).toUpperCase() === 'N') {
     const value = parseInt(unit.substring(0, unit.length - 1));
+    // convert nanoCPU to miliCPU
     return Math.round(value / 1000 / 1000);
   } else {
     return parseInt(unit) * 1000;

--- a/code/extensions/che-resource-monitor/src/units-converter.ts
+++ b/code/extensions/che-resource-monitor/src/units-converter.ts
@@ -66,7 +66,7 @@ export function convertToMilliCPU(unit: string | undefined): number {
     return parseInt(unit.substring(0, unit.length - 1));
   } else if (unit.substring(unit.length - 1).toUpperCase() === 'N') {
     const value = parseInt(unit.substring(0, unit.length - 1));
-    return Math.round(value / 1000);
+    return Math.round(value / 1000 / 1000);
   } else {
     return parseInt(unit) * 1000;
   }

--- a/code/extensions/che-resource-monitor/src/units-converter.ts
+++ b/code/extensions/che-resource-monitor/src/units-converter.ts
@@ -61,8 +61,12 @@ export function convertToMilliCPU(unit: string | undefined): number {
   if (!unit) {
     return 0;
   }
-  if (unit.substr(unit.length - 1).toUpperCase() === 'M') {
-    return parseInt(unit.substr(0, unit.length - 1));
+
+  if (unit.substring(unit.length - 1).toUpperCase() === 'M') {
+    return parseInt(unit.substring(0, unit.length - 1));
+  } else if (unit.substring(unit.length - 1).toUpperCase() === 'N') {
+    const value = parseInt(unit.substring(0, unit.length - 1));
+    return Math.round(value / 1000);
   } else {
     return parseInt(unit) * 1000;
   }


### PR DESCRIPTION
### What does this PR do?
- makes resource monitor working on the dogfooding cluster
- displays properly CPU usage for dev sandbox

![Screenshot from 2024-08-16 17-34-29](https://github.com/user-attachments/assets/b9137ae7-f864-4a30-9cff-f1ca8c15dada)

![Screenshot from 2024-08-16 17-43-42](https://github.com/user-attachments/assets/511c3ee8-e17f-4485-93fb-4446166767c9)

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23044
https://github.com/eclipse-che/che/issues/23066

### How to test this PR?
Using the editor image from this PR, create a workspace on the dogfooding and then on the developer sandbox instances.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
