### PR TITLE
Bump ripgrep version

### DIFF
--- a/code/build/package-lock.json
+++ b/code/build/package-lock.json
@@ -42,7 +42,7 @@
         "@types/workerpool": "^6.4.0",
         "@types/xml2js": "0.0.33",
         "@vscode/iconv-lite-umd": "0.7.0",
-        "@vscode/ripgrep": "^1.15.10",
+        "@vscode/ripgrep": "^1.15.11",
         "@vscode/vsce": "2.20.1",
         "byline": "^5.0.0",
         "debug": "^4.3.2",
@@ -1317,12 +1317,11 @@
       "dev": true
     },
     "node_modules/@vscode/ripgrep": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.10.tgz",
-      "integrity": "sha512-83Q6qFrELpFgf88bPOcwSWDegfY2r/cb6bIfdLTSZvN73Dg1wviSfO+1v6lTFMd0mAvUYYcTUu+Mn5xMroZMxA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.11.tgz",
+      "integrity": "sha512-G/VqtA6kR50mJkIH4WA+I2Q78V5blovgPPq0VPYM0QIRp57lYMkdV+U9VrY80b3AvaC72A1z8STmyxc8ZKiTsw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "https-proxy-agent": "^7.0.2",
         "proxy-from-env": "^1.1.0",

--- a/code/build/package.json
+++ b/code/build/package.json
@@ -36,7 +36,7 @@
     "@types/workerpool": "^6.4.0",
     "@types/xml2js": "0.0.33",
     "@vscode/iconv-lite-umd": "0.7.0",
-    "@vscode/ripgrep": "^1.15.10",
+    "@vscode/ripgrep": "^1.15.11",
     "@vscode/vsce": "2.20.1",
     "byline": "^5.0.0",
     "debug": "^4.3.2",


### PR DESCRIPTION
### What does this PR do?
Bump ripgrep version, the change should fix downstream build.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-8646

### How to test this PR?
`Patch` version was changed within current PR, so I think it should be safe enough. 
### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
