### PR TITLE
fix: do not overwrite existing NODE_EXTRA_CA_CERTS env var (#552)

### DIFF
--- a/launcher/src/vscode-launcher.ts
+++ b/launcher/src/vscode-launcher.ts
@@ -44,7 +44,7 @@ export class VSCodeLauncher {
       params.push('--default-folder', env.PROJECT_SOURCE);
     }
 
-    if (await fs.pathExists(NODE_EXTRA_CERTIFICATE)) {
+    if (!env.NODE_EXTRA_CA_CERTS && (await fs.pathExists(NODE_EXTRA_CERTIFICATE))) {
       env.NODE_EXTRA_CA_CERTS = NODE_EXTRA_CERTIFICATE;
     }
 


### PR DESCRIPTION
### What does this PR do?
Backport of https://github.com/che-incubator/che-code/pull/552

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23413

### How to test this PR?
See original PR

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
