### PR TITLE
Bump jsonpath-plus to 10.1.0 for 7.92.x

### DIFF
--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -49,7 +49,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.1"
+    "jsonpath-plus": "10.0.3"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -49,7 +49,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.3"
+    "jsonpath-plus": "10.0.5"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -49,7 +49,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.5"
+    "jsonpath-plus": "10.1.0"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-api/yarn.lock
+++ b/code/extensions/che-api/yarn.lock
@@ -2258,10 +2258,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@10.0.1, jsonpath-plus@^9.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.1.tgz#a61f4dc6c7489955af0872b0956cc42fbbacb5ab"
-  integrity sha512-30DeH2QD4nL1IpDLPIFz09G5XyLvh+oNMUI2Zxf4tbrlsVHs0e3VPnwpOnSTFb4yM0dfQK2WGKLsSaAS8V62rw==
+jsonpath-plus@10.0.3, jsonpath-plus@^9.0.0:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.3.tgz#c147259e1a0410d32b57d0d002263446abda0de9"
+  integrity sha512-d35qqWROJnJqZrwptBJZfNPfKZwJtD0eZdXKYHhJu7gDBMsGUo6mUXevK7Zzu/Lz1jpjCF7l6btyHHt5DSoreg==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-api/yarn.lock
+++ b/code/extensions/che-api/yarn.lock
@@ -2258,10 +2258,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@10.0.5, jsonpath-plus@^9.0.0:
-  version "10.0.5"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.5.tgz#0451b818c96f7654db99af9548f7084cbda37a78"
-  integrity sha512-it8kRSK9fdAhauC5ik86kBWpIIdDrnMvre1b3IDKqApPwC48iYI2IRvhy88TB/MrtZfXIQOMTF5p0UHucZVveA==
+jsonpath-plus@10.1.0, jsonpath-plus@^9.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz#e8724c721ac60ff2db667066131b1a2c992ffcf0"
+  integrity sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-api/yarn.lock
+++ b/code/extensions/che-api/yarn.lock
@@ -2258,10 +2258,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@10.0.3, jsonpath-plus@^9.0.0:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.3.tgz#c147259e1a0410d32b57d0d002263446abda0de9"
-  integrity sha512-d35qqWROJnJqZrwptBJZfNPfKZwJtD0eZdXKYHhJu7gDBMsGUo6mUXevK7Zzu/Lz1jpjCF7l6btyHHt5DSoreg==
+jsonpath-plus@10.0.5, jsonpath-plus@^9.0.0:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.5.tgz#0451b818c96f7654db99af9548f7084cbda37a78"
+  integrity sha512-it8kRSK9fdAhauC5ik86kBWpIIdDrnMvre1b3IDKqApPwC48iYI2IRvhy88TB/MrtZfXIQOMTF5p0UHucZVveA==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -67,7 +67,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.5"
+    "jsonpath-plus": "10.1.0"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -67,7 +67,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.3"
+    "jsonpath-plus": "10.0.5"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -67,7 +67,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.1"
+    "jsonpath-plus": "10.0.3"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-github-authentication/yarn.lock
+++ b/code/extensions/che-github-authentication/yarn.lock
@@ -780,10 +780,10 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-jsonpath-plus@10.0.1, jsonpath-plus@^9.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.1.tgz#a61f4dc6c7489955af0872b0956cc42fbbacb5ab"
-  integrity sha512-30DeH2QD4nL1IpDLPIFz09G5XyLvh+oNMUI2Zxf4tbrlsVHs0e3VPnwpOnSTFb4yM0dfQK2WGKLsSaAS8V62rw==
+jsonpath-plus@10.0.3, jsonpath-plus@^9.0.0:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.3.tgz#c147259e1a0410d32b57d0d002263446abda0de9"
+  integrity sha512-d35qqWROJnJqZrwptBJZfNPfKZwJtD0eZdXKYHhJu7gDBMsGUo6mUXevK7Zzu/Lz1jpjCF7l6btyHHt5DSoreg==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-github-authentication/yarn.lock
+++ b/code/extensions/che-github-authentication/yarn.lock
@@ -780,10 +780,10 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-jsonpath-plus@10.0.5, jsonpath-plus@^9.0.0:
-  version "10.0.5"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.5.tgz#0451b818c96f7654db99af9548f7084cbda37a78"
-  integrity sha512-it8kRSK9fdAhauC5ik86kBWpIIdDrnMvre1b3IDKqApPwC48iYI2IRvhy88TB/MrtZfXIQOMTF5p0UHucZVveA==
+jsonpath-plus@10.1.0, jsonpath-plus@^9.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz#e8724c721ac60ff2db667066131b1a2c992ffcf0"
+  integrity sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-github-authentication/yarn.lock
+++ b/code/extensions/che-github-authentication/yarn.lock
@@ -780,10 +780,10 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-jsonpath-plus@10.0.3, jsonpath-plus@^9.0.0:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.3.tgz#c147259e1a0410d32b57d0d002263446abda0de9"
-  integrity sha512-d35qqWROJnJqZrwptBJZfNPfKZwJtD0eZdXKYHhJu7gDBMsGUo6mUXevK7Zzu/Lz1jpjCF7l6btyHHt5DSoreg==
+jsonpath-plus@10.0.5, jsonpath-plus@^9.0.0:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.5.tgz#0451b818c96f7654db99af9548f7084cbda37a78"
+  integrity sha512-it8kRSK9fdAhauC5ik86kBWpIIdDrnMvre1b3IDKqApPwC48iYI2IRvhy88TB/MrtZfXIQOMTF5p0UHucZVveA==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -48,7 +48,7 @@
     "yarn": "^1.22.18"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.3"
+    "jsonpath-plus": "10.0.5"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -48,7 +48,7 @@
     "yarn": "^1.22.18"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.5"
+    "jsonpath-plus": "10.1.0"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -48,7 +48,7 @@
     "yarn": "^1.22.18"
   },
   "resolutions": {
-    "jsonpath-plus": "10.0.1"
+    "jsonpath-plus": "10.0.3"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-resource-monitor/yarn.lock
+++ b/code/extensions/che-resource-monitor/yarn.lock
@@ -2371,10 +2371,10 @@ json5@2.x, json5@^2.2.3:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonpath-plus@10.0.1, jsonpath-plus@^9.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.1.tgz#a61f4dc6c7489955af0872b0956cc42fbbacb5ab"
-  integrity sha512-30DeH2QD4nL1IpDLPIFz09G5XyLvh+oNMUI2Zxf4tbrlsVHs0e3VPnwpOnSTFb4yM0dfQK2WGKLsSaAS8V62rw==
+jsonpath-plus@10.0.3, jsonpath-plus@^9.0.0:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.3.tgz#c147259e1a0410d32b57d0d002263446abda0de9"
+  integrity sha512-d35qqWROJnJqZrwptBJZfNPfKZwJtD0eZdXKYHhJu7gDBMsGUo6mUXevK7Zzu/Lz1jpjCF7l6btyHHt5DSoreg==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-resource-monitor/yarn.lock
+++ b/code/extensions/che-resource-monitor/yarn.lock
@@ -2371,10 +2371,10 @@ json5@2.x, json5@^2.2.3:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonpath-plus@10.0.5, jsonpath-plus@^9.0.0:
-  version "10.0.5"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.5.tgz#0451b818c96f7654db99af9548f7084cbda37a78"
-  integrity sha512-it8kRSK9fdAhauC5ik86kBWpIIdDrnMvre1b3IDKqApPwC48iYI2IRvhy88TB/MrtZfXIQOMTF5p0UHucZVveA==
+jsonpath-plus@10.1.0, jsonpath-plus@^9.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz#e8724c721ac60ff2db667066131b1a2c992ffcf0"
+  integrity sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"

--- a/code/extensions/che-resource-monitor/yarn.lock
+++ b/code/extensions/che-resource-monitor/yarn.lock
@@ -2371,10 +2371,10 @@ json5@2.x, json5@^2.2.3:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonpath-plus@10.0.3, jsonpath-plus@^9.0.0:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.3.tgz#c147259e1a0410d32b57d0d002263446abda0de9"
-  integrity sha512-d35qqWROJnJqZrwptBJZfNPfKZwJtD0eZdXKYHhJu7gDBMsGUo6mUXevK7Zzu/Lz1jpjCF7l6btyHHt5DSoreg==
+jsonpath-plus@10.0.5, jsonpath-plus@^9.0.0:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.5.tgz#0451b818c96f7654db99af9548f7084cbda37a78"
+  integrity sha512-it8kRSK9fdAhauC5ik86kBWpIIdDrnMvre1b3IDKqApPwC48iYI2IRvhy88TB/MrtZfXIQOMTF5p0UHucZVveA==
   dependencies:
     "@jsep-plugin/assignment" "^1.2.1"
     "@jsep-plugin/regex" "^1.0.3"


### PR DESCRIPTION
### What does this PR do?
Bump `jsonpath-plus` to `10.1.0` for `7.92.x`

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED
