### PR TITLE
fix: Fix activation of VS Code extensions

### DIFF
--- a/code/extensions/che-api/src/extension.ts
+++ b/code/extensions/che-api/src/extension.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2022-2025 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,11 @@
 
 
 /* eslint-disable header/header */
-import 'reflect-metadata';
+
+if (Reflect.metadata === undefined) {
+    // tslint:disable-next-line:no-require-imports no-var-requires
+    require('reflect-metadata');
+}
 
 import { Container } from 'inversify';
 import * as vscode from 'vscode';
@@ -64,16 +68,16 @@ export async function activate(_extensionContext: vscode.ExtensionContext): Prom
         },
     };
 
-	const k8sDevWorkspaceEnvVariables = container.get(K8sDevWorkspaceEnvVariables);
-	const dashboardUrl = k8sDevWorkspaceEnvVariables.getDashboardURL();
-	const workspaceNamespace = k8sDevWorkspaceEnvVariables.getWorkspaceNamespace();
-	const workspaceName = k8sDevWorkspaceEnvVariables.getWorkspaceName();
-	const projectsRoot = k8sDevWorkspaceEnvVariables.getProjectsRoot();
-	
-	_extensionContext.environmentVariableCollection.replace('DASHBOARD_URL', dashboardUrl);
-	_extensionContext.environmentVariableCollection.replace('WORKSPACE_NAME', workspaceName);
-	_extensionContext.environmentVariableCollection.replace('WORKSPACE_NAMESPACE', workspaceNamespace);
-	_extensionContext.environmentVariableCollection.replace('PROJECTS_ROOT', projectsRoot);
+    const k8sDevWorkspaceEnvVariables = container.get(K8sDevWorkspaceEnvVariables);
+    const dashboardUrl = k8sDevWorkspaceEnvVariables.getDashboardURL();
+    const workspaceNamespace = k8sDevWorkspaceEnvVariables.getWorkspaceNamespace();
+    const workspaceName = k8sDevWorkspaceEnvVariables.getWorkspaceName();
+    const projectsRoot = k8sDevWorkspaceEnvVariables.getProjectsRoot();
+
+    _extensionContext.environmentVariableCollection.replace('DASHBOARD_URL', dashboardUrl);
+    _extensionContext.environmentVariableCollection.replace('WORKSPACE_NAME', workspaceName);
+    _extensionContext.environmentVariableCollection.replace('WORKSPACE_NAMESPACE', workspaceNamespace);
+    _extensionContext.environmentVariableCollection.replace('PROJECTS_ROOT', projectsRoot);
 
     await container.get(K8SServiceImpl).ensureKubernetesServiceHostWhitelisted();
 

--- a/code/extensions/che-port/src/extension.ts
+++ b/code/extensions/che-port/src/extension.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2022-2025 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,11 @@
 
 /* eslint-disable header/header */
 
-import 'reflect-metadata';
+if (Reflect.metadata === undefined) {
+  // tslint:disable-next-line:no-require-imports no-var-requires
+  require('reflect-metadata');
+}
+
 import * as vscode from 'vscode';
 
 import { PortsPlugin } from './ports-plugin';

--- a/code/extensions/che-resource-monitor/src/extension.ts
+++ b/code/extensions/che-resource-monitor/src/extension.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2022-2025 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,10 @@
 
 /* eslint-disable header/header */
 
-import 'reflect-metadata';
+if (Reflect.metadata === undefined) {
+  // tslint:disable-next-line:no-require-imports no-var-requires
+  require('reflect-metadata');
+}
 
 import * as vscode from 'vscode';
 
@@ -22,11 +25,11 @@ let resourceMonitorPLugin: ResourceMonitor;
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const inversifyBinding = new InversifyBinding();
   const container = await inversifyBinding.initBindings();
-  
+
   const workspaceService = await getWorkspaceService();
   const namespace = await workspaceService.getNamespace();
   const podName = await workspaceService.getPodName();
-  
+
   resourceMonitorPLugin = container.get(ResourceMonitor);
   resourceMonitorPLugin.start(context, namespace, podName);
 }

--- a/code/extensions/che-resource-monitor/src/inversify-binding.ts
+++ b/code/extensions/che-resource-monitor/src/inversify-binding.ts
@@ -10,8 +10,6 @@
 
 /* eslint-disable header/header */
 
-import 'reflect-metadata';
-
 import { Container } from 'inversify';
 import { K8sHelper } from './k8s-helper';
 import { ResourceMonitor } from './resource-monitor';


### PR DESCRIPTION
### What does this PR do?
There is a problem with activation some VS Code extensions, python, for example.
I was able to reproduce it after refreshing the web page. 

The current changes fixes the problem.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
[CRW-8231](https://issues.redhat.com//browse/CRW-8231)

### How to test this PR?

**Python extension case:**
1. Start a workspace using https://workspaces.openshift.com/#/https://github.com/RomanNikitenko/python-hello-world/tree/test-vscode-extensions
2. Go to the extensions panel - check that all extensions from the `.vscode/extensions.json` are installed.
3. Open `hello-world.py` file.
4. Click on the `Run Python File` button
5. Check that `Hello, world!` is displayed in a terminal.
6. Go to the `Output` panel, `Python` channel - check that there is no errors like:
<img width="1432" alt="image" src="https://github.com/user-attachments/assets/31b5c53f-86f4-4647-9507-a2714ddc322c" />

7. **Important:**  I was able to reproduce the problem **only** after refreshing the page - so please refresh the page and do all steps above again. Also it's important to have **active** open .py file when you refresh the page.
8. Restart your workspace and try 2-6 steps again.

**Check Che-specific logic**
The current changes have an impact on the following extensions:
-  che-api
- che-port
- che-resource-monitor

so, the corresponding functionality should be tested as well.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
