### PR TITLE
fix: update @devfile/api dependency

### DIFF
--- a/code/extensions/che-api/extension.webpack.config.js
+++ b/code/extensions/che-api/extension.webpack.config.js
@@ -34,16 +34,3 @@ const config = withDefaults({
         new webpack.ContextReplacementPlugin(/keyv/), // needs to exclude the package to ignore warnings https://github.com/jaredwray/keyv/issues/45
     ],
 });
-
-module.exports = merge(config, {
-    module: {
-        rules: [
-            {
-                test: /\.m?js$/,
-                resolve: {
-                    fullySpecified: false, // This avoids the issue with the devfile/api extension requirement
-                },
-            }
-        ]
-    }
-})

--- a/code/extensions/che-api/extension.webpack.config.js
+++ b/code/extensions/che-api/extension.webpack.config.js
@@ -34,3 +34,16 @@ const config = withDefaults({
         new webpack.ContextReplacementPlugin(/keyv/), // needs to exclude the package to ignore warnings https://github.com/jaredwray/keyv/issues/45
     ],
 });
+
+module.exports = merge(config, {
+    module: {
+        rules: [
+            {
+                test: /\.m?js$/,
+                resolve: {
+                    fullySpecified: false, // This avoids the issue with the devfile/api extension requirement
+                },
+            }
+        ]
+    }
+});

--- a/code/extensions/che-api/package-lock.json
+++ b/code/extensions/che-api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@devfile/api": "^2.3.0-1723034342",
+        "@devfile/api": "^2.3.0-1738854228",
         "@eclipse-che/workspace-telemetry-client": "^0.0.1-1685523760",
         "@kubernetes/client-node": "^0.22.0",
         "axios": "^1.7.4",
@@ -587,9 +587,9 @@
       "dev": true
     },
     "node_modules/@devfile/api": {
-      "version": "2.3.0-1725380172",
-      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1725380172.tgz",
-      "integrity": "sha512-J0O2h81M3kcbkwLnod64aHH9PAUzHRJyOvfDyOE8LSv62Yj+3tf0MYHPXOFWMwQWFUFTymMK2fHPnINWaV6MxQ==",
+      "version": "2.3.0-1738854228",
+      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1738854228.tgz",
+      "integrity": "sha512-sA7ZqmamZ786Lnvs7sFyK7E7l9CNsYN/TzQmdDHvmiVXzF9XLm2LfqxTRpyhXO9IMFdbI702g1JudIlyrw6IQQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/node-fetch": "^2.5.7",

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -29,7 +29,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@devfile/api": "^2.3.0-1723034342",
+    "@devfile/api": "^2.3.0-1738854228",
     "axios": "^1.7.4",
     "@kubernetes/client-node": "^0.22.0",
     "fs-extra": "^11.2.0",

--- a/code/extensions/che-commands/package-lock.json
+++ b/code/extensions/che-commands/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@devfile/api": "^2.3.0-1723034342",
+        "@devfile/api": "^2.3.0-1738854228",
         "fs-extra": "^11.2.0",
         "js-yaml": "^4.1.0",
         "reflect-metadata": "^0.2.2",
@@ -582,9 +582,9 @@
       "dev": true
     },
     "node_modules/@devfile/api": {
-      "version": "2.3.0-1725380172",
-      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1725380172.tgz",
-      "integrity": "sha512-J0O2h81M3kcbkwLnod64aHH9PAUzHRJyOvfDyOE8LSv62Yj+3tf0MYHPXOFWMwQWFUFTymMK2fHPnINWaV6MxQ==",
+      "version": "2.3.0-1738854228",
+      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1738854228.tgz",
+      "integrity": "sha512-sA7ZqmamZ786Lnvs7sFyK7E7l9CNsYN/TzQmdDHvmiVXzF9XLm2LfqxTRpyhXO9IMFdbI702g1JudIlyrw6IQQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/node-fetch": "^2.5.7",

--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -34,7 +34,7 @@
     "fs-extra": "^11.2.0",
     "vscode-nls": "^5.0.0",
     "js-yaml": "^4.1.0",
-    "@devfile/api": "^2.3.0-1723034342"
+    "@devfile/api": "^2.3.0-1738854228"
   },
   "devDependencies": {
     "jest": "27.3.1",

--- a/code/extensions/che-github-authentication/extension.webpack.config.js
+++ b/code/extensions/che-github-authentication/extension.webpack.config.js
@@ -34,16 +34,3 @@ const config = withDefaults({
         new webpack.ContextReplacementPlugin(/keyv/), // needs to exclude the package to ignore warnings https://github.com/jaredwray/keyv/issues/45
     ],
 });
-
-module.exports = merge(config, {
-    module: {
-        rules: [
-            {
-                test: /\.m?js$/,
-                resolve: {
-                    fullySpecified: false, // This avoids the issue with the devfile/api extension requirement
-                },
-            }
-        ]
-    }
-})

--- a/code/extensions/che-github-authentication/extension.webpack.config.js
+++ b/code/extensions/che-github-authentication/extension.webpack.config.js
@@ -34,3 +34,16 @@ const config = withDefaults({
         new webpack.ContextReplacementPlugin(/keyv/), // needs to exclude the package to ignore warnings https://github.com/jaredwray/keyv/issues/45
     ],
 });
+
+module.exports = merge(config, {
+    module: {
+        rules: [
+            {
+                test: /\.m?js$/,
+                resolve: {
+                    fullySpecified: false, // This avoids the issue with the devfile/api extension requirement
+                },
+            }
+        ]
+    }
+});

--- a/code/extensions/che-github-authentication/package-lock.json
+++ b/code/extensions/che-github-authentication/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@devfile/api": "^2.3.0-1723034342",
+        "@devfile/api": "^2.3.0-1738854228",
         "@kubernetes/client-node": "^0.22.0",
         "@vscode/extension-telemetry": "0.7.5",
         "inversify": "^6.0.2",
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@devfile/api": {
-      "version": "2.3.0-1725380172",
-      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1725380172.tgz",
-      "integrity": "sha512-J0O2h81M3kcbkwLnod64aHH9PAUzHRJyOvfDyOE8LSv62Yj+3tf0MYHPXOFWMwQWFUFTymMK2fHPnINWaV6MxQ==",
+      "version": "2.3.0-1738854228",
+      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1738854228.tgz",
+      "integrity": "sha512-sA7ZqmamZ786Lnvs7sFyK7E7l9CNsYN/TzQmdDHvmiVXzF9XLm2LfqxTRpyhXO9IMFdbI702g1JudIlyrw6IQQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/node-fetch": "^2.5.7",

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "inversify": "^6.0.2",
-    "@devfile/api": "^2.3.0-1723034342",
+    "@devfile/api": "^2.3.0-1738854228",
     "@kubernetes/client-node": "^0.22.0",
     "uuid": "8.1.0",
     "@vscode/extension-telemetry": "0.7.5",

--- a/code/extensions/che-port/package-lock.json
+++ b/code/extensions/che-port/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@devfile/api": "^2.3.0-1723034342",
+        "@devfile/api": "^2.3.0-1738854228",
         "fs-extra": "^11.2.0",
         "reflect-metadata": "^0.2.2",
         "vscode-nls": "^5.0.0"
@@ -581,9 +581,9 @@
       "dev": true
     },
     "node_modules/@devfile/api": {
-      "version": "2.3.0-1725380172",
-      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1725380172.tgz",
-      "integrity": "sha512-J0O2h81M3kcbkwLnod64aHH9PAUzHRJyOvfDyOE8LSv62Yj+3tf0MYHPXOFWMwQWFUFTymMK2fHPnINWaV6MxQ==",
+      "version": "2.3.0-1738854228",
+      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1738854228.tgz",
+      "integrity": "sha512-sA7ZqmamZ786Lnvs7sFyK7E7l9CNsYN/TzQmdDHvmiVXzF9XLm2LfqxTRpyhXO9IMFdbI702g1JudIlyrw6IQQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/node-fetch": "^2.5.7",

--- a/code/extensions/che-port/package.json
+++ b/code/extensions/che-port/package.json
@@ -33,7 +33,7 @@
     "reflect-metadata": "^0.2.2",
     "fs-extra": "^11.2.0",
     "vscode-nls": "^5.0.0",
-    "@devfile/api": "^2.3.0-1723034342"
+    "@devfile/api": "^2.3.0-1738854228"
   },
   "devDependencies": {
     "jest": "27.3.1",

--- a/code/extensions/che-resource-monitor/package-lock.json
+++ b/code/extensions/che-resource-monitor/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "EPL-2.0",
       "dependencies": {
-        "@devfile/api": "^2.3.0-1723034342",
+        "@devfile/api": "^2.3.0-1738854228",
         "@kubernetes/client-node": "^0.22.0",
         "inversify": "^6.0.2",
         "reflect-metadata": "^0.2.2",
@@ -583,9 +583,9 @@
       "dev": true
     },
     "node_modules/@devfile/api": {
-      "version": "2.3.0-1725380172",
-      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1725380172.tgz",
-      "integrity": "sha512-J0O2h81M3kcbkwLnod64aHH9PAUzHRJyOvfDyOE8LSv62Yj+3tf0MYHPXOFWMwQWFUFTymMK2fHPnINWaV6MxQ==",
+      "version": "2.3.0-1738854228",
+      "resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1738854228.tgz",
+      "integrity": "sha512-sA7ZqmamZ786Lnvs7sFyK7E7l9CNsYN/TzQmdDHvmiVXzF9XLm2LfqxTRpyhXO9IMFdbI702g1JudIlyrw6IQQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/node-fetch": "^2.5.7",

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -30,7 +30,7 @@
     "lint:fix": "eslint --fix --cache=true --no-error-on-unmatched-pattern=true \"{src,tests}/**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@devfile/api": "^2.3.0-1723034342",
+    "@devfile/api": "^2.3.0-1738854228",
     "@kubernetes/client-node": "^0.22.0",
     "inversify": "^6.0.2",
     "reflect-metadata": "^0.2.2",


### PR DESCRIPTION
### What does this PR do?
A new version [2.3.0-1738854228](https://www.npmjs.com/package/@devfile/api/v/2.3.0-1738854228) of @devfile/api package is compiled as commonjs.
Updating to the version will fix che-code, compiled without using webpack (development mode).

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23163

### How to test this PR?
- create a workspace using https://github.com/che-incubator/che-code/tree/fix-che-code-dogfooding

- open terminal, take the value of `DEVWORKSPACE_POD_NAME` environment variable, update the line https://github.com/che-incubator/che-code/blob/main/code/extensions/che-resource-monitor/src/extension.ts#L28 like below
```
  const podName = await workspaceService.getPodName() || 'workspace61d3f2121bf8438e-6475588896-cq5hq';
```

- install node dependencies, compile and run secondary instance of che-code
- pay attention at che extensions, they should be initialized successfully
- resource monitor extension should work as well


### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
