### PR TITLE
fix: Fix 'Changes' actions of the Source Control panel 

### DIFF
--- a/code/extensions/git/package.json
+++ b/code/extensions/git/package.json
@@ -163,14 +163,14 @@
         "title": "%command.stageAll%",
         "category": "Git",
         "icon": "$(add)",
-        "enablement": "!operationInProgress && scmResourceGroupResourceCount > 0"
+        "enablement": "!operationInProgress"
       },
       {
         "command": "git.stageAllTracked",
         "title": "%command.stageAllTracked%",
         "category": "Git",
         "icon": "$(add)",
-        "enablement": "!operationInProgress && scmResourceGroupResourceCount > 0"
+        "enablement": "!operationInProgress"
       },
       {
         "command": "git.stageAllUntracked",
@@ -243,7 +243,7 @@
         "title": "%command.unstageAll%",
         "category": "Git",
         "icon": "$(remove)",
-        "enablement": "!operationInProgress && scmResourceGroupResourceCount > 0"
+        "enablement": "!operationInProgress"
       },
       {
         "command": "git.unstageSelectedRanges",
@@ -270,14 +270,14 @@
         "title": "%command.cleanAll%",
         "category": "Git",
         "icon": "$(discard)",
-        "enablement": "!operationInProgress && scmResourceGroupResourceCount > 0"
+        "enablement": "!operationInProgress"
       },
       {
         "command": "git.cleanAllTracked",
         "title": "%command.cleanAllTracked%",
         "category": "Git",
         "icon": "$(discard)",
-        "enablement": "!operationInProgress && scmResourceGroupResourceCount > 0"
+        "enablement": "!operationInProgress"
       },
       {
         "command": "git.cleanAllUntracked",
@@ -889,14 +889,14 @@
         "title": "%command.viewChanges%",
         "icon": "$(diff-multiple)",
         "category": "Git",
-        "enablement": "!operationInProgress && scmResourceGroupResourceCount > 0"
+        "enablement": "!operationInProgress"
       },
       {
         "command": "git.viewStagedChanges",
         "title": "%command.viewStagedChanges%",
         "icon": "$(diff-multiple)",
         "category": "Git",
-        "enablement": "!operationInProgress && scmResourceGroupResourceCount > 0"
+        "enablement": "!operationInProgress"
       },
       {
         "command": "git.viewUntrackedChanges",

--- a/code/src/vs/workbench/contrib/scm/browser/menus.ts
+++ b/code/src/vs/workbench/contrib/scm/browser/menus.ts
@@ -6,7 +6,7 @@
 import { IAction } from '../../../../base/common/actions.js';
 import { equals } from '../../../../base/common/arrays.js';
 import { Emitter } from '../../../../base/common/event.js';
-import { DisposableStore, IDisposable, MutableDisposable, dispose } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, dispose } from '../../../../base/common/lifecycle.js';
 import './media/scm.css';
 import { localize } from '../../../../nls.js';
 import { getActionBarActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
@@ -70,14 +70,13 @@ interface IContextualResourceMenuItem {
 
 class SCMMenusItem implements IDisposable {
 
-	private readonly _resourceGroupMenu = new MutableDisposable<IMenu>();
+	private _resourceGroupMenu: IMenu | undefined;
 	get resourceGroupMenu(): IMenu {
-		const contextKeyService = this.contextKeyService.createOverlay([
-			['scmResourceGroupResourceCount', this.group.resources.length],
-		]);
+		if (!this._resourceGroupMenu) {
+			this._resourceGroupMenu = this.menuService.createMenu(MenuId.SCMResourceGroupContext, this.contextKeyService);
+		}
 
-		this._resourceGroupMenu.value = this.menuService.createMenu(MenuId.SCMResourceGroupContext, contextKeyService);
-		return this._resourceGroupMenu.value;
+		return this._resourceGroupMenu;
 	}
 
 	private _resourceFolderMenu: IMenu | undefined;
@@ -93,9 +92,8 @@ class SCMMenusItem implements IDisposable {
 	private contextualResourceMenus: Map<string /* contextValue */, IContextualResourceMenuItem> | undefined;
 
 	constructor(
-		private readonly group: ISCMResourceGroup,
-		private readonly contextKeyService: IContextKeyService,
-		private readonly menuService: IMenuService
+		private contextKeyService: IContextKeyService,
+		private menuService: IMenuService
 	) { }
 
 	getResourceMenu(resource: ISCMResource): IMenu {
@@ -208,7 +206,7 @@ export class SCMRepositoryMenus implements ISCMRepositoryMenus, IDisposable {
 				['multiDiffEditorEnableViewChanges', group.multiDiffEditorEnableViewChanges],
 			]);
 
-			result = new SCMMenusItem(group, contextKeyService, this.menuService);
+			result = new SCMMenusItem(contextKeyService, this.menuService);
 			this.resourceGroupMenusItems.set(group, result);
 		}
 


### PR DESCRIPTION
### What does this PR do?
Backport of https://github.com/che-incubator/che-code/pull/502

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23323

### How to test this PR?
- Go to the dashboard => Create Workspace page
- put `quay.io/che-incubator-pull-requests/che-code:pr-501-amd64` to the `Editor image` field and select any sample 
- open a file, provide any change
- open `Source Control` panel => `...` => `More actions` => `Changes` submenu
- Check if actions of `Changes` submenu are enabled
- Try to use any action from that submenu

<img width="885" alt="image" src="https://github.com/user-attachments/assets/4d6678d8-08db-45b5-9b1c-4766e6d1e726" />

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
