### PR TITLE
fix: Always install release version of extensions

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,12 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/539
+
+- code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+---
+
+#### @RomanNikitenko
 https://github.com/che-incubator/che-code/pull/557
 
 - code/package.json

--- a/.rebase/replace/code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts.json
+++ b/.rebase/replace/code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts.json
@@ -1,0 +1,6 @@
+[
+    {
+        "from": "this.preferPreReleases = this.productService.quality !== 'stable';",
+        "by": "this.preferPreReleases = false;"
+    }
+]

--- a/code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -69,7 +69,7 @@ export abstract class CommontExtensionManagementService extends Disposable imple
 		@IAllowedExtensionsService protected readonly allowedExtensionsService: IAllowedExtensionsService,
 	) {
 		super();
-		this.preferPreReleases = this.productService.quality !== 'stable';
+		this.preferPreReleases = false;
 	}
 
 	async canInstall(extension: IGalleryExtension): Promise<true | IMarkdownString> {

--- a/rebase.sh
+++ b/rebase.sh
@@ -482,6 +482,8 @@ resolve_conflicts() {
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/platform/extensionManagement/node/extensionManagementService.ts" ]]; then
       apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts" ]]; then
+      apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts" ]]; then
       apply_multi_line_replace "$conflictingFile"
     else


### PR DESCRIPTION
### What does this PR do?
- changes default behaviour - `Extensions` panel proposes to install `release` version of an extension (instead of the `pre-release` one)
- fixes bug related to installation `pre-release` version of an extension, see https://github.com/eclipse-che/che/issues/23486  

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23486

### How to test this PR?
#### `Install` button should be displayed by default instead of `Install Pre-release` one 
- Go to the dashboard
- Set `quay.io/che-incubator-pull-requests/che-code:pr-539-amd64` to the `Editor Image` field 
- Start a workspace or Empty Workspace
- Go to the `Extensions` panel
- Check that `Install` button is displayed by default on an extension's item 

Wrong behaviour: 
<img width="306" height="291" alt="image" src="https://github.com/user-attachments/assets/5ea57fa9-6a4f-4b60-a252-7ee7ba4c7b50" />

Correct behaviour:
<img width="306" height="291" alt="image" src="https://github.com/user-attachments/assets/8ef96531-1a1d-4d5d-94f4-a60547d4e3fd" />

#### Use case related to https://github.com/eclipse-che/che/issues/23486
- Start workspace https://workspaces.openshift.com#https://github.com/che-incubator/quarkus-api-example?editor-image=quay.io/che-incubator-pull-requests/che-code:pr-539-amd64
- Go to the `Extensions` panel
- Check that `release` version of the `Language Support for Java` extension is installed
<img width="608" height="291" alt="image" src="https://github.com/user-attachments/assets/ecfe54c7-0270-476d-b79b-2a820002fbb4" />

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
