### PR TITLE
fix: load static webview resources with the editor from the same domain

### DIFF
--- a/launcher/src/webview-resources.ts
+++ b/launcher/src/webview-resources.ts
@@ -28,8 +28,8 @@ export class WebviewResources {
   async configure(): Promise<void> {
     console.log('# Configuring Webview Resources location...');
 
-    if ('true' !== env.WEBVIEW_LOCAL_RESOURCES) {
-      console.log(`  > env.WEBVIEW_LOCAL_RESOURCES is not set to 'true', skip this step`);
+    if (env.WEBVIEW_LOCAL_RESOURCES !== undefined && 'false' === env.WEBVIEW_LOCAL_RESOURCES) {
+      console.log(`  > env.WEBVIEW_LOCAL_RESOURCES is set to 'false', skip this step`);
       return;
     }
 


### PR DESCRIPTION
### What does this PR do?
Cherry-pick of https://github.com/che-incubator/che-code/pull/411

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/22986

### How to test this PR?

See original PR for details

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
