### PR TITLE
chore: revert back pull request #396

### DIFF
--- a/code/extensions/che-api/extension.webpack.config.js
+++ b/code/extensions/che-api/extension.webpack.config.js
@@ -16,7 +16,6 @@
 
 const withDefaults = require('../shared.webpack.config');
 const webpack = require('webpack');
-const { merge } = require('webpack-merge');
 
 const config = withDefaults({
     context: __dirname,
@@ -34,16 +33,3 @@ const config = withDefaults({
         new webpack.ContextReplacementPlugin(/keyv/), // needs to exclude the package to ignore warnings https://github.com/jaredwray/keyv/issues/45
     ],
 });
-
-module.exports = merge(config, {
-    module: {
-        rules: [
-            {
-                test: /\.m?js$/,
-                resolve: {
-                    fullySpecified: false, // This avoids the issue with the devfile/api extension requirement
-                },
-            }
-        ]
-    }
-})

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -29,7 +29,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@devfile/api": "^2.3.0-1723034342",
+    "@devfile/api": "^2.2.0-alpha-1641413790",
     "axios": "^1.7.4",
     "@kubernetes/client-node": "^0.22.0",
     "fs-extra": "^11.2.0",

--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -34,7 +34,7 @@
     "fs-extra": "^11.2.0",
     "vscode-nls": "^5.0.0",
     "js-yaml": "^4.1.0",
-    "@devfile/api": "^2.3.0-1723034342"
+    "@devfile/api": "^2.2.0-alpha-1641413790"
   },
   "devDependencies": {
     "jest": "27.3.1",

--- a/code/extensions/che-github-authentication/extension.webpack.config.js
+++ b/code/extensions/che-github-authentication/extension.webpack.config.js
@@ -16,7 +16,6 @@
 
 const withDefaults = require('../shared.webpack.config');
 const webpack = require('webpack');
-const { merge } = require('webpack-merge');
 
 const config = withDefaults({
     context: __dirname,
@@ -34,16 +33,3 @@ const config = withDefaults({
         new webpack.ContextReplacementPlugin(/keyv/), // needs to exclude the package to ignore warnings https://github.com/jaredwray/keyv/issues/45
     ],
 });
-
-module.exports = merge(config, {
-    module: {
-        rules: [
-            {
-                test: /\.m?js$/,
-                resolve: {
-                    fullySpecified: false, // This avoids the issue with the devfile/api extension requirement
-                },
-            }
-        ]
-    }
-})

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "inversify": "^6.0.2",
-    "@devfile/api": "^2.3.0-1723034342",
+    "@devfile/api": "^2.2.0-alpha-1641413790",
     "@kubernetes/client-node": "^0.22.0",
     "uuid": "8.1.0",
     "@vscode/extension-telemetry": "0.7.5",

--- a/code/extensions/che-port/package.json
+++ b/code/extensions/che-port/package.json
@@ -33,7 +33,7 @@
     "reflect-metadata": "^0.2.2",
     "fs-extra": "^11.2.0",
     "vscode-nls": "^5.0.0",
-    "@devfile/api": "^2.3.0-1723034342"
+    "@devfile/api": "^2.2.0-alpha-1641413790"
   },
   "devDependencies": {
     "jest": "27.3.1",

--- a/code/extensions/che-port/src/devfile-handler-devworkspace-impl.ts
+++ b/code/extensions/che-port/src/devfile-handler-devworkspace-impl.ts
@@ -17,7 +17,7 @@ import { EndpointCategory } from './endpoint-category';
 import { EndpointExposure } from './endpoint-exposure';
 import {
   V1alpha2DevWorkspaceSpecTemplate,
-  V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEndpointsExposureEnum
+  V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEndpoints
 } from '@devfile/api';
 import * as vscode from 'vscode';
 
@@ -56,13 +56,11 @@ export class DevWorkspaceDevfileHandlerImpl implements DevfileHandler {
       )
       .reduce((acc, val) => acc.concat(val), []);
 
-    const publicExposureEndpoint: V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEndpointsExposureEnum = 'public';
-    const internalExposureEndpoint: V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEndpointsExposureEnum = 'internal';
     const endpoints = devfileEndpoints.map(exposedEndpoint => {
       let exposure: EndpointExposure;
-      if (exposedEndpoint.exposure === publicExposureEndpoint) {
+      if (exposedEndpoint.exposure === V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEndpoints.ExposureEnum.Public) {
         exposure = EndpointExposure.FROM_DEVFILE_PUBLIC;
-      } else if (exposedEndpoint.exposure === internalExposureEndpoint) {
+      } else if (exposedEndpoint.exposure === V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEndpoints.ExposureEnum.Internal) {
         exposure = EndpointExposure.FROM_DEVFILE_PRIVATE;
       } else {
         exposure = EndpointExposure.FROM_DEVFILE_NONE;

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "vscode-nls": "^5.0.0",
     "axios": "^1.7.4",
-    "@eclipse-che/che-devworkspace-generator": "7.90.0-1a2253f",
+    "@eclipse-che/che-devworkspace-generator": "7.88.0-next-a2e5c63",
     "https": "^1.0.0",
     "js-yaml": "^4.0.0"
   },

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -30,7 +30,7 @@
     "lint:fix": "eslint --fix --cache=true --no-error-on-unmatched-pattern=true \"{src,tests}/**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@devfile/api": "^2.3.0-1723034342",
+    "@devfile/api": "^2.2.0-alpha-1641413790",
     "@kubernetes/client-node": "^0.22.0",
     "got": "11.8.0",
     "inversify": "^6.0.2",


### PR DESCRIPTION
### What does this PR do?

It is a temporary solution.
Reverts back https://github.com/che-incubator/che-code/pull/396 as it become not possible to run che-code in the development mode

![Screenshot from 2024-09-25 15-23-36](https://github.com/user-attachments/assets/0bf6cfa6-cb83-4c81-9cd6-bd48c8bf7348)


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
Part of https://github.com/eclipse-che/che/issues/23163

### How to test this PR?
- create a PR from che-code repository
- update node dependencies, compile and then run che-code

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
