### PR TITLE
fix: load static webview resources with the editor from the same domain

### DIFF
--- a/launcher/src/webview-resources.ts
+++ b/launcher/src/webview-resources.ts
@@ -28,8 +28,8 @@ export class WebviewResources {
   async configure(): Promise<void> {
     console.log('# Configuring Webview Resources location...');
 
-    if ('true' !== env.WEBVIEW_LOCAL_RESOURCES) {
-      console.log(`  > env.WEBVIEW_LOCAL_RESOURCES is not set to 'true', skip this step`);
+    if (env.WEBVIEW_LOCAL_RESOURCES !== undefined && 'false' === env.WEBVIEW_LOCAL_RESOURCES) {
+      console.log(`  > env.WEBVIEW_LOCAL_RESOURCES is set to 'false', skip this step`);
       return;
     }
 


### PR DESCRIPTION
### What does this PR do?

Normally, Visual Studio Code loads the webview static resources from a CDN.

After merging this PR the webview static resources in Che-Code ( there are several files https://github.com/che-incubator/che-code/tree/main/code/src/vs/workbench/contrib/webview/browser/pre  ) will be loaded from the same location as the editor ( from the same host ).

Before, we added an option for turning this feature on for instances that are behind a proxy.

Probably something related to the cross-domain policy has been changed in the upstream (but I cannot say for sure) and it brought us some isues with handling the webview events. If the webview scripts are loaded from the same host as the editor, the events are not blocked, so loading everything from one place is the cheapest way to fix the problem.

The feature is still configurable. It can be turned off by defining `WEBVIEW_LOCAL_RESOURCES=false` environment variable for tooling container. But this thing could be discussed. To not confuse the user we can give up using the `WEBVIEW_LOCAL_RESOURCES` variable at all.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/22986

### How to test this PR?
1. Any workspace
- create a workspace using the editor image from this pull request
- preview any README that has a hyperlink
- click the link
2. Ansible sample
- create a workspace using the ansible sample with applying the editor image from this pull request
- Openshift welcome page should be opened automatically. Scroll down a bit and click on buttons. Clicking must work.
- Go to Ansible view, click `Get started` and in the appeared `Ansible content creator` tab check that clicking on the links works. 

It would be nice to open any walkthrough that has a markdown (display the content on the right) and check that clicking works as well.

![Screenshot from 2024-09-09 11-00-45](https://github.com/user-attachments/assets/1754d704-7c50-472e-b64c-e17928349788)

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
