### PR TITLE
fix: Filter out init-ssh-agent from Che Code's Devfile task lists

### DIFF
--- a/code/extensions/che-commands/src/taskProvider.ts
+++ b/code/extensions/che-commands/src/taskProvider.ts
@@ -41,6 +41,7 @@ export class DevfileTaskProvider implements vscode.TaskProvider {
 				const importedByAttribute = (command.attributes as any)?.['controller.devfile.io/imported-by'];
 				return !command.attributes || importedByAttribute === undefined || importedByAttribute === 'parent';
 			})
+			.filter(command => !/^init-ssh-agent-command-\d+$/.test(command.id))
 			.map(command => this.createCheTask(command.exec?.label || command.id, command.exec?.commandLine!, command.exec?.workingDir || '${PROJECT_SOURCE}', command.exec?.component!, command.exec?.env));
 		return cheTasks;
 	}


### PR DESCRIPTION

### What does this PR do?
please see https://github.com/che-incubator/che-code/pull/445

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED
