### PR TITLE
Fix build of the downstream project

### DIFF
--- a/code/extensions/package-lock.json
+++ b/code/extensions/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@parcel/watcher": "2.1.0",
+        "crypto": "1.0.1",
         "esbuild": "0.23.0",
         "vscode-grammar-updater": "^1.1.0"
       }
@@ -447,6 +448,13 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
+      "dev": true
     },
     "node_modules/cson-parser": {
       "version": "4.0.9",

--- a/code/extensions/package.json
+++ b/code/extensions/package.json
@@ -13,7 +13,8 @@
   "devDependencies": {
     "@parcel/watcher": "2.1.0",
     "esbuild": "0.23.0",
-    "vscode-grammar-updater": "^1.1.0"
+    "vscode-grammar-updater": "^1.1.0",
+    "crypto": "1.0.1"
   },
   "overrides": {
     "node-gyp-build": "4.8.1",


### PR DESCRIPTION
Note: The changes are for the `7.95.x` branch to fix build in the downstream.

### What does this PR do?
Downstream project is failing with the error:
```
npm error 404 'crypto@1.0.1' is not in this registry.
```
`crypto` is present as a `peerDependency`, see https://github.com/che-incubator/che-code/blob/98b032b6f6c236b2e5165beeac100eb609481a70/code/extensions/ipynb/package-lock.json#L43
So, let's add it explicitly to the package.json file.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-7882

### How to test this PR?
I tested adding the dependency to the downstream project - build passed successfully for the corresponding step.
### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
