### PR TITLE
chore: add ripgrep-aarch64 artifcat download url

### DIFF
--- a/build/artifacts/artifacts.lock.yaml
+++ b/build/artifacts/artifacts.lock.yaml
@@ -31,6 +31,6 @@ artifacts:
     filename: ripgrep-v13.0.0-10-x86_64-unknown-linux-musl.tar.gz
     checksum: sha256:ef820a62c1d6fdc396646762ff0f0e47e127947073ed8b5aa4ceea8b61cb1659
   # ripgrep-aarch64
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-4/ripgrep-v13.0.0-4-aarch64-unknown-linux-musl.tar.gz
-    filename: ripgrep-v13.0.0-4-aarch64-unknown-linux-musl.tar.gz
-    checksum: sha256:4f68e74e505dbac9d5f399a18e165b4ca2231be09926adf7a83379eda5c8b666
+  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-10/ripgrep-v13.0.0-10-aarch64-unknown-linux-musl.tar.gz
+    filename: ripgrep-v13.0.0-10-aarch64-unknown-linux-musl.tar.gz
+    checksum: sha256:96bcc969ba424c2dd0cd622d7aa8ecf05ec06ff5a0db42c785a737a61c838879

--- a/build/artifacts/artifacts.lock.yaml
+++ b/build/artifacts/artifacts.lock.yaml
@@ -30,3 +30,7 @@ artifacts:
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-10/ripgrep-v13.0.0-10-x86_64-unknown-linux-musl.tar.gz
     filename: ripgrep-v13.0.0-10-x86_64-unknown-linux-musl.tar.gz
     checksum: sha256:ef820a62c1d6fdc396646762ff0f0e47e127947073ed8b5aa4ceea8b61cb1659
+  # ripgrep-aarch64
+  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-4/ripgrep-v13.0.0-4-aarch64-unknown-linux-musl.tar.gz
+    filename: ripgrep-v13.0.0-4-aarch64-unknown-linux-musl.tar.gz
+    checksum: sha256:4f68e74e505dbac9d5f399a18e165b4ca2231be09926adf7a83379eda5c8b666

--- a/build/artifacts/generate.sh
+++ b/build/artifacts/generate.sh
@@ -60,8 +60,8 @@ makeArtifactsLockYaml () {
       'aarch64') RG_ARCH_SUFFIX='aarch64-unknown-linux-musl';;
     esac
     case $PLATFORM in
-      'ppc64le' | 'aarch64' | 's390x') RG_VERSION=${VSIX_RIPGREP_PREBUILT_MULTIARCH_VERSION};;
-      'x86_64') RG_VERSION="${VSIX_RIPGREP_PREBUILT_VERSION}";;
+      'ppc64le' | 's390x') RG_VERSION=${VSIX_RIPGREP_PREBUILT_MULTIARCH_VERSION};;
+      'x86_64' | 'aarch64') RG_VERSION="${VSIX_RIPGREP_PREBUILT_VERSION}";;
     esac
 
     FILENAME="ripgrep-${RG_VERSION}-${RG_ARCH_SUFFIX}.tar.gz"

--- a/build/artifacts/generate.sh
+++ b/build/artifacts/generate.sh
@@ -51,15 +51,16 @@ makeArtifactsLockYaml () {
   VSIX_RIPGREP_PREBUILT_VERSION=$(echo "${POST_INSTALL_SCRIPT}" | grep "const VERSION" | cut -d"'" -f 2 )
   VSIX_RIPGREP_PREBUILT_MULTIARCH_VERSION=$(echo "${POST_INSTALL_SCRIPT}" | grep "const MULTI_ARCH_LINUX_VERSION" | cut -d"'" -f 2 )
 
-  PLATFORMS=("ppc64le" "s390x" "x86_64")
+  PLATFORMS=("ppc64le" "s390x" "x86_64" "aarch64")
   for PLATFORM in "${PLATFORMS[@]}"; do
     case $PLATFORM in
       'ppc64le') RG_ARCH_SUFFIX='powerpc64le-unknown-linux-gnu';;
       's390x') RG_ARCH_SUFFIX='s390x-unknown-linux-gnu';;
       'x86_64') RG_ARCH_SUFFIX='x86_64-unknown-linux-musl';;
+      'aarch64') RG_ARCH_SUFFIX='aarch64-unknown-linux-musl';;
     esac
     case $PLATFORM in
-      'ppc64le' | 's390x') RG_VERSION=${VSIX_RIPGREP_PREBUILT_MULTIARCH_VERSION};;
+      'ppc64le' | 'aarch64' | 's390x') RG_VERSION=${VSIX_RIPGREP_PREBUILT_MULTIARCH_VERSION};;
       'x86_64') RG_VERSION="${VSIX_RIPGREP_PREBUILT_VERSION}";;
     esac
 


### PR DESCRIPTION
### What does this PR do?
Add ripgrep-aarch64 artifcat download url

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
Fix building downstream version of che-code on arm64 platform

### How to test this PR?
N/A

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
