### PR TITLE
fix: whitelist k8s service in no_proxy environment variable

### DIFF
--- a/code/extensions/che-api/src/extension.ts
+++ b/code/extensions/che-api/src/extension.ts
@@ -75,5 +75,7 @@ export async function activate(_extensionContext: vscode.ExtensionContext): Prom
 	_extensionContext.environmentVariableCollection.replace('WORKSPACE_NAMESPACE', workspaceNamespace);
 	_extensionContext.environmentVariableCollection.replace('PROJECTS_ROOT', projectsRoot);
 
+    await container.get(K8SServiceImpl).ensureKubernetesServiceHostWhitelisted();
+
     return api;
 }

--- a/code/extensions/che-api/src/impl/k8s-service-impl.ts
+++ b/code/extensions/che-api/src/impl/k8s-service-impl.ts
@@ -54,14 +54,11 @@ export class K8SServiceImpl implements K8SService {
           'Do you want to fix this and add the kubernetes service host to the no_proxy environment variable?', 'Add', 'Cancel');
 
         if ('Add' === action) {
-          if (env.NO_PROXY && env.no_proxy) {
-            env.NO_PROXY += ',' + k8sHost;
-            env.no_proxy += ',' + k8sHost;
-            console.log('Kubernetes Service Host has been added to env.NO_PROXY and env.no_proxy environment variables');
-          } else if (env.NO_PROXY) {
+          if (env.NO_PROXY) {
             env.NO_PROXY += ',' + k8sHost;
             console.log('Kubernetes Service Host has been added to env.NO_PROXY environment variable');
-          } else if (env.no_proxy) {
+          }
+          if (env.no_proxy) {
             env.no_proxy += ',' + k8sHost;
             console.log('Kubernetes Service Host has been added to env.no_proxy environment variable');
           }

--- a/code/extensions/che-api/src/impl/k8s-service-impl.ts
+++ b/code/extensions/che-api/src/impl/k8s-service-impl.ts
@@ -40,21 +40,31 @@ export class K8SServiceImpl implements K8SService {
 
   async ensureKubernetesServiceHostWhitelisted(): Promise<void> {
     const proxy = env.HTTPS_PROXY || env.HTTP_PROXY || env.https_proxy || env.http_proxy;
-    if (proxy && env.no_proxy && env.KUBERNETES_SERVICE_HOST) {
+    const noProxy = env.NO_PROXY || env.no_proxy;
+    if (proxy && noProxy && env.KUBERNETES_SERVICE_HOST) {
 
       // take k8s service host
       const k8sHost = env.KUBERNETES_SERVICE_HOST;
 
       // check whether it is set to no_proxy environment variable
-      const noProxy = env.no_proxy.split(',');
-      if (!noProxy.includes(k8sHost)) {
+      if (!noProxy.split(',').includes(k8sHost)) {
         const action = await vscode.window.showInformationMessage(
           'The cluster you are using is behind a proxy, but kubernetes service host is not whitelisted in no_proxy environment variable. ' +
           'This may cause the kubernetes service to be unaccessible. ' +
           'Do you want to fix this and add the kubernetes service host to the no_proxy environment variable?', 'Add', 'Cancel');
 
         if ('Add' === action) {
-          env.no_proxy += ',' + k8sHost;
+          if (env.NO_PROXY && env.no_proxy) {
+            env.NO_PROXY += ',' + k8sHost;
+            env.no_proxy += ',' + k8sHost;
+            console.log('Kubernetes Service Host has been added to env.NO_PROXY and env.no_proxy environment variables');
+          } else if (env.NO_PROXY) {
+            env.NO_PROXY += ',' + k8sHost;
+            console.log('Kubernetes Service Host has been added to env.NO_PROXY environment variable');
+          } else if (env.no_proxy) {
+            env.no_proxy += ',' + k8sHost;
+            console.log('Kubernetes Service Host has been added to env.no_proxy environment variable');
+          }
         }
       }
 


### PR DESCRIPTION
### What does this PR do?
For the clusters, that behind a proxy, checks whether kubernetes service host defined by `KUBERNETES_SERVICE_HOST` environment variable is added to `no_proxy` environment variable.
I it is not, user is warned with a proposal to fix that.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-7514

![Screenshot from 2024-11-25 15-57-22](https://github.com/user-attachments/assets/e7652c53-1fdb-452e-9e96-8f63beac14ce)

### How to test this PR?
- create a workspace with https://github.com/vitaliy-guliy/k8s-sample/tree/test_proxy_settings
- ensure the warning is appeared

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
