### PR TITLE
Bump jsonpath-plus to 10.0.1

### DIFF
--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -49,7 +49,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.0"
+    "jsonpath-plus": "10.0.1"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-api/yarn.lock
+++ b/code/extensions/che-api/yarn.lock
@@ -2258,10 +2258,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@10.0.0, jsonpath-plus@^9.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz#7a747d47e20a27867dbbc80b57fd554788b91474"
-  integrity sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==
+jsonpath-plus@10.0.1, jsonpath-plus@^9.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.1.tgz#a61f4dc6c7489955af0872b0956cc42fbbacb5ab"
+  integrity sha512-30DeH2QD4nL1IpDLPIFz09G5XyLvh+oNMUI2Zxf4tbrlsVHs0e3VPnwpOnSTFb4yM0dfQK2WGKLsSaAS8V62rw==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -67,7 +67,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.0"
+    "jsonpath-plus": "10.0.1"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-github-authentication/yarn.lock
+++ b/code/extensions/che-github-authentication/yarn.lock
@@ -780,10 +780,10 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-jsonpath-plus@10.0.0, jsonpath-plus@^9.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz#7a747d47e20a27867dbbc80b57fd554788b91474"
-  integrity sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==
+jsonpath-plus@10.0.1, jsonpath-plus@^9.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.1.tgz#a61f4dc6c7489955af0872b0956cc42fbbacb5ab"
+  integrity sha512-30DeH2QD4nL1IpDLPIFz09G5XyLvh+oNMUI2Zxf4tbrlsVHs0e3VPnwpOnSTFb4yM0dfQK2WGKLsSaAS8V62rw==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"
@@ -1034,6 +1034,7 @@ stream-buffers@^3.0.2:
   integrity sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1052,6 +1053,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     strip-ansi "^7.0.1"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -48,7 +48,7 @@
     "yarn": "^1.22.18"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.0"
+    "jsonpath-plus": "10.0.1"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-resource-monitor/yarn.lock
+++ b/code/extensions/che-resource-monitor/yarn.lock
@@ -2371,10 +2371,10 @@ json5@2.x, json5@^2.2.3:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonpath-plus@10.0.0, jsonpath-plus@^9.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz#7a747d47e20a27867dbbc80b57fd554788b91474"
-  integrity sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==
+jsonpath-plus@10.0.1, jsonpath-plus@^9.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.1.tgz#a61f4dc6c7489955af0872b0956cc42fbbacb5ab"
+  integrity sha512-30DeH2QD4nL1IpDLPIFz09G5XyLvh+oNMUI2Zxf4tbrlsVHs0e3VPnwpOnSTFb4yM0dfQK2WGKLsSaAS8V62rw==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"


### PR DESCRIPTION
### What does this PR do?
Bump jsonpath-plus to 10.0.1

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED
