### PR TITLE
fix: rebuild @devfile/api dependency to fix che-in-che development

### DIFF
--- a/code/extensions/che-resource-monitor/package-lock.json
+++ b/code/extensions/che-resource-monitor/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@devfile/api": "^2.3.0-1723034342",
         "@kubernetes/client-node": "^0.22.0",
         "inversify": "^6.0.2",
         "reflect-metadata": "^0.2.2",
@@ -581,19 +580,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "node_modules/@devfile/api": {
-      "version": "2.3.0-1725380172",
-      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1725380172.tgz",
-      "integrity": "sha512-J0O2h81M3kcbkwLnod64aHH9PAUzHRJyOvfDyOE8LSv62Yj+3tf0MYHPXOFWMwQWFUFTymMK2fHPnINWaV6MxQ==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/node-fetch": "^2.5.7",
-        "es6-promise": "^4.2.4",
-        "form-data": "^2.5.0",
-        "node-fetch": "^2.6.0",
-        "url-parse": "^1.4.3"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1229,28 +1215,6 @@
       "integrity": "sha512-vtgGzjxLF7QT88qRHtXMzCWpAAmwonE7fwgVjFtXosUva2oSpnIEc3gNO9P7uIfOxKnii2f79/xtOnfreYtDaA==",
       "dependencies": {
         "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@types/prettier": {
@@ -2040,11 +2004,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3800,44 +3759,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4184,7 +4105,8 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -4265,7 +4187,8 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -4892,6 +4815,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -13,7 +13,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "capabilities": {
     "virtualWorkspaces": true,
@@ -30,7 +30,6 @@
     "lint:fix": "eslint --fix --cache=true --no-error-on-unmatched-pattern=true \"{src,tests}/**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@devfile/api": "^2.3.0-1723034342",
     "@kubernetes/client-node": "^0.22.0",
     "inversify": "^6.0.2",
     "reflect-metadata": "^0.2.2",

--- a/code/remote/package-lock.json
+++ b/code/remote/package-lock.json
@@ -863,6 +863,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/font-finder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/font-finder/-/font-finder-1.1.0.tgz",
+      "integrity": "sha512-wpCL2uIbi6GurJbU7ZlQ3nGd61Ho+dSU6U83/xJT5UPFfN35EeCW/rOtS+5k+IuEZu2SYmHzDIPL9eA5tSYRAw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-system-fonts": "^2.0.0",
+        "promise-stream-reader": "^1.0.1"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      }
+    },
+    "node_modules/font-ligatures": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/font-ligatures/-/font-ligatures-1.4.1.tgz",
+      "integrity": "sha512-7W6zlfyhvCqShZ5ReUWqmSd9vBaUudW0Hxis+tqUjtHhsPU+L3Grf8mcZAtCiXHTzorhwdRTId2WeH/88gdFkw==",
+      "license": "MIT",
+      "dependencies": {
+        "font-finder": "^1.0.3",
+        "lru-cache": "^6.0.0",
+        "opentype.js": "^0.8.0"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -900,33 +927,6 @@
       },
       "engines": {
         "node": ">= 0.12"
-      }
-    },
-    "node_modules/font-finder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/font-finder/-/font-finder-1.1.0.tgz",
-      "integrity": "sha512-wpCL2uIbi6GurJbU7ZlQ3nGd61Ho+dSU6U83/xJT5UPFfN35EeCW/rOtS+5k+IuEZu2SYmHzDIPL9eA5tSYRAw==",
-      "license": "MIT",
-      "dependencies": {
-        "get-system-fonts": "^2.0.0",
-        "promise-stream-reader": "^1.0.1"
-      },
-      "engines": {
-        "node": ">8.0.0"
-      }
-    },
-    "node_modules/font-ligatures": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/font-ligatures/-/font-ligatures-1.4.1.tgz",
-      "integrity": "sha512-7W6zlfyhvCqShZ5ReUWqmSd9vBaUudW0Hxis+tqUjtHhsPU+L3Grf8mcZAtCiXHTzorhwdRTId2WeH/88gdFkw==",
-      "license": "MIT",
-      "dependencies": {
-        "font-finder": "^1.0.3",
-        "lru-cache": "^6.0.0",
-        "opentype.js": "^0.8.0"
-      },
-      "engines": {
-        "node": ">8.0.0"
       }
     },
     "node_modules/fs-constants": {
@@ -1510,6 +1510,18 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/opentype.js": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-0.8.0.tgz",
+      "integrity": "sha512-FQHR4oGP+a0m/f6yHoRpBOIbn/5ZWxKd4D/djHVJu8+KpBTYrJda0b7mLcgDEMWXE9xBCJm+qb0yv6FcvPjukg==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.2"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -1546,18 +1558,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/opentype.js": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-0.8.0.tgz",
-      "integrity": "sha512-FQHR4oGP+a0m/f6yHoRpBOIbn/5ZWxKd4D/djHVJu8+KpBTYrJda0b7mLcgDEMWXE9xBCJm+qb0yv6FcvPjukg==",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-inflate": "^1.0.2"
-      },
-      "bin": {
-        "ot": "bin/ot"
-      }
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -38,6 +38,7 @@ commands:
       workingDir: ${PROJECTS_ROOT}/che-code
       commandLine: |
         npm install
+        recompile-@devfile-api.sh
       group:
         kind: build
 

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -38,7 +38,6 @@ commands:
       workingDir: ${PROJECTS_ROOT}/che-code
       commandLine: |
         npm install
-        echo "Current directory: $(pwd)"
         ./recompile-@devfile-api.sh
       group:
         kind: build

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -38,7 +38,8 @@ commands:
       workingDir: ${PROJECTS_ROOT}/che-code
       commandLine: |
         npm install
-        recompile-@devfile-api.sh
+        echo "Current directory: $(pwd)"
+        ./recompile-@devfile-api.sh
       group:
         kind: build
 

--- a/recompile-@devfile-api.sh
+++ b/recompile-@devfile-api.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+#!/bin/bash
+
+# This script will recompile `node_modules/@devfile/api` for specified extensions
+
+set -e
+set -u
+
+recompile_devfile_api() {
+  local devfile_api_path="code/extensions/${1}/node_modules/@devfile/api"
+  echo "Recompile ${devfile_api_path}"
+
+  # remember current directory
+  local cur_dir=$(pwd)
+
+  # go to dependency directory
+  cd $devfile_api_path
+
+  # delete dist directory
+  rm -rf dist
+
+  #
+  # Patch package.json
+  #
+
+  # remove `main`, `type`, `module`, `exports`, `typings` properties
+  echo "$(jq 'del(.main)' package.json)" > package.json
+  echo "$(jq 'del(.type)' package.json)" > package.json
+  echo "$(jq 'del(.module)' package.json)" > package.json
+  echo "$(jq 'del(.exports)' package.json)" > package.json
+  echo "$(jq 'del(.typings)' package.json)" > package.json
+
+  # add new values for `main` and `types` properties
+  echo "$(jq '. += {"main": "dist/index.js"}' package.json)" > package.json
+  echo "$(jq '. += {"types": "dist/index.d.ts"}' package.json)" > package.json
+
+  #
+  # Patch tsconfig.json
+  #
+
+  # remove comments
+  cp -f tsconfig.json tsconfig.json.copy
+  node -p 'JSON.stringify(eval(`(${require("fs").readFileSync("tsconfig.json.copy", "utf-8").toString()})`))' | jq > tsconfig.json
+  
+  # remove unwanted properties
+  echo "$(jq 'del(.compilerOptions.noUnusedLocals)' tsconfig.json)" > tsconfig.json
+  echo "$(jq 'del(.compilerOptions.noUnusedParameters)' tsconfig.json)" > tsconfig.json
+  echo "$(jq 'del(.compilerOptions.noImplicitReturns)' tsconfig.json)" > tsconfig.json
+  echo "$(jq 'del(.compilerOptions.noFallthroughCasesInSwitch)' tsconfig.json)" > tsconfig.json
+
+  # add module type
+  echo "$(jq '.compilerOptions += {"module": "commonjs"}' tsconfig.json)" > tsconfig.json
+  # add skipLibCheck
+  echo "$(jq '.compilerOptions += {"skipLibCheck": true}' tsconfig.json)" > tsconfig.json
+
+  # recompile the library
+  npm run build
+
+  # return back to the root directory
+  cd $cur_dir
+}
+
+extensions=("che-api" "che-commands" "che-github-authentication" "che-port" "che-remote" "che-resource-monitor")
+for extension in ${extensions[@]}; do
+  recompile_devfile_api "${extension}"
+done
+
+echo "Done"

--- a/recompile-@devfile-api.sh
+++ b/recompile-@devfile-api.sh
@@ -68,7 +68,7 @@ recompile_devfile_api() {
   cd $cur_dir
 }
 
-extensions=("che-api" "che-commands" "che-github-authentication" "che-port" "che-remote" "che-resource-monitor")
+extensions=("che-api" "che-commands" "che-github-authentication" "che-port" "che-remote")
 for extension in ${extensions[@]}; do
   recompile_devfile_api "${extension}"
 done


### PR DESCRIPTION
### What does this PR do?

Re-compiles `@devfile/api` node package on its place inside `node_modules/@devfile/api` directory to have a library with type `commonjs` instead of `module`.

Since the type of `@devfile/api` node package has been changed from `commonjs` to `module`, it become not possible anymore to use `import` from VS Code when we compile it inside the workspace and then launch a secondary editor instance. 

The `@devfile/api` version we are currently using can be found here https://www.npmjs.com/package/@devfile/api/v/2.3.0-1723034342?activeTab=code
It it possible to open `packge.json` and check for `type` property.

The version we used before is https://www.npmjs.com/package/@devfile/api/v/2.2.1-alpha-1667236163?activeTab=code
There is no `type` property in the `package.json` file, so default `commonjs` value is used.

Why do we have the issue when compile and run the editor in the development mode only?

Normally, the `webpack` is used to create the editor bundle, and instead of having a dozen of separate javascript file, we have only one weight, obfuscated javascript file which speeds up the process of downloading the script in the browser.

When we compile che-code in the development mode, the compiler creates thousands of seprarate javascript files and then when we run the backend with node, we face the restriction with the incompatibility of types (vscode is compiled as commonjs).

The changes provided by this pull request will be used only when che-code dogfooding.

![Screenshot from 2024-12-20 19-55-42](https://github.com/user-attachments/assets/48ec0f29-c992-4747-a7a2-d158ed2dc4b6)

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23163

### How to test this PR?
- create a workspace from this the branch https://github.com/che-incubator/che-code/tree/recompile-devfile-api
- run `devfile: Run VS Code server on port 8000` command. When the command is being executed, it is possible to check the output and see which `@devfile/api` packages have been recompiled.

- run `devfile: Compile with npm` command
- run `devfile: Run VS Code server on port 8000` command and open the secondary editor in a separate window
- once the editor is opened, ensure there are no error notifications appeared

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
