### PR TITLE
Bump dompurify from 3.0.5 to 3.1.3 for 7.92.x

### DIFF
--- a/code/extensions/markdown-language-features/package.json
+++ b/code/extensions/markdown-language-features/package.json
@@ -764,7 +764,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.0",
-    "dompurify": "^3.0.5",
+    "dompurify": "^3.1.3",
     "highlight.js": "^11.8.0",
     "markdown-it": "^12.3.2",
     "markdown-it-front-matter": "^0.2.4",

--- a/code/extensions/markdown-language-features/yarn.lock
+++ b/code/extensions/markdown-language-features/yarn.lock
@@ -248,10 +248,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.5.tgz#eb3d9cfa10037b6e73f32c586682c4b2ab01fbed"
-  integrity sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A==
+dompurify@^3.1.3:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
+  integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
 
 domutils@^3.0.1:
   version "3.1.0"


### PR DESCRIPTION
### What does this PR do?
See https://github.com/che-incubator/che-code/pull/433

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
