### PR TITLE
fix: update epel (Extra Packages for Enterprise Linux)

### DIFF
--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -113,7 +113,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then yarn playwright-install; fi
 RUN if [ "$(uname -m)" = "x86_64" ]; then \
       ARCH=$(uname -m) && \
       yum install --nobest -y procps \
-        https://rpmfind.net/linux/epel/9/Everything/${ARCH}/Packages/e/epel-release-9-7.el9.noarch.rpm \
+        https://rpmfind.net/linux/epel/9/Everything/${ARCH}/Packages/e/epel-release-9-8.el9.noarch.rpm \
         https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-23.el9.noarch.rpm \
         https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-23.el9.noarch.rpm; \
     fi


### PR DESCRIPTION
### What does this PR do?
Fixes building of che-code ubi9 image for amd64 platform.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23137

### How to test this PR?
- take che-code image built by a PR check on this pull request and create a workspace using python sample
- ensure the editor work
- open `/checode/entrypoint-logs.txt`, ensure ubi9 is used

![Screenshot from 2024-09-10 16-23-55](https://github.com/user-attachments/assets/dfbad4f8-34ff-42f3-9908-6d717e0a36be)

### !Pay attention

Failed smoke test is not related to changes in this PR.

![selection_008](https://github.com/user-attachments/assets/6e475029-f3e6-4618-9ba3-13a4e9b9fea5)


### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
