### PR TITLE
fix: build and publish che-code images

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -55,15 +55,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Download linux-libc-ubi8-amd64 image
-        uses: ishworkh/docker-image-artifact-download@v1
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "linux-libc-ubi8-amd64"
       - name: Download linux-libc-ubi9-amd64 image
-        uses: ishworkh/docker-image-artifact-download@v1
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "linux-libc-ubi9-amd64"
       - name: Download linux-musl image
-        uses: ishworkh/docker-image-artifact-download@v1
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "linux-musl-amd64"
       - name: Display docker images


### PR DESCRIPTION
### What does this PR do?

Fixes building and publishing the che-code images after merging a pull request to main.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->

An addition to https://github.com/che-incubator/che-code/pull/497

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
