### PR TITLE
chore: Add tslib dependency

### DIFF
--- a/code/extensions/package-lock.json
+++ b/code/extensions/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "tslib": "^2.0.0",
         "typescript": "^5.7.0-dev.20241030"
       },
       "devDependencies": {
@@ -604,6 +605,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/typescript": {
       "version": "5.7.0-dev.20241030",

--- a/code/extensions/package.json
+++ b/code/extensions/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "description": "Dependencies shared by all extensions",
   "dependencies": {
-    "typescript": "^5.7.0-dev.20241030"
+    "typescript": "^5.7.0-dev.20241030",
+    "tslib": "^2.0.0"
   },
   "scripts": {
     "postinstall": "node ./postinstall.mjs"


### PR DESCRIPTION
Note: The changes are for the `7.95.x` branch to fix build in the downstream.

### What does this PR do?
Downstream project is failing with the error:
```
npm error 404 Not Found - Package 'tslib' not found
```
`tslib` is present as a `peerDependency` in different extensions.
So, let's add it explicitly to the package.json file.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-7882

### How to test this PR?
Build in the downstream project should pass successfully.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
