### PR TITLE
feat: Add a setting that allows to control window header text separately from a window title

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
+#### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/456
+
+- code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+- code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+- code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+- code/src/vs/workbench/browser/workbench.contribution.ts
+---
+
 #### @benoitf @RomanNikitenko
 https://github.com/che-incubator/che-code/pull/379 \
 https://github.com/che-incubator/che-code/commit/d3cf7dc86d284bc4cdff7cc163c5642bb6744524#diff-36f85da944a1b6c01cb656687e520f7415d692e1b7d8856e2161db97a134b224

--- a/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts.json
@@ -1,0 +1,6 @@
+[
+	{
+		"from": "if (that._windowTitle.isCustomTitleFormat()) {",
+		"by": "const headerText = that._windowTitle.getHeaderText();\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tif (headerText) {\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\t\\\tlabel = headerText;\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\t} else if (that._windowTitle.isCustomTitleFormat()) {"
+	}
+]

--- a/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts.json
@@ -1,6 +1,6 @@
 [
 	{
 		"from": "if (that._windowTitle.isCustomTitleFormat()) {",
-		"by": "const headerText = that._windowTitle.getHeaderText();\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tif (headerText) {\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\t\\\tlabel = headerText;\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\t} else if (that._windowTitle.isCustomTitleFormat()) {"
+		"by": "const header = that._windowTitle.getHeader();\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\tif (header) {\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\t\\\tlabel = header;\\\n\\\t\\\t\\\t\\\t\\\t\\\t\\\t} else if (that._windowTitle.isCustomTitleFormat()) {"
 	}
 ]

--- a/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts.json
@@ -1,0 +1,6 @@
+[
+	{
+		"from": "this.title.innerText = this.windowTitle.value;",
+		"by": "this.title.innerText = this.windowTitle.getHeaderText() \\|\\| this.windowTitle.value;"
+	}
+]

--- a/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts.json
@@ -1,6 +1,6 @@
 [
 	{
 		"from": "this.title.innerText = this.windowTitle.value;",
-		"by": "this.title.innerText = this.windowTitle.getHeaderText() \\|\\| this.windowTitle.value;"
+		"by": "this.title.innerText = this.windowTitle.getHeader() \\|\\| this.windowTitle.value;"
 	}
 ]

--- a/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts.json
@@ -1,10 +1,10 @@
 [
 	{
 		"from": "title = 'window.title'",
-		"by": "title = 'window.title',\\\n\\\theaderText = 'window.headerText'"
+		"by": "title = 'window.title',\\\n\\\theader = 'window.header'"
 	},
 	{
 		"from": "isCustomTitleFormat(): boolean {",
-		"by": "getHeaderText(): string \\| undefined{\\\n\\\t\\\tconst header = this.configurationService.inspect<string>(WindowSettingNames.headerText);\\\n\\\t\\\treturn header.value;\\\n\\\t}\\\n\\\n\\\tisCustomTitleFormat(): boolean {"
+		"by": "getHeader(): string \\| undefined{\\\n\\\t\\\tconst header = this.configurationService.inspect<string>(WindowSettingNames.header);\\\n\\\t\\\treturn header.value;\\\n\\\t}\\\n\\\n\\\tisCustomTitleFormat(): boolean {"
 	}
 ]

--- a/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts.json
@@ -1,0 +1,10 @@
+[
+	{
+		"from": "title = 'window.title'",
+		"by": "title = 'window.title',\\\n\\\theaderText = 'window.headerText'"
+	},
+	{
+		"from": "isCustomTitleFormat(): boolean {",
+		"by": "getHeaderText(): string \\| undefined{\\\n\\\t\\\tconst header = this.configurationService.inspect<string>(WindowSettingNames.headerText);\\\n\\\t\\\treturn header.value;\\\n\\\t}\\\n\\\n\\\tisCustomTitleFormat(): boolean {"
+	}
+]

--- a/.rebase/replace/code/src/vs/workbench/browser/workbench.contribution.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/workbench.contribution.ts.json
@@ -5,6 +5,6 @@
 	},
 	{
 		"from": "'window.title': {",
-		"by": "'window.headerText': {\\\n\\\t\\\t\\\t\\\t'type': 'string',\\\n\\\t\\\t\\\t\\\t'markdownDescription': windowHeaderDescription\\\n\\\t\\\t\\\t},\\\n\\\t\\\t\\\t'window.title': {"
+		"by": "'window.header': {\\\n\\\t\\\t\\\t\\\t'type': 'string',\\\n\\\t\\\t\\\t\\\t'markdownDescription': windowHeaderDescription\\\n\\\t\\\t\\\t},\\\n\\\t\\\t\\\t'window.title': {"
 	}
 ]

--- a/.rebase/replace/code/src/vs/workbench/browser/workbench.contribution.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/workbench.contribution.ts.json
@@ -1,0 +1,10 @@
+[
+	{
+		"from": "\\/\\/ Window",
+		"by": "\\/\\/ Window\\\n\\\tconst windowHeaderDescription = 'Controls the window header';"
+	},
+	{
+		"from": "'window.title': {",
+		"by": "'window.headerText': {\\\n\\\t\\\t\\\t\\\t'type': 'string',\\\n\\\t\\\t\\\t\\\t'markdownDescription': windowHeaderDescription\\\n\\\t\\\t\\\t},\\\n\\\t\\\t\\\t'window.title': {"
+	}
+]

--- a/code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -181,9 +181,9 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 						private _getLabel(): string {
 							const { prefix, suffix } = that._windowTitle.getTitleDecorations();
 							let label = that._windowTitle.workspaceName;
-							const headerText = that._windowTitle.getHeaderText();
-							if (headerText) {
-								label = headerText;
+							const header = that._windowTitle.getHeader();
+							if (header) {
+								label = header;
 							} else if (that._windowTitle.isCustomTitleFormat()) {
 								label = that._windowTitle.getWindowTitle();
 							} else if (that._editorGroupService.partOptions.showTabs === 'none') {

--- a/code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -181,7 +181,10 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 						private _getLabel(): string {
 							const { prefix, suffix } = that._windowTitle.getTitleDecorations();
 							let label = that._windowTitle.workspaceName;
-							if (that._windowTitle.isCustomTitleFormat()) {
+							const headerText = that._windowTitle.getHeaderText();
+							if (headerText) {
+								label = headerText;
+							} else if (that._windowTitle.isCustomTitleFormat()) {
 								label = that._windowTitle.getWindowTitle();
 							} else if (that._editorGroupService.partOptions.showTabs === 'none') {
 								label = that._windowTitle.fileName ?? label;

--- a/code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -549,9 +549,9 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 		// Text Title
 		if (!this.isCommandCenterVisible) {
-			this.title.innerText = this.windowTitle.value;
+			this.title.innerText = this.windowTitle.getHeaderText() || this.windowTitle.value;
 			this.titleDisposables.add(this.windowTitle.onDidChange(() => {
-				this.title.innerText = this.windowTitle.value;
+				this.title.innerText = this.windowTitle.getHeaderText() || this.windowTitle.value;
 			}));
 		}
 

--- a/code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -549,9 +549,9 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 		// Text Title
 		if (!this.isCommandCenterVisible) {
-			this.title.innerText = this.windowTitle.getHeaderText() || this.windowTitle.value;
+			this.title.innerText = this.windowTitle.getHeader() || this.windowTitle.value;
 			this.titleDisposables.add(this.windowTitle.onDidChange(() => {
-				this.title.innerText = this.windowTitle.getHeaderText() || this.windowTitle.value;
+				this.title.innerText = this.windowTitle.getHeader() || this.windowTitle.value;
 			}));
 		}
 

--- a/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -32,7 +32,8 @@ import { CodeWindow } from '../../../../base/browser/window.js';
 
 const enum WindowSettingNames {
 	titleSeparator = 'window.titleSeparator',
-	title = 'window.title'
+	title = 'window.title',
+	headerText = 'window.headerText'
 }
 
 export const defaultWindowTitle = (() => {
@@ -387,5 +388,10 @@ export class WindowTitle extends Disposable {
 		const titleSeparator = this.configurationService.inspect<string>(WindowSettingNames.titleSeparator);
 
 		return title.value !== title.defaultValue || titleSeparator.value !== titleSeparator.defaultValue;
+	}
+
+	getHeaderText(): string | undefined{
+		const header = this.configurationService.inspect<string>(WindowSettingNames.headerText);
+		return header.value;
 	}
 }

--- a/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -383,15 +383,15 @@ export class WindowTitle extends Disposable {
 		});
 	}
 
+	getHeaderText(): string | undefined{
+		const header = this.configurationService.inspect<string>(WindowSettingNames.headerText);
+		return header.value;
+	}
+
 	isCustomTitleFormat(): boolean {
 		const title = this.configurationService.inspect<string>(WindowSettingNames.title);
 		const titleSeparator = this.configurationService.inspect<string>(WindowSettingNames.titleSeparator);
 
 		return title.value !== title.defaultValue || titleSeparator.value !== titleSeparator.defaultValue;
-	}
-
-	getHeaderText(): string | undefined{
-		const header = this.configurationService.inspect<string>(WindowSettingNames.headerText);
-		return header.value;
 	}
 }

--- a/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -33,7 +33,7 @@ import { CodeWindow } from '../../../../base/browser/window.js';
 const enum WindowSettingNames {
 	titleSeparator = 'window.titleSeparator',
 	title = 'window.title',
-	headerText = 'window.headerText'
+	header = 'window.header'
 }
 
 export const defaultWindowTitle = (() => {
@@ -383,8 +383,8 @@ export class WindowTitle extends Disposable {
 		});
 	}
 
-	getHeaderText(): string | undefined{
-		const header = this.configurationService.inspect<string>(WindowSettingNames.headerText);
+	getHeader(): string | undefined{
+		const header = this.configurationService.inspect<string>(WindowSettingNames.header);
 		return header.value;
 	}
 

--- a/code/src/vs/workbench/browser/workbench.contribution.ts
+++ b/code/src/vs/workbench/browser/workbench.contribution.ts
@@ -637,7 +637,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 	});
 
 	// Window
-	const windowHeaderDescription = "Controls the window header";
+	const windowHeaderDescription = 'Controls the window header';
 	let windowTitleDescription = localize('windowTitle', "Controls the window title based on the current context such as the opened workspace or active editor. Variables are substituted based on the context:");
 	windowTitleDescription += '\n- ' + [
 		localize('activeEditorShort', "`${activeEditorShort}`: the file name (e.g. myFile.txt)."),

--- a/code/src/vs/workbench/browser/workbench.contribution.ts
+++ b/code/src/vs/workbench/browser/workbench.contribution.ts
@@ -664,7 +664,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 	registry.registerConfiguration({
 		...windowConfigurationNodeBase,
 		'properties': {
-			'window.headerText': {
+			'window.header': {
 				'type': 'string',
 				'markdownDescription': windowHeaderDescription
 			},

--- a/code/src/vs/workbench/browser/workbench.contribution.ts
+++ b/code/src/vs/workbench/browser/workbench.contribution.ts
@@ -637,7 +637,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 	});
 
 	// Window
-
+	const windowHeaderDescription = "Controls the window header";
 	let windowTitleDescription = localize('windowTitle', "Controls the window title based on the current context such as the opened workspace or active editor. Variables are substituted based on the context:");
 	windowTitleDescription += '\n- ' + [
 		localize('activeEditorShort', "`${activeEditorShort}`: the file name (e.g. myFile.txt)."),
@@ -664,6 +664,10 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 	registry.registerConfiguration({
 		...windowConfigurationNodeBase,
 		'properties': {
+			'window.headerText': {
+				'type': 'string',
+				'markdownDescription': windowHeaderDescription
+			},
 			'window.title': {
 				'type': 'string',
 				'default': defaultWindowTitle,

--- a/rebase.sh
+++ b/rebase.sh
@@ -393,6 +393,14 @@ resolve_conflicts() {
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/code/browser/workbench/workbench.html" ]]; then
       apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/workbench.contribution.ts" ]]; then
+      apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/parts/titlebar/windowTitle.ts" ]]; then
+      apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts" ]]; then
+      apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts" ]]; then
+      apply_changes "$conflictingFile"
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"
       exit 1


### PR DESCRIPTION
### What does this PR do?
- Adds new setting `window.header` that allows to control window header text separately from a window title

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->

https://issues.redhat.com/browse/CRW-7258

### How to test this PR?
I'm going to provide an ability to apply editor configurations from a configmap within another PR: https://github.com/che-incubator/che-code/pull/460.
So, you have to do some actions manually to test the current PR changes:

- Start a workspace using editor image with the PR changes: `quay.io/che-incubator-pull-requests/che-code:pr-456-amd64` 
- `File` => `Open File` => `/projects/.code-workspace`
- Add the following content:
```
"settings": {
      "window.header": "SOME TEST HEADER MESSAGE"
}
```
- Refresh the page
- Check header message

<img width="1258" alt="Screenshot 2024-12-02 at 14 08 05" src="https://github.com/user-attachments/assets/8b697568-b77d-46e1-af3a-cc236108901e">

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
