### PR TITLE
fix: Allow to build che-code using cachito system

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,12 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/482
+
+- code/extensions/microsoft-authentication/package.json
+---
+
+#### @RomanNikitenko
 https://github.com/che-incubator/che-code/pull/476
 
 - code/extensions/package.json

--- a/.rebase/add/code/extensions/microsoft-authentication/package.json
+++ b/.rebase/add/code/extensions/microsoft-authentication/package.json
@@ -1,0 +1,5 @@
+{
+    "workspaces": [
+        "packageMocks/keytar"
+    ]
+}

--- a/.rebase/override/code/extensions/microsoft-authentication/package.json
+++ b/.rebase/override/code/extensions/microsoft-authentication/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "keytar": "workspace:*"
+  }
+}

--- a/code/extensions/microsoft-authentication/package-lock.json
+++ b/code/extensions/microsoft-authentication/package-lock.json
@@ -8,12 +8,15 @@
       "name": "microsoft-authentication",
       "version": "0.0.1",
       "license": "MIT",
+      "workspaces": [
+        "packageMocks/keytar"
+      ],
       "dependencies": {
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/msal-node": "^2.16.2",
         "@azure/msal-node-extensions": "^1.5.0",
         "@vscode/extension-telemetry": "^0.9.0",
-        "keytar": "file:./packageMocks/keytar",
+        "keytar": "workspace:*",
         "vscode-tas-client": "^0.1.84"
       },
       "devDependencies": {
@@ -405,9 +408,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/packageMocks/keytar": {
-      "extraneous": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",

--- a/code/extensions/microsoft-authentication/package.json
+++ b/code/extensions/microsoft-authentication/package.json
@@ -143,11 +143,14 @@
     "@azure/msal-node": "^2.16.2",
     "@azure/msal-node-extensions": "^1.5.0",
     "@vscode/extension-telemetry": "^0.9.0",
-    "keytar": "file:./packageMocks/keytar",
+    "keytar": "workspace:*",
     "vscode-tas-client": "^0.1.84"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"
-  }
+  },
+  "workspaces": [
+    "packageMocks/keytar"
+  ]
 }

--- a/rebase.sh
+++ b/rebase.sh
@@ -153,6 +153,29 @@ apply_code_extensions_package_lock_changes() {
   git add code/extensions/package-lock.json > /dev/null 2>&1
 }
 
+# Apply changes on code/extensions/microsoft-authentication/package-lock.json file
+apply_code_extensions_microsoft_authentication_package_lock_changes() {
+
+  echo "  ⚙️ reworking code/extensions/microsoft-authentication/package-lock.json..."
+  
+  conflicted_files=$(git diff --name-only --diff-filter=U)
+
+  # Check if code/extensions/microsoft-authentication/package.json is in the list
+  if echo "$conflicted_files" | grep -q "^code/extensions/microsoft-authentication/package.json$"; then
+      echo "Conflict for the code/extensions/microsoft-authentication/package.json should be fixed first!"
+      apply_package_changes_by_path "code/extensions/microsoft-authentication/package.json"
+  fi
+  
+  # reset the file from what is upstream
+  git checkout --ours code/extensions/microsoft-authentication/package-lock.json > /dev/null 2>&1
+
+  # update package-lock.json
+  npm install --ignore-scripts --prefix code/extensions/microsoft-authentication
+
+  # resolve the change
+  git add code/extensions/microsoft-authentication/package-lock.json > /dev/null 2>&1
+}
+
 # Apply changes on code/remote/package-lock.json file
 apply_code_remote_package_lock_changes() {
 
@@ -378,6 +401,10 @@ resolve_conflicts() {
       apply_code_extensions_package_lock_changes
     elif [[ "$conflictingFile" == "code/product.json" ]]; then
       apply_code_product_changes
+    elif [[ "$conflictingFile" == "code/extensions/microsoft-authentication/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/microsoft-authentication/package-lock.json" ]]; then
+      apply_code_extensions_microsoft_authentication_package_lock_changes
     elif [[ "$conflictingFile" == "code/build/lib/mangle/index.js" ]]; then
       apply_mangle_index_js_changes
     elif [[ "$conflictingFile" == "code/build/lib/mangle/index.ts" ]]; then


### PR DESCRIPTION
### What does this PR do?
Downstream project uses `cachito` system.
At the moment it's failing with the following error:
```
cachito - ERROR - Request is in "failed" state: keytar@file:node_modules/packageMocks/keytar is a 'file:' dependency. File dependencies are allowed if: a) the dependency is declared as a workspace in package.json or b) the dependency is present in the server-side allowlist.
```

Current changes should fix the problem.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-7882

### How to test this PR?
- build should pass successfully for the che-code
- I'm going to test the changes in the downstream

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
