### PR TITLE
[DRAFT] Create dedicated step to cleanup space on smoke test runner

### DIFF
--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -78,12 +78,12 @@ jobs:
         run: |
           docker images
 
-      - name: Cleanup docker images
+      - name: Clean up to save disk space
         run: |
+          df -h
+
           docker system prune -af
 
-      - name: Disk free
-        run: |
           df -h
 
       - name: Start minikube


### PR DESCRIPTION
### What does this PR do?
Cleans up GitHub runner to prevent EmptyWorkspace test PR check failure because of lack of space.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
[#23455](https://github.com/eclipse-che/che/issues/23457)

### How to test this PR?
Check `Smoke Test` GitHub Action status.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
