### PR TITLE
Add commands for alignment che-code with upstream

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -97,3 +97,32 @@ commands:
         podman build -f build/dockerfiles/assembly.libc.Dockerfile -t che-code .
       group:
         kind: run
+  - id: install-git-subtree
+    exec:
+      label: Install git-subtree
+      component: dev
+      workingDir: ${PROJECTS_ROOT}
+      commandLine: |
+        mkdir temp && cd temp
+        git clone https://github.com/git/git.git
+        cd git/contrib/subtree
+        make && make prefix=${PROJECTS_ROOT}/temp install
+        cp -r ${PROJECTS_ROOT}/temp/libexec/git-core/ ~/bin
+        rm -rf ${PROJECTS_ROOT}/temp
+  - id: add-remote-upstream
+    exec:
+      label: Add remote for upstream
+      component: dev
+      workingDir: ${PROJECTS_ROOT}/che-code
+      commandLine: |
+        git remote add upstream-code https://github.com/microsoft/vscode
+        
+  - id: fetch-upstream-changes
+    exec:
+      label: Fetch upstream changes
+      component: dev
+      workingDir: ${PROJECTS_ROOT}/che-code
+      commandLine: |
+        git stash save --include-untracked
+        git fetch upstream-code main
+        ./rebase.sh


### PR DESCRIPTION
### What does this PR do?
Add commands to the devfile to help with alignment che-code with upstream

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/22578

### How to test this PR?
1. Start a workspace with che-code
2. Terminal => Run Task => devfile => Install git-subtree
3. Terminal => Run Task => devfile => Add remote for upstream
4. Terminal => Run Task => devfile => Fetch upstream changes

As result you can get the following state:
- che-code is up to date with upstream
or
- there are conflicts that should be resolved manually

Both states are expected - as it's depends on the current state of che-code and vscode repos.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
