### PR TITLE
fix: Fix VS Code tests

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,13 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/488
+
+- code/test/integration/browser/src/index.ts
+- code/test/automation/src/playwrightBrowser.ts
+---
+
+#### @RomanNikitenko
 https://github.com/che-incubator/che-code/pull/482
 
 - code/extensions/microsoft-authentication/package.json

--- a/.rebase/replace/code/test/automation/src/playwrightBrowser.ts.json
+++ b/.rebase/replace/code/test/automation/src/playwrightBrowser.ts.json
@@ -1,0 +1,6 @@
+[
+	{
+			"from": "headless: headless ?? false,",
+			"by": "headless: headless ?? false,\\\n\\\t\\\targs: ['--headless=new'],"
+	}
+]

--- a/.rebase/replace/code/test/integration/browser/src/index.ts.json
+++ b/.rebase/replace/code/test/integration/browser/src/index.ts.json
@@ -1,0 +1,6 @@
+[
+	{
+			"from": "const browser = await playwright[browserType].launch({ headless: !Boolean(args.debug) });",
+			"by": "const browser = await playwright[browserType].launch({ headless: !Boolean(args.debug), args: ['--headless=new'], });"
+	}
+]

--- a/code/test/automation/src/playwrightBrowser.ts
+++ b/code/test/automation/src/playwrightBrowser.ts
@@ -92,6 +92,7 @@ async function launchBrowser(options: LaunchOptions, endpoint: string) {
 
 	const browser = await measureAndLog(() => playwright[options.browser ?? 'chromium'].launch({
 		headless: headless ?? false,
+		args: ['--headless=new'],
 		timeout: 0
 	}), 'playwright#launch', logger);
 

--- a/code/test/integration/browser/src/index.ts
+++ b/code/test/integration/browser/src/index.ts
@@ -63,7 +63,7 @@ const height = 800;
 type BrowserType = 'chromium' | 'firefox' | 'webkit';
 
 async function runTestsInBrowser(browserType: BrowserType, endpoint: url.UrlWithStringQuery, server: cp.ChildProcess): Promise<void> {
-	const browser = await playwright[browserType].launch({ headless: !Boolean(args.debug) });
+	const browser = await playwright[browserType].launch({ headless: !Boolean(args.debug), args: ['--headless=new'], });
 	const context = await browser.newContext();
 
 	const page = await context.newPage();

--- a/rebase.sh
+++ b/rebase.sh
@@ -447,6 +447,10 @@ resolve_conflicts() {
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts" ]]; then
       apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/test/automation/src/playwrightBrowser.ts" ]]; then
+      apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/test/integration/browser/src/index.ts" ]]; then
+      apply_changes "$conflictingFile"
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"
       exit 1


### PR DESCRIPTION
### What does this PR do?
At the moment Che-Code build fails on the VS Code tests іеуз with the following error:
```
Old Headless mode has been removed from the Chrome binary. Please use the new Headless mode
```

Arg `--headless=new` fixes the problem.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23315

### How to test this PR?
all checks for the PR should be successful - so VS Code tests are passed for all assemblies

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
