### PR TITLE
Fix image-publish workflow

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/${{matrix.arch}} -f build/dockerfiles/linux-${{matrix.dist}}.Dockerfile --load -t linux-${{matrix.dist}}-${{matrix.arch}} .
       - name: Upload image
-        uses: ishworkh/docker-image-artifact-upload@v1
+        uses: ishworkh/container-image-artifact-upload@v2.0.0
         with:
           image: "linux-${{matrix.dist}}-${{matrix.arch}}"
   assemble:


### PR DESCRIPTION
### What does this PR do?
At the moment image-publish workflow fails, see https://github.com/che-incubator/che-code/actions/runs/13115004260/job/36587065805

The current change should fix the problem.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
no issue, see https://github.com/che-incubator/che-code/actions/runs/13115004260/job/36587065805

### How to test this PR?
image-publish workflow should pass successfully.
 
### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
