### PR TITLE
Improve the ssh-askpass.sh script

### DIFF
--- a/.rebase/replace/code/extensions/git/src/ssh-askpass.sh.json
+++ b/.rebase/replace/code/extensions/git/src/ssh-askpass.sh.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "#!/bin/sh",
+    "by": "#!/bin/sh\\\nif [ -f /etc/ssh/passphrase ] && command -v ssh-keygen >/dev/null; then\\\n\\\tif ssh-keygen -y -P \"$(cat /etc/ssh/passphrase)\" -f /etc/ssh/dwo_ssh_key >/dev/null; then\\\n\\\t\\\tcat /etc/ssh/passphrase\\\n\\\t\\\texit 0\\\n\\\tfi\\\nfi"
+  }
+]

--- a/code/extensions/git/src/ssh-askpass.sh
+++ b/code/extensions/git/src/ssh-askpass.sh
@@ -1,3 +1,11 @@
 #!/bin/sh
-# see https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#configuring-devworkspaces-to-use-ssh-keys-for-git-operations
-cat /etc/ssh/passphrase
+if [ -f /etc/ssh/passphrase ] && command -v ssh-keygen >/dev/null; then
+  if ssh-keygen -y -P "$(cat /etc/ssh/passphrase)" -f /etc/ssh/dwo_ssh_key >/dev/null; then
+    cat /etc/ssh/passphrase
+    exit 0
+  fi
+fi
+VSCODE_GIT_ASKPASS_PIPE=`mktemp`
+ELECTRON_RUN_AS_NODE="1" VSCODE_GIT_ASKPASS_PIPE="$VSCODE_GIT_ASKPASS_PIPE" VSCODE_GIT_ASKPASS_TYPE="ssh" "$VSCODE_GIT_ASKPASS_NODE" "$VSCODE_GIT_ASKPASS_MAIN" $VSCODE_GIT_ASKPASS_EXTRA_ARGS $*
+cat $VSCODE_GIT_ASKPASS_PIPE
+rm $VSCODE_GIT_ASKPASS_PIPE

--- a/rebase.sh
+++ b/rebase.sh
@@ -316,8 +316,11 @@ apply_code_src_vs_code_browser_workbench_workbench_changes() {
 apply_code_extensions_git_src_ssh-askpass_changes() {
 
   echo "  ⚙️ reworking code/extensions/git/src/ssh-askpass.sh..."
-  # reset the file from local
-  git checkout --ours code/extensions/git/src/ssh-askpass.sh > /dev/null 2>&1
+  # reset the file from upstream
+  git checkout --theirs code/extensions/git/src/ssh-askpass.sh > /dev/null 2>&1
+
+  # apply the changes
+  apply_replace code/extensions/git/src/ssh-askpass.sh
 
   # resolve the change
   git add code/extensions/git/src/ssh-askpass.sh > /dev/null 2>&1


### PR DESCRIPTION
### What does this PR do?
Do the default vscode flow (get the passphrase from the inputbox) under next conditions:
* If the passphrase file is missing.
* If the passphrase is incorrect, for that we test the passphrase with the `ssh-keygen`.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
fixes https://github.com/eclipse-che/che/issues/23244

### How to test this PR?
see https://github.com/eclipse-che/che/issues/23244
### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
