### PR TITLE
feat: allow to configure product.json using configmap (#521)

### DIFF
--- a/launcher/package-lock.json
+++ b/launcher/package-lock.json
@@ -2110,7 +2110,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/launcher/src/editor-configurations.ts
+++ b/launcher/src/editor-configurations.ts
@@ -10,6 +10,8 @@
 
 import * as k8s from '@kubernetes/client-node';
 import * as fs from './fs-extra.js';
+import { ProductJSON } from './product-json.js';
+import { mergeFirstWithSecond, parseJSON } from './json-utils.js';
 
 const CONFIGMAP_NAME = 'vscode-editor-configurations';
 const REMOTE_SETTINGS_PATH = '/checode/remote/data/Machine/settings.json';
@@ -17,27 +19,35 @@ const REMOTE_SETTINGS_PATH = '/checode/remote/data/Machine/settings.json';
 const enum EditorConfigs {
   Settings = 'settings.json',
   Extensions = 'extensions.json',
+  Product = 'product.json',
 }
 
-export class EditorConfigurations {
-  private coreV1API: k8s.CoreV1Api;
+/**
+ * See following documentation for details
+ * https://eclipse.dev/che/docs/stable/administration-guide/editor-configurations-for-microsoft-visual-studio-code/
+ */
 
+export class EditorConfigurations {
   constructor(private readonly workspaceFilePath?: string) {}
 
   async configure(): Promise<void> {
-    console.log('# Checking if editor configurations are provided...');
+    console.log(`# Checking for editor configurations provided by '${CONFIGMAP_NAME}' Config Map...`);
+
+    if (!process.env.DEVWORKSPACE_NAMESPACE) {
+      console.log('  > process.env.DEVWORKSPACE_NAMESPACE is not set, skip this step');
+      return;
+    }
 
     try {
       const configmap = await this.getConfigmap();
       if (!configmap || !configmap.data) {
-        console.log('  > Editor configurations are not provided');
+        console.log(`  > Config Map ${CONFIGMAP_NAME} is not provided, skip this step`);
         return;
       }
 
-      const settingsPromise = this.configureSettings(configmap);
-      const extensionsPromise = this.configureExtensions(configmap);
-
-      await Promise.all([settingsPromise, extensionsPromise]);
+      await this.configureSettings(configmap);
+      await this.configureExtensions(configmap);
+      await this.configureProductJSON(configmap);
     } catch (error) {
       console.log(`  > Failed to apply editor configurations ${error}`);
     }
@@ -46,134 +56,120 @@ export class EditorConfigurations {
   private async configureSettings(configmap: k8s.V1ConfigMap): Promise<void> {
     const configmapContent = configmap.data![EditorConfigs.Settings];
     if (!configmapContent) {
-      console.log(`  > ${EditorConfigs.Settings} is not provided in the ${CONFIGMAP_NAME} configmap`);
-      return;
-    } else {
-      console.log(
-        `  > ${EditorConfigs.Settings} is provided in the ${CONFIGMAP_NAME} configmap, trying to apply it...`
-      );
-    }
-
-    const settingsFromConfigmap = parseJsonFrom(configmapContent);
-    if (!settingsFromConfigmap) {
-      console.log(
-        `    > Can not apply editor configurations: failed to parse ${EditorConfigs.Settings} data from the ${CONFIGMAP_NAME} configmap`
-      );
       return;
     }
 
-    let remoteSettingsJson;
-    if (await fs.fileExists(REMOTE_SETTINGS_PATH)) {
-      console.log(`    > File with settings is found: ${REMOTE_SETTINGS_PATH}`);
+    console.log('  > Configure editor settings...');
 
-      const remoteSettingsContent = await fs.readFile(REMOTE_SETTINGS_PATH);
-      remoteSettingsJson = parseJsonFrom(remoteSettingsContent);
-    } else {
-      console.log(`    > File with settings is not found, creating a new one: ${REMOTE_SETTINGS_PATH}`);
-      remoteSettingsJson = {};
+    try {
+      const settingsFromConfigmap = parseJSON(configmapContent, {
+        errorMessage: 'Configmap content is not valid.',
+      });
+
+      let remoteSettingsJson;
+      if (await fs.fileExists(REMOTE_SETTINGS_PATH)) {
+        console.log(`    > Found setings file: ${REMOTE_SETTINGS_PATH}`);
+        const remoteSettingsContent = await fs.readFile(REMOTE_SETTINGS_PATH);
+        remoteSettingsJson = parseJSON(remoteSettingsContent, {
+          errorMessage: 'Settings.json file is not valid.',
+        });
+      } else {
+        console.log(`    > Creating settings file: ${REMOTE_SETTINGS_PATH}`);
+        remoteSettingsJson = {};
+      }
+
+      const mergedSettings = { ...remoteSettingsJson, ...settingsFromConfigmap };
+      const json = JSON.stringify(mergedSettings, null, '\t');
+      await fs.writeFile(REMOTE_SETTINGS_PATH, json);
+
+      console.log('    > Editor settings have been configured.');
+    } catch (error) {
+      console.log('Failed to configure editor settings.', error);
     }
-
-    const mergedSettings = { ...remoteSettingsJson, ...settingsFromConfigmap };
-    const json = JSON.stringify(mergedSettings, null, '\t');
-    await fs.writeFile(REMOTE_SETTINGS_PATH, json);
-
-    console.log(`    > ${EditorConfigs.Settings} configs were applied successfully!`);
   }
 
   private async configureExtensions(configmap: k8s.V1ConfigMap): Promise<void> {
     const configmapContent = configmap.data![EditorConfigs.Extensions];
     if (!configmapContent) {
-      console.log(`  > ${EditorConfigs.Extensions} is not provided in the ${CONFIGMAP_NAME} configmap`);
-      return;
-    } else {
-      console.log(
-        `  > ${EditorConfigs.Extensions} is provided in the ${CONFIGMAP_NAME} configmap, trying to apply it...`
-      );
-    }
-
-    const extensionsFromConfigmap = parseJsonFrom(configmapContent);
-    if (!extensionsFromConfigmap) {
-      console.log(
-        `    > Can not apply editor configurations: failed to parse ${EditorConfigs.Extensions} data from the ${CONFIGMAP_NAME} configmap`
-      );
       return;
     }
 
-    if (this.workspaceFilePath && (await fs.fileExists(this.workspaceFilePath))) {
-      console.log(`    > File with configs is found: ${this.workspaceFilePath}`);
+    console.log('  > Configure workspace extensions...');
 
-      const workspaceFileContent = await fs.readFile(this.workspaceFilePath);
-      const workspaceConfigData = parseJsonFrom(workspaceFileContent);
-      if (!workspaceConfigData) {
-        console.log(
-          `    > Can not apply configurations for ${EditorConfigs.Extensions}: failed to parse data from the ${this.workspaceFilePath}`
-        );
+    try {
+      const extensionsFromConfigmap = parseJSON(configmapContent, {
+        errorMessage: 'Configmap content is not valid.',
+      });
+
+      if (!this.workspaceFilePath) {
+        console.log('    > Missing workspace file. Skip this step.');
         return;
       }
 
-      const extensionsSection = 'extensions';
-      if (!workspaceConfigData[extensionsSection]) {
-        console.log('    > Extensions section is absent in the workspace file, creating a new one...');
-        workspaceConfigData[extensionsSection] = {};
+      if (!(await fs.fileExists(this.workspaceFilePath))) {
+        console.log(`    > Unable to find workspace file: ${this.workspaceFilePath}. Skip this step.`);
+        return;
       }
 
-      workspaceConfigData[extensionsSection] = {
-        ...workspaceConfigData[extensionsSection],
+      console.log(`    > Found workspace file: ${this.workspaceFilePath}`);
+
+      const workspaceFileContent = await fs.readFile(this.workspaceFilePath);
+      const workspaceConfigData = parseJSON(workspaceFileContent, {
+        errorMessage: 'Workspace file is not valid.',
+      });
+
+      workspaceConfigData['extensions'] = {
+        ...(workspaceConfigData['extensions'] || {}),
         ...extensionsFromConfigmap,
       };
 
       const json = JSON.stringify(workspaceConfigData, null, '\t');
       await fs.writeFile(this.workspaceFilePath, json);
-      console.log(`    > ${EditorConfigs.Extensions} was applied successfully!`);
-    } else {
-      console.log(`    > Workspace Config File with is not found: ${this.workspaceFilePath}`);
-      // it's not possible to store extensions for the Remote scope,
-      // for sinle root mode extensions should come with a project, like: /project/.vscode/extensions.json - Folder scope
-      // so, we don't store extensions configs in another place if there is no workspace config file
-      //
+      console.log('    > Workspace extensions have been configured.');
+    } catch (error) {
+      console.log('Failed to configure workspace extensions.', error);
+    }
+  }
+
+  private async configureProductJSON(configmap: k8s.V1ConfigMap): Promise<void> {
+    const configmapContent = configmap.data![EditorConfigs.Product];
+    if (!configmapContent) {
       return;
+    }
+
+    console.log('  > Configure product.json ...');
+
+    try {
+      const productFromConfigmap = parseJSON(configmapContent, {
+        errorMessage: 'Configmap content is not valid.',
+      });
+
+      const product = new ProductJSON();
+      await product.load();
+
+      mergeFirstWithSecond(productFromConfigmap, product.get());
+
+      await product.save();
+
+      console.log('    > product.json have been configured.');
+    } catch (error) {
+      console.log(`Failed to configure ${EditorConfigs.Product}.`, error);
     }
   }
 
   private async getConfigmap(): Promise<k8s.V1ConfigMap | undefined> {
-    const coreV1API = this.getCoreApi();
-    const namespace = process.env.DEVWORKSPACE_NAMESPACE;
-    if (!namespace) {
-      console.log(
-        '  > Error: Can not get Configmap with editor configurations - DEVWORKSPACE_NAMESPACE env variable is not defined'
-      );
-      return undefined;
-    }
+    const k8sConfig = new k8s.KubeConfig();
+    k8sConfig.loadFromCluster();
+    const coreV1API = k8sConfig.makeApiClient(k8s.CoreV1Api);
 
     try {
-      const { body } = await coreV1API.readNamespacedConfigMap(CONFIGMAP_NAME, namespace);
+      const { body } = await coreV1API.readNamespacedConfigMap(CONFIGMAP_NAME, process.env.DEVWORKSPACE_NAMESPACE!);
       return body;
     } catch (error) {
       console.log(
-        `#   > Warning: Can not get Configmap with editor configurations: ${error.message}, status code: ${error?.response?.statusCode}`
+        `  > Warning: Can not get Configmap with editor configurations: ${error.message}, status code: ${error?.response?.statusCode}`
       );
       return undefined;
     }
-  }
-
-  getCoreApi(): k8s.CoreV1Api {
-    if (!this.coreV1API) {
-      const k8sConfig = new k8s.KubeConfig();
-      k8sConfig.loadFromCluster();
-      this.coreV1API = k8sConfig.makeApiClient(k8s.CoreV1Api);
-    }
-    return this.coreV1API;
-  }
-}
-
-export function parseJsonFrom(content: string): any {
-  if (!content) {
-    return undefined;
-  }
-
-  try {
-    return JSON.parse(content);
-  } catch (parseError) {
-    console.error(`  > Error parsing JSON: ${parseError}`);
   }
 }

--- a/launcher/src/json-utils.ts
+++ b/launcher/src/json-utils.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/**
+ * Recursively copies all properties from the first object to the next.
+ * If the property exists in the next object, its value will be updated.
+ */
+export function mergeFirstWithSecond(first: any, second: any) {
+  if (Array.isArray(first)) {
+    if (!Array.isArray(second)) {
+      // incompatiblity of types :: skip and do nothing
+      return;
+    }
+
+    for (const element of first) {
+      if (second.includes(element)) {
+        continue;
+      }
+
+      second.push(element);
+    }
+
+    return;
+  }
+
+  for (const key of Object.keys(first)) {
+    if (second[key] === undefined) {
+      // if second object does not contain the property, copy it
+      second[key] = first[key];
+    } else {
+      // if second object contains the same property, check for options
+      if ('string' === typeof first[key] && 'string' === typeof second[key]) {
+        // if the property is string, update the value
+        second[key] = first[key];
+      } else if ('number' === typeof first[key] && 'number' === typeof second[key]) {
+        // if the property is number, update the value
+        second[key] = first[key];
+      } else if ('object' === typeof first[key] && 'object' === typeof second[key]) {
+        // if the property is object, merge values
+        mergeFirstWithSecond(first[key], second[key]);
+      }
+
+      // in case of incompatibility of types, do nothing
+    }
+  }
+}
+
+export function parseJSON(content: string, options?: { errorMessage: string }) {
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    if (error.message && options && options.errorMessage) {
+      error.message = `${options.errorMessage} ${error.message}`;
+    }
+
+    throw error;
+  }
+}

--- a/launcher/src/product-json.ts
+++ b/launcher/src/product-json.ts
@@ -17,22 +17,28 @@ export interface Record {
 }
 
 export class ProductJSON {
-  private json: any;
+  private product: any;
 
   async load(): Promise<ProductJSON> {
     const content = await fs.readFile(PRODUCT_JSON);
-    this.json = JSON.parse(content);
+    this.product = JSON.parse(content);
 
     return this;
   }
 
   async save(): Promise<void> {
-    const serialized = JSON.stringify(this.json, null, '\t');
-    await fs.writeFile(PRODUCT_JSON, serialized);
+    if (this.product) {
+      const serialized = JSON.stringify(this.product, null, '\t');
+      await fs.writeFile(PRODUCT_JSON, serialized);
+    }
+  }
+
+  get(): any {
+    return this.product;
   }
 
   getWebviewContentExternalBaseUrlTemplate(): string {
-    const url = this.json.webviewContentExternalBaseUrlTemplate;
+    const url = this.product.webviewContentExternalBaseUrlTemplate;
 
     if (!url) {
       throw new Error('Failure to find .webviewContentExternalBaseUrlTemplate in product.json.');
@@ -42,11 +48,11 @@ export class ProductJSON {
   }
 
   setWebviewContentExternalBaseUrlTemplate(url: string): void {
-    this.json.webviewContentExternalBaseUrlTemplate = url;
+    this.product.webviewContentExternalBaseUrlTemplate = url;
   }
 
   getExtensionsGalleryServiceURL(): string {
-    const gallery = this.json.extensionsGallery;
+    const gallery = this.product.extensionsGallery;
     if (!gallery) {
       throw new Error('Failure to find .extensionsGallery.serviceUrl in product.json.');
     }
@@ -61,17 +67,17 @@ export class ProductJSON {
   }
 
   setExtensionsGalleryServiceURL(url: string): void {
-    let gallery = this.json.extensionsGallery;
+    let gallery = this.product.extensionsGallery;
     if (!gallery) {
       gallery = {};
-      this.json.extensionsGallery = gallery;
+      this.product.extensionsGallery = gallery;
     }
 
     gallery.serviceUrl = url;
   }
 
   getExtensionsGalleryItemURL(): string {
-    const gallery = this.json.extensionsGallery;
+    const gallery = this.product.extensionsGallery;
     if (!gallery) {
       throw new Error('Failure to find .extensionsGallery.serviceUrl in product.json.');
     }
@@ -85,20 +91,20 @@ export class ProductJSON {
   }
 
   setExtensionsGalleryItemURL(url: string): void {
-    let gallery = this.json.extensionsGallery;
+    let gallery = this.product.extensionsGallery;
     if (!gallery) {
       gallery = {};
-      this.json.extensionsGallery = gallery;
+      this.product.extensionsGallery = gallery;
     }
 
     gallery.itemUrl = url;
   }
 
   getTrustedExtensionAuthAccess(): string[] | Record | undefined {
-    return this.json.trustedExtensionAuthAccess;
+    return this.product.trustedExtensionAuthAccess;
   }
 
   setTrustedExtensionAuthAccess(trustedExtensionAuthAccess: string[] | Record | undefined) {
-    this.json.trustedExtensionAuthAccess = trustedExtensionAuthAccess;
+    this.product.trustedExtensionAuthAccess = trustedExtensionAuthAccess;
   }
 }


### PR DESCRIPTION
### What does this PR do?
Backport of https://github.com/che-incubator/che-code/pull/521

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23270

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
