### PR TITLE
Fix path in in generating extension callback URL

### DIFF
--- a/.rebase/replace/code/src/vs/code/browser/workbench/workbench.ts.json
+++ b/.rebase/replace/code/src/vs/code/browser/workbench/workbench.ts.json
@@ -1,7 +1,7 @@
 [
   {
     "from": "return URI.parse(mainWindow.location.href).with({ path: this._callbackRoute, query: queryParams.join('&') });",
-    "by": "const windowURI = URI.parse(mainWindow.location.href);\\\n\\\t\\\tconst fullPath = windowURI.path.replace(/\\\\/$/, '') + this._callbackRoute;\\\n\\\t\\\treturn windowURI.with({ path: fullPath, query: queryParams.join('\\&') });"
+    "by": "const windowURI = URI.parse(mainWindow.location.href);\\\n\\\t\\\tconst callback = this._callbackRoute.replace(', ', '');\\\n\\\t\\\treturn windowURI.with({ path: callback, query: queryParams.join('\\&') });"
   },
   {
     "from": "private _serverKey: Uint8Array \\| undefined;",

--- a/code/src/vs/code/browser/workbench/workbench.ts
+++ b/code/src/vs/code/browser/workbench/workbench.ts
@@ -319,12 +319,8 @@ class LocalStorageURLCallbackProvider extends Disposable implements IURLCallback
 		}
 
 		const windowURI = URI.parse(mainWindow.location.href);
-		console.log('--------window URL---------' + windowURI.toString());
 		const callback = this._callbackRoute.replace(', ', '');
-		console.log('--------callbackRoute---------' + callback);
-		const result = windowURI.with({ path: callback, query: queryParams.join('&') });
-		console.log('--------Result---------' + result.toString());
-		return result;
+		return windowURI.with({ path: callback, query: queryParams.join('&') });
 	}
 
 	private startListening(): void {

--- a/code/src/vs/code/browser/workbench/workbench.ts
+++ b/code/src/vs/code/browser/workbench/workbench.ts
@@ -320,12 +320,9 @@ class LocalStorageURLCallbackProvider extends Disposable implements IURLCallback
 
 		const windowURI = URI.parse(mainWindow.location.href);
 		console.log('--------window URL---------' + windowURI.toString());
-		const windowURIPatched = windowURI.path.replace(/\/$/, '');
-		const fullPath = windowURIPatched + this._callbackRoute;
-		console.log('--------1 Part---------' + windowURIPatched);
-		console.log('--------callbackRoute---------' + this._callbackRoute);
-		console.log('--------fullPath---------' + fullPath.toString());
-		const result = windowURI.with({ path: fullPath, query: queryParams.join('&') });
+		const callback = this._callbackRoute.replace(', ', '');
+		console.log('--------callbackRoute---------' + callback);
+		const result = windowURI.with({ path: callback, query: queryParams.join('&') });
 		console.log('--------Result---------' + result.toString());
 		return result;
 	}

--- a/code/src/vs/code/browser/workbench/workbench.ts
+++ b/code/src/vs/code/browser/workbench/workbench.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { log } from 'node:console';
 import { isStandalone } from '../../../base/browser/browser.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { VSBuffer, decodeBase64, encodeBase64 } from '../../../base/common/buffer.js';

--- a/code/src/vs/code/browser/workbench/workbench.ts
+++ b/code/src/vs/code/browser/workbench/workbench.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { log } from 'node:console';
 import { isStandalone } from '../../../base/browser/browser.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { VSBuffer, decodeBase64, encodeBase64 } from '../../../base/common/buffer.js';
@@ -319,8 +320,15 @@ class LocalStorageURLCallbackProvider extends Disposable implements IURLCallback
 		}
 
 		const windowURI = URI.parse(mainWindow.location.href);
-		const fullPath = windowURI.path.replace(/\/$/, '') + this._callbackRoute;
-		return windowURI.with({ path: fullPath, query: queryParams.join('&') });
+		console.log('--------window URL---------' + windowURI.toString());
+		const windowURIPatched = windowURI.path.replace(/\/$/, '');
+		const fullPath = windowURIPatched + this._callbackRoute;
+		console.log('--------1 Part---------' + windowURIPatched);
+		console.log('--------callbackRoute---------' + this._callbackRoute);
+		console.log('--------fullPath---------' + fullPath.toString());
+		const result = windowURI.with({ path: fullPath, query: queryParams.join('&') });
+		console.log('--------Result---------' + result.toString());
+		return result;
 	}
 
 	private startListening(): void {


### PR DESCRIPTION
### What does this PR do?
Extension callback rout contains a few parts that should be merged into one path before adding it into the extension redirect URL:
`callbackRoute = '/namespace-name/workspace-name, /3100/oss-dev/callback';` --> `callbackRoute = '/namespace-name/workspace-name/3100/oss-dev/callback';`

To have 
```
https://devspaces.apps.rstage.wybr.p1.openshiftapps.com/vsvydenk/ansible-demo/3100/oss-dev/callback?vscode-reqid=11&vscode-scheme=checode&vscode-authority=redhat.ansible
```
Instead of
```
https://devspaces.apps.rstage.wybr.p1.openshiftapps.com/vsvydenk/ansible-demo/3100/vsvydenk/ansible-demo,+3100/oss-dev/callback?vscode-reqid=11&vscode-scheme=checode&vscode-authority=redhat.ansible
```
### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-8312

### How to test this PR?
You can use [Dev Spaces stage](https://devspaces.apps.rstage.wybr.p1.openshiftapps.com/dashboard/ ) for testing
Start Ansible sample with the editor image built in this PR:
![screenshot-devspaces_apps_rstage_wybr_p1_openshiftapps_com-2025_03_28-13_27_15](https://github.com/user-attachments/assets/03d8dcbe-7d3c-4379-ac54-b0acaf4cab49)
Try to Connect to Ansible lightspeed server form Ansible extension view:
![screenshot-devspaces_apps_rstage_wybr_p1_openshiftapps_com-2025_03_28-14_06_02](https://github.com/user-attachments/assets/81e3a349-f5d8-41c5-85a3-fd9d5cb781be)

You should login to the server without errors

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [+] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [+] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
