### PR TITLE
Increase Che deployment timeout in PR check

### DIFF
--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -108,8 +108,8 @@ jobs:
           chectl server:deploy \
             --batch \
             --platform minikube \
-            --k8spodwaittimeout=120000 \
-            --k8spodreadytimeout=120000 \
+            --k8spodwaittimeout=480000 \
+            --k8spodreadytimeout=480000 \
             --che-operator-cr-patch-yaml "${GITHUB_WORKSPACE}/build/test/github-minikube-checluster-patch.yaml"
 
           #


### PR DESCRIPTION
### What does this PR do?
It fixes `Smoke Test / smoke-test` in the pull request check of this repo (thanks @tolusha for the investigation).

### What issues does this PR fix?
https://github.com/eclipse-che/che/issues/23206

### How to test this PR?
Make sure  `Smoke Test / smoke-test` in this PR has passed.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
