### PR TITLE
chore: Change artifacts download urls to point to Open VSX registry

### DIFF
--- a/build/artifacts/artifacts.lock.yaml
+++ b/build/artifacts/artifacts.lock.yaml
@@ -3,19 +3,19 @@ metadata:
   version: "1.0"
 artifacts:
   # ms-vscode.js-debug-companion
-  - download_url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix
+  - download_url: https://open-vsx.org/api/ms-vscode/js-debug-companion/1.1.3/file/ms-vscode.js-debug-companion-1.1.3.vsix
     filename: ms-vscode.js-debug-companion.1.1.3.vsix
     checksum: sha256:7380a890787452f14b2db7835dfa94de538caf358ebc263f9d46dd68ac52de93
   # ms-vscode.js-debug
-  - download_url: https://github.com/microsoft/vscode-js-debug/releases/download/v1.97.1/ms-vscode.js-debug.1.97.1.vsix
+  - download_url: https://open-vsx.org/api/ms-vscode/js-debug/1.97.1/file/ms-vscode.js-debug-1.97.1.vsix
     filename: ms-vscode.js-debug.1.97.1.vsix
     checksum: sha256:977dd854805547702e312e176f68a1b142fa123f228258f47f0964560ad32496
   # ms-vscode.vscode-js-profile-table
-  - download_url: https://github.com/microsoft/vscode-js-profile-visualizer/releases/download/v1.0.10/ms-vscode.vscode-js-profile-table.1.0.10.vsix
+  - download_url: https://open-vsx.org/api/ms-vscode/vscode-js-profile-table/1.0.10/file/ms-vscode.vscode-js-profile-table-1.0.10.vsix
     filename: ms-vscode.vscode-js-profile-table.1.0.10.vsix
     checksum: sha256:7361748ddf9fd09d8a2ed1f2a2d7376a2cf9aae708692820b799708385c38e08
   # devfile.vscode-devfile
-  - download_url: https://github.com/devfile/vscode-walkthrough-extension/releases/download/v0.0.4/devfile.vscode-devfile.0.0.4.vsix
+  - download_url: https://open-vsx.org/api/devfile/vscode-devfile/0.0.4/file/devfile.vscode-devfile-0.0.4.vsix
     filename: devfile.vscode-devfile.0.0.4.vsix
     checksum: sha256:c55a6c1d087e7715bfacb01c0c2b52ef0f935d85f0707265d9068cd64143744c
   # ripgrep-ppc64le

--- a/build/artifacts/generate.sh
+++ b/build/artifacts/generate.sh
@@ -31,19 +31,17 @@ makeArtifactsLockYaml () {
   PLUGINS=$(jq -r '.builtInExtensions[] | .name' "$PRODUCT_JSON")
   for PLUGIN in $PLUGINS; do
     VERSION=$(jq -r '.builtInExtensions[] | select(.name=="'${PLUGIN}'") | .version' "$PRODUCT_JSON")
-    REPOSITORY=$(jq -r '.builtInExtensions[] | select(.name=="'${PLUGIN}'") | .repo' "$PRODUCT_JSON")
     SHA256=$(jq -r '.builtInExtensions[] | select(.name=="'${PLUGIN}'") | .sha256' "$PRODUCT_JSON")
+    PUBLISHER=$(echo "$PLUGIN" | cut -d '.' -f 1)
+    NAME=$(echo "$PLUGIN" | cut -d '.' -f 2)
+    DOWNLOAD_URL="https://open-vsx.org/api/${PUBLISHER}/${NAME}/${VERSION}/file/${PLUGIN}-${VERSION}.vsix"
+    FILENAME="$PLUGIN.$VERSION.vsix"
+    checkUrlExistence "$DOWNLOAD_URL"
 
-    if [[ ! $SHA256 == "null" ]]; then
-      FILENAME="$PLUGIN.$VERSION.vsix"
-      DOWNLOAD_URL="$REPOSITORY/releases/download/v$VERSION/$FILENAME"
-      checkUrlExistence "$DOWNLOAD_URL"
-
-      echo "  # $PLUGIN"                      >> "$ARTIFACTS_LOCK_YAML"
-      echo "  - download_url: $DOWNLOAD_URL"  >> "$ARTIFACTS_LOCK_YAML"
-      echo "    filename: $FILENAME"          >> "$ARTIFACTS_LOCK_YAML"
-      echo "    checksum: sha256:$SHA256"     >> "$ARTIFACTS_LOCK_YAML"
-    fi
+    echo "  # $PLUGIN"                      >> "$ARTIFACTS_LOCK_YAML"
+    echo "  - download_url: $DOWNLOAD_URL"  >> "$ARTIFACTS_LOCK_YAML"
+    echo "    filename: $FILENAME"          >> "$ARTIFACTS_LOCK_YAML"
+    echo "    checksum: sha256:$SHA256"     >> "$ARTIFACTS_LOCK_YAML"
   done
 
   # Generate artifacts for ripgrep dependency


### PR DESCRIPTION
### What does this PR do?
chore: Change artifacts download urls to point to Open VSX registry

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
N/A

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
