### PR TITLE
chore: che-port extension doesn't use reflect-metadata anymore

### DIFF
--- a/code/extensions/che-port/package-lock.json
+++ b/code/extensions/che-port/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@devfile/api": "^2.3.0-1738854228",
         "fs-extra": "^11.2.0",
-        "reflect-metadata": "^0.2.2",
         "vscode-nls": "^5.0.0"
       },
       "devDependencies": {
@@ -3508,11 +3507,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "node_modules/reflect-metadata": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/code/extensions/che-port/package.json
+++ b/code/extensions/che-port/package.json
@@ -30,7 +30,6 @@
     "lint:fix": "eslint --fix --cache=true --no-error-on-unmatched-pattern=true \"{src,tests}/**/*.{ts,tsx}\""
     },
   "dependencies": {
-    "reflect-metadata": "^0.2.2",
     "fs-extra": "^11.2.0",
     "vscode-nls": "^5.0.0",
     "@devfile/api": "^2.3.0-1738854228"

--- a/code/extensions/che-port/src/extension.ts
+++ b/code/extensions/che-port/src/extension.ts
@@ -10,11 +10,6 @@
 
 /* eslint-disable header/header */
 
-if (Reflect.metadata === undefined) {
-  // tslint:disable-next-line:no-require-imports no-var-requires
-  require('reflect-metadata');
-}
-
 import * as vscode from 'vscode';
 
 import { PortsPlugin } from './ports-plugin';

--- a/code/extensions/che-port/tsconfig.json
+++ b/code/extensions/che-port/tsconfig.json
@@ -6,8 +6,7 @@
 		"emitDecoratorMetadata": true,
 		"types": [
 			"node",
-			"jest",
-			"reflect-metadata"
+			"jest"
 		]
 	},
 	"include": [


### PR DESCRIPTION
### What does this PR do?
`che-port` extension doesn't use `reflect-metadata`, so this dependency can be removed.
 
### How to test this PR?
1. Create a workspace using https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/dashboard/#/load-factory?editor-image=quay.io/che-incubator-pull-requests/che-code:pr-515-amd64&url=https://registry.devfile.io/devfiles/nodejs/2.2.1
2. Terminal => Run Task => devfile => install
3. Terminal => Run Task => devfile => run
4. The following notification should be displayed 
<img width="496" alt="image" src="https://github.com/user-attachments/assets/ff38d897-d05c-461e-8932-79d08759adf6" />

6. Use notification's buttons to check if a page will be opened 
7. Go to the `Explorer` view and check that the `Endpoints` panel is present and functionality works as expected.
<img width="360" alt="image" src="https://github.com/user-attachments/assets/ed26c0e5-f74d-421a-b8ef-5f8ccbfbd1c9" />



### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
