### PR TITLE
Add warning message when tracker cannot ping machine-exec

### DIFF
--- a/code/extensions/che-activity-tracker/package.json
+++ b/code/extensions/che-activity-tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "che-activity-tracker",
-  "displayName": "che-activity-tracker",
-  "description": "",
+  "displayName": "Eclipse Che Activity Tracker",
+  "description": "Determines if current workspace should be idled",
   "publisher": "eclipse-che",
   "license": "EPL-2.0",
   "version": "0.0.1",

--- a/code/extensions/che-activity-tracker/src/activity-tracker-service.ts
+++ b/code/extensions/che-activity-tracker/src/activity-tracker-service.ts
@@ -85,7 +85,8 @@ export class ActivityTrackerService {
 				this.channel.appendLine('Activity tracker: Failed to ping che-machine-exec: ' + error.message);
 				if (!this.errorDisplayed) {
 					this.errorDisplayed = true;
-					this.showErrorMessage();
+					await this.showErrorMessage();
+					this.errorDisplayed = false;
 				}
 			}
 		}

--- a/code/extensions/che-activity-tracker/src/activity-tracker-service.ts
+++ b/code/extensions/che-activity-tracker/src/activity-tracker-service.ts
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
+import * as vscode from "vscode";
 
 export type WorkspaceService = { updateWorkspaceActivity: () => any };
 
@@ -28,13 +29,17 @@ export class ActivityTrackerService {
 	private isTimerRunning: boolean;
 	// Flag which is used to check if new requests were received during timer awaiting.
 	private isNewRequest: boolean;
-
+	// Flag used to keep track whether the ping error warning was already displayed or not.
+	private warningDisplayed: boolean;
 	private workspaceService: WorkspaceService;
+	private channel: vscode.OutputChannel;
 
-	constructor(workspaceService: WorkspaceService) {
+	constructor(workspaceService: WorkspaceService, channel: vscode.OutputChannel) {
 		this.isTimerRunning = false;
 		this.isNewRequest = false;
+		this.warningDisplayed = false;
 		this.workspaceService = workspaceService;
+		this.channel = channel;
 	}
 
 	/**
@@ -67,17 +72,82 @@ export class ActivityTrackerService {
 		}
 	}
 
-	private sendRequest(
-		attemptsLeft: number = ActivityTrackerService.RETRY_COUNT,
-	): void {
+	private async sendRequest(
+		attemptsLeft: number = ActivityTrackerService.RETRY_COUNT
+	): Promise<void> {
 		try {
-			this.workspaceService.updateWorkspaceActivity();
+			await this.workspaceService.updateWorkspaceActivity();
 		} catch (error) {
 			if (attemptsLeft > 0) {
-			  setTimeout(this.sendRequest, ActivityTrackerService.RETRY_REQUEST_PERIOD_MS, --attemptsLeft);
+				await new Promise((resolve) => setTimeout(resolve, ActivityTrackerService.RETRY_REQUEST_PERIOD_MS));
+				await this.sendRequest(--attemptsLeft);
 			} else {
-			  console.error('Activity tracker: Failed to ping che-machine-exec: ', error.message);
+				this.channel.appendLine('Activity tracker: Failed to ping che-machine-exec: ' + error.message);
+				if (!this.warningDisplayed) {
+					this.warningDisplayed = true;
+					this.showWarningMessage();
+				}
 			}
 		}
+	}
+
+	private async showWarningMessage(): Promise<void> {
+		const viewText = 'View Logs';
+		const response = await vscode.window.showWarningMessage(
+			this.getWarningMessage(),
+			viewText
+		);
+
+		if (response === viewText) {
+			this.channel.show();
+		}
+	}
+
+	private getWarningMessage(): string {
+
+		let message = 'Failed to communicate with idling service.';
+
+		const idletimeout = process.env.SECONDS_OF_DW_INACTIVITY_BEFORE_IDLING;
+		if (idletimeout) {
+			const timeoutInSeconds = parseInt(idletimeout);
+			if (!isNaN(timeoutInSeconds)) {
+				message += ` This development environment may automatically terminate in ${this.getTimeString(timeoutInSeconds)}.`;
+			}
+		} else {
+			message += ' This development environment may automatically terminate soon.';
+		}
+
+		message += ' For environments with the ephemeral storage type, you may lose any unsaved work. Please contact an administrator.'
+		return message;
+	}
+
+	private getTimeString(_seconds: number): string {
+		const hours = Math.floor(_seconds / 3600);
+		const minutes = Math.floor((_seconds % 3600) / 60);
+		const seconds = _seconds % 60;
+
+		let output = '';
+
+		if (hours > 0) {
+			output += `${hours} hour`;
+			if (hours > 1) {
+				output += 's';
+			}
+		}
+
+		if (minutes > 0) {
+			output += ` ${minutes} minute`;
+			if (minutes > 1) {
+				output += 's';
+			}
+		}
+
+		if (seconds > 0) {
+			output += ` ${seconds} second`;
+			if (seconds > 1) {
+				output += 's';
+			}
+		}
+		return output
 	}
 }

--- a/code/extensions/che-activity-tracker/src/activity-tracker-service.ts
+++ b/code/extensions/che-activity-tracker/src/activity-tracker-service.ts
@@ -30,14 +30,14 @@ export class ActivityTrackerService {
 	// Flag which is used to check if new requests were received during timer awaiting.
 	private isNewRequest: boolean;
 	// Flag used to keep track whether the ping error warning was already displayed or not.
-	private warningDisplayed: boolean;
+	private errorDisplayed: boolean;
 	private workspaceService: WorkspaceService;
 	private channel: vscode.OutputChannel;
 
 	constructor(workspaceService: WorkspaceService, channel: vscode.OutputChannel) {
 		this.isTimerRunning = false;
 		this.isNewRequest = false;
-		this.warningDisplayed = false;
+		this.errorDisplayed = false;
 		this.workspaceService = workspaceService;
 		this.channel = channel;
 	}
@@ -83,18 +83,18 @@ export class ActivityTrackerService {
 				await this.sendRequest(--attemptsLeft);
 			} else {
 				this.channel.appendLine('Activity tracker: Failed to ping che-machine-exec: ' + error.message);
-				if (!this.warningDisplayed) {
-					this.warningDisplayed = true;
-					this.showWarningMessage();
+				if (!this.errorDisplayed) {
+					this.errorDisplayed = true;
+					this.showErrorMessage();
 				}
 			}
 		}
 	}
 
-	private async showWarningMessage(): Promise<void> {
+	private async showErrorMessage(): Promise<void> {
 		const viewText = 'View Logs';
-		const response = await vscode.window.showWarningMessage(
-			this.getWarningMessage(),
+		const response = await vscode.window.showErrorMessage(
+			this.getErrorMessage(),
 			viewText
 		);
 
@@ -103,7 +103,7 @@ export class ActivityTrackerService {
 		}
 	}
 
-	private getWarningMessage(): string {
+	private getErrorMessage(): string {
 
 		let message = 'Failed to communicate with idling service.';
 

--- a/code/extensions/che-activity-tracker/src/extension.ts
+++ b/code/extensions/che-activity-tracker/src/extension.ts
@@ -13,6 +13,8 @@ import { ActivityTrackerService, WorkspaceService } from "./activity-tracker-ser
 
 export async function activate(context: vscode.ExtensionContext) {
 
+	const channel: vscode.OutputChannel = vscode.window.createOutputChannel('Che Activity Tracker');
+
 	const eventsToTrack = [
 		vscode.workspace.onDidChangeTextDocument,
 		vscode.window.onDidChangeActiveTextEditor,
@@ -22,13 +24,12 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.onDidChangeTerminalState,
 		vscode.window.onDidChangeActiveTerminal,
 	];
-
-	await track(eventsToTrack, context);
+	await track(eventsToTrack, channel, context);
 }
 
-async function track(events: vscode.Event<any>[], context: vscode.ExtensionContext) {
+async function track(events: vscode.Event<any>[], channel: vscode.OutputChannel, context: vscode.ExtensionContext) {
 	const workspaceService = await getWorkspaceService();
-	const activityTracker = new ActivityTrackerService(workspaceService);
+	const activityTracker = new ActivityTrackerService(workspaceService, channel);
 	events.forEach((e: vscode.Event<any>) => {
 		context.subscriptions.push(
 			e(async () => {


### PR DESCRIPTION
### What does this PR do?
This PR displays an error message to the user if the activity tracker extension fails to ping che-machine-exec. The activity tracker extension regularly pings che-machine-exec to prevent dev environment idling, therefore if the ping fails, this PR lets the user know that their workspace might idle.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
Fixes https://github.com/eclipse-che/che/issues/23134

### How to test this PR?

1. Create a workspace with the PR image as the editor URL
2. In the editor, run the following to terminate the che-machine-exec process:
```
// find machine-exec pid
ps -aux

kill -9 <pid>
```
3. Make any file edits in the editor.
4. Wait about 1 minute. After one minute, the error notification should appear:
![image](https://github.com/user-attachments/assets/564dba65-d275-4ce2-889b-47a7fb77d159)
5. Click on "View Logs" to view the error message in the extension's output:

![image](https://github.com/user-attachments/assets/38a7e319-17ed-4731-83db-b002283d211f)


### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
