### PR TITLE
Update upload-artifact action for the Smoke Test workflow

### DIFF
--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -167,14 +167,14 @@ jobs:
 
       - name: Store e2e artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-artifacts
           path: /tmp/tests
       
       - name: Store k8s logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: k8s-logs
           path: /tmp/devworkspace-happy-path-artifacts/admin-che-info


### PR DESCRIPTION
### What does this PR do?
At the moment `Smoke Test` workflow fails for the Che-Code as `actions/upload-artifact: v3` was deprecated and it doesn't work starting January 30th, 2025.

So, let's use `v4` for the workflow. 

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->

https://github.com/eclipse-che/che/issues/23325

### How to test this PR?
Smoke Test workflow should pass successfully

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
