### PR TITLE
fix: keep devworkspace attributes when restarting from local devfile

### DIFF
--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -209,48 +209,34 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
     return false;
   }
 
+  let flattenedDevfile: any;
+
   try {
     const flattenedDevfileContent = await fs.readFile(process.env.DEVWORKSPACE_FLATTENED_DEVFILE!, 'utf8');
-    const flattenedDevfile = jsYaml.load(flattenedDevfileContent) as any;
-    
-    // if a new Devfile does not contain projects, copy them from flattened Devfile
-    let projects: V1alpha2DevWorkspaceSpecTemplateProjects[] | undefined = devfileContext.devWorkspace.spec!.template!.projects;
-    if ((!projects || projects.length === 0) && flattenedDevfile.projects) {
-      devfileContext.devWorkspace.spec!.template!.projects = flattenedDevfile.projects;
-    }
-
-    // keep spec.template.attributes
-    if (!devfileContext.devWorkspace.spec!.template!.attributes) {
-      await vscode.window.showInformationMessage('Copying spec.template.attributes...', {
-        modal: true
-      });
-
-      devfileContext.devWorkspace.spec!.template!.attributes = flattenedDevfile.attributes;
-    } else {
-      await vscode.window.showInformationMessage('Devworkspace attributes spec.template.attributes already defined.', {
-        modal: true
-      });
-    }
-
+    flattenedDevfile = jsYaml.load(flattenedDevfileContent) as any;
   } catch (error) {
     await vscode.window.showErrorMessage(`Failed to read Devfile. ${error}`);
     return false;
   }
 
-  const jsonStr = JSON.stringify(devfileContext, null, '  ');
-
-  const file = '/projects/.new-devfile-context.json';
-  if (await fs.pathExists(file)) {
-    await fs.remove(file);
+  try {
+    // if a new Devfile does not contain projects, copy them from flattened Devfile
+    let projects: V1alpha2DevWorkspaceSpecTemplateProjects[] | undefined = devfileContext.devWorkspace.spec!.template!.projects;
+    if ((!projects || projects.length === 0) && flattenedDevfile.projects) {
+      devfileContext.devWorkspace.spec!.template!.projects = flattenedDevfile.projects;
+    }
+  } catch (error) {
+    await vscode.window.showErrorMessage(`Failed to update DevWorkspace projects. ${error}`);
+    return false;
   }
 
-  await fs.writeFile(file, jsonStr);
-
-  const updateAction = await vscode.window.showInformationMessage('Do update devfile?', {
-    modal: true
-  }, 'Update');
-
-  if (updateAction !== 'Update') {
+  try {
+    // keep spec.template.attributes
+    if (!devfileContext.devWorkspace.spec!.template!.attributes) {
+      devfileContext.devWorkspace.spec!.template!.attributes = flattenedDevfile.attributes;
+    }
+  } catch (error) {
+    await vscode.window.showErrorMessage(`Failed to update DevWorkspace attributes. ${error}`);
     return false;
   }
 


### PR DESCRIPTION
### What does this PR do?
- Persists devworkspace attributes when restarting the workspace from local devfile.

- Prevents appearing `claim-devworkspace` PVC wen restarting the workspace from local devfile.
![Screenshot from 2024-12-09 15-41-35](https://github.com/user-attachments/assets/e40aa280-ce9c-4b00-a13c-440a7b01efe3)

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23110

### How to test this PR?
- create a workspace using the editor [quay.io/che-incubator-pull-requests/che-code:pr-465-amd64](https://quay.io/che-incubator-pull-requests/che-code:pr-465-amd64)
- open the OpenShift console, go to Storage -> PersistentVolumeClaims
- return back to the workspace, restart it from local devfile 
- switch to the OpenShift console again and refresh the page. `claim-devworkspace` PVS should not be created
- return back to the workspace, it should be restarted successfully

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
