### PR TITLE
fix: Align sha256 for the ms-vscode.js-debug extension with the open-vsx.org registry

### DIFF
--- a/code/product.json
+++ b/code/product.json
@@ -52,7 +52,7 @@
 		{
 			"name": "ms-vscode.js-debug",
 			"version": "1.95.2",
-			"sha256": "4f9236d20fa34c7f8310a482f4fb1eb89e7ee5e171438da101f5c97fcb0527d2",
+			"sha256": "c7db7b77787dcefbda15e0bcf43a456a4e4ac669c4a097b663664d94a48adce5",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
### What does this PR do?
Align sha256 for the ms-vscode.js-debug extension with the open-vsx.org registry

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23251

### How to test this PR?
PR checks should be happy

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
