### PR TITLE
fix: do not overwrite existing NODE_EXTRA_CA_CERTS env var

### DIFF
--- a/launcher/src/node-extra-certificate.ts
+++ b/launcher/src/node-extra-certificate.ts
@@ -15,6 +15,7 @@ export const NODE_EXTRA_CERTIFICATE_DIR = '/tmp/node-extra-certificates';
 export const NODE_EXTRA_CERTIFICATE = `${NODE_EXTRA_CERTIFICATE_DIR}/ca.crt`;
 
 const CHE_CERTIFICATE = '/tmp/che/secret/ca.crt';
+const TLS_CA_BUNDLE = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem';
 const PUBLIC_CERTS_DIR = '/public-certs';
 
 export class NodeExtraCertificate {
@@ -41,7 +42,15 @@ export class NodeExtraCertificate {
 
     let data = '';
 
-    // Check if we have a custom Che CA certificate
+    // Check if there is /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem certificate
+    if (await fs.pathExists(TLS_CA_BUNDLE)) {
+      console.log(`  > found ${TLS_CA_BUNDLE}`);
+
+      let content = await fs.readFile(TLS_CA_BUNDLE);
+      data += content ? (content.endsWith('\n') ? content : (content += '\n')) : '';
+    }
+
+    // DEPRECATED :: Check if there is custom Che CA certificate
     if (await fs.pathExists(CHE_CERTIFICATE)) {
       console.log(`  > found ${CHE_CERTIFICATE}`);
 
@@ -49,7 +58,7 @@ export class NodeExtraCertificate {
       data += content ? (content.endsWith('\n') ? content : (content += '\n')) : '';
     }
 
-    // Check if we have public certificates in /public-certs
+    // DEPRECATED :: Check if there are public certificates in /public-certs
     if (await fs.pathExists(PUBLIC_CERTS_DIR)) {
       const dir = await fs.readdir(PUBLIC_CERTS_DIR);
 

--- a/launcher/src/node-extra-certificate.ts
+++ b/launcher/src/node-extra-certificate.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import { env } from 'process';
 import * as fs from './fs-extra.js';
 
 export const NODE_EXTRA_CERTIFICATE_DIR = '/tmp/node-extra-certificates';
@@ -27,6 +28,11 @@ export class NodeExtraCertificate {
    *****************************************************************************************************************/
   async configure(): Promise<void> {
     console.log('# Configuring Node extra certificates...');
+
+    if (env.NODE_EXTRA_CA_CERTS) {
+      console.log(`  > NODE_EXTRA_CA_CERTS environment variable is already defined, skip this step`);
+      return;
+    }
 
     if (await fs.pathExists(NODE_EXTRA_CERTIFICATE)) {
       console.log(`  > File ${NODE_EXTRA_CERTIFICATE} is already exist, skip this step`);

--- a/launcher/src/vscode-launcher.ts
+++ b/launcher/src/vscode-launcher.ts
@@ -44,7 +44,7 @@ export class VSCodeLauncher {
       params.push('--default-folder', env.PROJECT_SOURCE);
     }
 
-    if (await fs.pathExists(NODE_EXTRA_CERTIFICATE)) {
+    if (!env.NODE_EXTRA_CA_CERTS && (await fs.pathExists(NODE_EXTRA_CERTIFICATE))) {
       env.NODE_EXTRA_CA_CERTS = NODE_EXTRA_CERTIFICATE;
     }
 

--- a/launcher/tests/node-extra-certificate.spec.ts
+++ b/launcher/tests/node-extra-certificate.spec.ts
@@ -73,7 +73,7 @@ describe('Test generating Node Extra Certificate:', () => {
 
     await new NodeExtraCertificate().configure();
 
-    expect(pathExistsMock).toBeCalledTimes(3);
+    expect(pathExistsMock).toBeCalledTimes(4);
 
     expect(pathExistsMock).toBeCalledWith('/tmp/node-extra-certificates/ca.crt');
     expect(pathExistsMock).toBeCalledWith('/tmp/che/secret/ca.crt');
@@ -120,7 +120,7 @@ describe('Test generating Node Extra Certificate:', () => {
 
     await new NodeExtraCertificate().configure();
 
-    expect(pathExistsMock).toBeCalledTimes(3);
+    expect(pathExistsMock).toBeCalledTimes(4);
     expect(mkdirMock).toBeCalled();
     expect(writeFileMock).toBeCalledTimes(1);
 
@@ -170,14 +170,14 @@ describe('Test generating Node Extra Certificate:', () => {
 
     await new NodeExtraCertificate().configure();
 
-    expect(pathExistsMock).toBeCalledTimes(3);
+    expect(pathExistsMock).toBeCalledTimes(4);
     expect(mkdirMock).toBeCalled();
     expect(writeFileMock).toBeCalledTimes(1);
 
     expect(test).toBe('first-certificate\nsecond-certificate\n');
   });
 
-  test('should create a bundle containing custom Che certificate and all public certificates', async () => {
+  test('should create a bundle containing tls-ca-bundle.pem certificate, custom Che certificate and all public certificates', async () => {
     const pathExistsMock = jest.fn();
     const readdirMock = jest.fn();
     const isFileMock = jest.fn();
@@ -195,7 +195,11 @@ describe('Test generating Node Extra Certificate:', () => {
     });
 
     pathExistsMock.mockImplementation(async (path: string) => {
-      return '/tmp/che/secret/ca.crt' === path || '/public-certs' === path;
+      return (
+        '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem' === path ||
+        '/tmp/che/secret/ca.crt' === path ||
+        '/public-certs' === path
+      );
     });
 
     readdirMock.mockImplementation(async (dir) => {
@@ -212,6 +216,8 @@ describe('Test generating Node Extra Certificate:', () => {
 
     readFileMock.mockImplementation(async (file: string) => {
       switch (file) {
+        case '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem':
+          return 'tls-ca-bundle';
         case '/tmp/che/secret/ca.crt':
           return 'custom-che-certificate';
         case '/public-certs/first-key':
@@ -230,10 +236,12 @@ describe('Test generating Node Extra Certificate:', () => {
 
     await new NodeExtraCertificate().configure();
 
-    expect(pathExistsMock).toBeCalledTimes(3);
+    expect(pathExistsMock).toBeCalledTimes(4);
     expect(mkdirMock).toBeCalled();
     expect(writeFileMock).toBeCalledTimes(1);
 
-    expect(test).toBe('custom-che-certificate\nfirst-certificate\nsecond-certificate\nthird-certificate\n');
+    expect(test).toBe(
+      'tls-ca-bundle\ncustom-che-certificate\nfirst-certificate\nsecond-certificate\nthird-certificate\n'
+    );
   });
 });

--- a/launcher/tests/node-extra-certificate.spec.ts
+++ b/launcher/tests/node-extra-certificate.spec.ts
@@ -8,11 +8,14 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import { env } from 'process';
 import * as fs from '../src/fs-extra';
 import { NodeExtraCertificate } from '../src/node-extra-certificate';
 
 describe('Test generating Node Extra Certificate:', () => {
   beforeEach(() => {
+    delete env.NODE_EXTRA_CA_CERTS;
+
     Object.assign(fs, {
       pathExists: jest.fn(),
       isFile: jest.fn(),
@@ -37,6 +40,19 @@ describe('Test generating Node Extra Certificate:', () => {
 
     expect(pathExistsMock).toBeCalledTimes(1);
     expect(pathExistsMock).toBeCalledWith('/tmp/node-extra-certificates/ca.crt');
+  });
+
+  test('should skip if NODE_EXTRA_CA_CERTS environment variable is already defined', async () => {
+    env.NODE_EXTRA_CA_CERTS = '/tmp/user.crt';
+
+    const pathExistsMock = jest.fn();
+    Object.assign(fs, {
+      pathExists: pathExistsMock,
+    });
+
+    await new NodeExtraCertificate().configure();
+
+    expect(pathExistsMock).not.toBeCalled();
   });
 
   test('should not create a bundle if nothing found', async () => {


### PR DESCRIPTION
### What does this PR do?


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23413

### How to test this PR?

1. Ensure `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` certificate is used
- Create a workspace using the editor image **quay.io/che-incubator-pull-requests/che-code:pr-552-amd64**
- Open a terminal, check `NODE_EXTRA_CA_CERTS` environment variable, it should refer to a certificate in `/tmp`
```
export | grep NODE_EXTRA_CA_CERTS
```
- And check the certificate is not empty
```
cat $NODE_EXTRA_CA_CERTS
``` 

2. Define `NODE_EXTRA_CA_CERTS` is the devfile, ensure the variable it not overwritten in created workspace
- Create a workspace from https://github.com/vitaliy-guliy/vscode-test-extension/tree/do-not-overwrite-NODE_EXTRA_CA_CERTS and using the editor image **quay.io/che-incubator-pull-requests/che-code:pr-552-amd64**
- Open a terminal, ensure `NODE_EXTRA_CA_CERTS` environment variable is set to `/projects/vscode-test-extension/empty.crt`
```
export | grep NODE_EXTRA_CA_CERTS
```

- To double check, `/checode/entrypoint-logs.txt` file should contain following
```
# Configuring Node extra certificates...
  > NODE_EXTRA_CA_CERTS environment variable is already defined, skip this step
```

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
