### PR TITLE
fix: restart from local devfile should work even whem some attributes are empty

### DIFF
--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -160,11 +160,7 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   } = cheApi.getDevfileService();
   const devWorkspaceGenerator = new DevWorkspaceGenerator();
 
-  await new Promise(resolve => setTimeout(resolve, 500));
-
   let devfilePath = await selectDevfile();
-  await new Promise(resolve => setTimeout(resolve, 500));
-
   if (`${process.env.PROJECTS_ROOT!}/*` === devfilePath) {
     const uri = await vscode.window.showOpenDialog({
       canSelectFolders: false
@@ -179,8 +175,6 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   if (!devfilePath) {
     return false;
   }
-
-  await new Promise(resolve => setTimeout(resolve, 500));
 
   const action = await vscode.window.showInformationMessage(
     'Workspace restart', {
@@ -237,20 +231,15 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   }
 
   try {
-    const action = await vscode.window.showInformationMessage('Do you want to copy attributes from existing to a new devfile?', {
-      modal: true
-    }, 'Copy', 'Skip');
-    console.log(`> action [${action}]`);
+    // keep spec.template.attributes
+    if (!devfileContext.devWorkspace.spec!.template!.attributes) {
+      devfileContext.devWorkspace.spec!.template!.attributes = {};
+    }
 
-    if ('Copy' === action) {
-      // keep spec.template.attributes
-      if (!devfileContext.devWorkspace.spec!.template!.attributes) {
-        devfileContext.devWorkspace.spec!.template!.attributes = flattenedDevfile.attributes;
+    for (const key of Object.keys(flattenedDevfile.attributes)) {
+      if (flattenedDevfile.attributes[key]) {
+        devfileContext.devWorkspace.spec!.template!.attributes[key] = flattenedDevfile.attributes[key];
       }
-    } else if (action === 'Skip') {
-      // do nothing
-    } else if (action === undefined) {
-      return false;
     }
   } catch (error) {
     await vscode.window.showErrorMessage(`Failed to update DevWorkspace attributes. ${error}`);
@@ -269,8 +258,9 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   }
 
   try {
-    const action = await vscode.window.showInformationMessage('Apply changes?', {
-      modal: true
+    const action = await vscode.window.showInformationMessage('The new devfile has been written to \'/projects/new-devfile.yaml\'', {
+      modal: true,
+      detail: 'Apply changes?'
     }, 'Apply');
     if (action !== 'Apply') {
       return false;

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -247,25 +247,6 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   }
 
   try {
-    const serialized = jsYaml.dump(devfileContext);
-    await fs.writeFile('/projects/new-devfile.yaml', serialized);
-    await vscode.window.showInformationMessage('The new devfile has been written to \'/projects/new-devfile.yaml\'', {
-      modal: true
-    });
-  } catch (error) {
-    await vscode.window.showErrorMessage(`Failed to write new devfile context to '/projects/new-devfile.yaml'. ${error}`);
-    return false;
-  }
-
-  try {
-    const action = await vscode.window.showInformationMessage('The new devfile has been written to \'/projects/new-devfile.yaml\'', {
-      modal: true,
-      detail: 'Apply changes?'
-    }, 'Apply');
-    if (action !== 'Apply') {
-      return false;
-    }
-
     await devfileService.updateDevfile(devfileContext.devWorkspace.spec?.template);
   } catch (error) {
     if (error.body && error.body.message) {

--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -160,7 +160,11 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   } = cheApi.getDevfileService();
   const devWorkspaceGenerator = new DevWorkspaceGenerator();
 
+  await new Promise(resolve => setTimeout(resolve, 500));
+
   let devfilePath = await selectDevfile();
+  await new Promise(resolve => setTimeout(resolve, 500));
+
   if (`${process.env.PROJECTS_ROOT!}/*` === devfilePath) {
     const uri = await vscode.window.showOpenDialog({
       canSelectFolders: false
@@ -175,6 +179,8 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   if (!devfilePath) {
     return false;
   }
+
+  await new Promise(resolve => setTimeout(resolve, 500));
 
   const action = await vscode.window.showInformationMessage(
     'Workspace restart', {


### PR DESCRIPTION
### What does this PR do?
In a existing devworkspace object some attributes may have null values, we do not need to copy them to a new generated devfile.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23292

### How to test this PR?
- create a workspace with the editor [quay.io/che-incubator-pull-requests/che-code:pr-470-amd64](https://quay.io/che-incubator-pull-requests/che-code:pr-470-amd64)
- open the devfile and change it
- restart the workspace from local devfile

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
