### PR TITLE
chore: Upgrade Node.js version for the muscl-based assembly

### DIFF
--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # Make an assembly including both musl and libc variant to be able to run on all linux systems
-FROM docker.io/node:20-alpine3.18 as linux-musl-builder
+FROM docker.io/node:20-alpine3.19 as linux-musl-builder
 
 RUN apk add --update --no-cache \
     # Download some files


### PR DESCRIPTION
### What does this PR do?
Currently `docker.io/node:20-alpine3.18` is used to prepare `muscl`-based Che-Code assembly.
It contains `20.13.1` version of Node.js.

I propose to use `docker.io/node:20-alpine3.19` image to upgrade Node.js version for the `muscl`-based assembly.


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23313

### How to test this PR?

- all PR's check should be happy
- testing any functionality is useful

The changes are related to the `muscl`-based assembly only, so:
- you can use this link to start a workspace https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#/https://github.com/RomanNikitenko/web-nodejs-sample/tree/ubuntu-22 
- or any other devfile that based on the alpine image
 
### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
