### PR TITLE
[7-104] Do not display Copilot-related items in the Command Center area

### DIFF
--- a/build/remote-config/settings.json
+++ b/build/remote-config/settings.json
@@ -1,3 +1,4 @@
 {
-  "git.defaultCloneDirectory": "/projects/"
+  "git.defaultCloneDirectory": "/projects/",
+  "chat.commandCenter.enabled": false
 }

--- a/code/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/code/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -709,7 +709,10 @@ registerAction2(class ToggleCopilotControl extends ToggleTitleBarConfigAction {
 			'chat.commandCenter.enabled',
 			localize('toggle.chatControl', 'Copilot Controls'),
 			localize('toggle.chatControlsDescription', "Toggle visibility of the Copilot Controls in title bar"), 5, false,
-			ChatContextKeys.supported
+			ContextKeyExpr.and(
+				ChatContextKeys.supported,
+				ContextKeyExpr.has('config.chat.commandCenter.enabled')
+			)
 		);
 	}
 });


### PR DESCRIPTION
Note: the changes are for the `7.104.x` branch.

### What does this PR do?
- do not display `Copilot` icon at the top of workspaces
- do not display `Copilot Controls` action

It's still possible to return back those items using [ConfigMap approach](https://eclipse.dev/che/docs/stable/administration-guide/editor-configurations-for-microsoft-visual-studio-code/) to override the corresponding setting.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-8894

### How to test this PR?
1. Start a workspace using `quay.io/che-incubator-pull-requests/che-code:pr-551-amd64` as editor image 
or 
click here: 
https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/dashboard/#/load-factory?editor-image=quay.io/che-incubator-pull-requests/che-code:pr-551-amd64&url=https://registry.devfile.io/devfiles/nodejs/2.2.1
2. Check that `Copilot` icon is absent at the top of window
3. Context menu of the Command Center area => check that `Copilot Controls` item is absent in the list of the available actions.

**Before:**
<img width="756" alt="Screenshot 2025-06-12 at 15 09 57" src="https://github.com/user-attachments/assets/ffd7521b-70ad-4507-9cab-2512f4f3ec48" />

**After:**
<img width="756" alt="Screenshot 2025-06-12 at 15 13 10" src="https://github.com/user-attachments/assets/02f45e97-87b6-459c-af55-55252b0c2718" />

4. Add the following ConfigMap to the user’s namespace:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: vscode-editor-configurations
  labels:
     app.kubernetes.io/part-of: che.eclipse.org
data:
  settings.json: |
    {
      "chat.commandCenter.enabled": true
    }
  
```
 then restart your workspace => check that both `Copilot` icon and `Copilot Controls` item are available again.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
