### PR TITLE
Update tar-fs to 2.1.3 and 3.0.9

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,14 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/557
+
+- code/package.json
+- code/build/package.json
+- code/remote/package.json
+---
+
+#### @RomanNikitenko
 https://github.com/che-incubator/che-code/pull/549
 
 - code/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts

--- a/.rebase/add/code/build/package.json
+++ b/.rebase/add/code/build/package.json
@@ -1,0 +1,7 @@
+{
+    "overrides": {
+        "prebuild-install": {
+            "tar-fs": "2.1.3"
+        }
+    }
+}

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -16,6 +16,12 @@
         },
         "postcss": {
             "nanoid": "3.3.8"
+        },
+        "@vscode/test-web": {
+            "tar-fs": "3.0.9"
+        },
+        "prebuild-install": {
+            "tar-fs": "2.1.3"
         }
     }
 }

--- a/.rebase/add/code/remote/package.json
+++ b/.rebase/add/code/remote/package.json
@@ -3,5 +3,10 @@
         "ws": "8.2.3",
         "js-yaml": "^4.1.0",
         "@kubernetes/client-node": "^0.22.0"
+    },
+    "overrides": {
+        "prebuild-install": {
+            "tar-fs": "2.1.3"
+        }
     }
 }

--- a/code/build/package-lock.json
+++ b/code/build/package-lock.json
@@ -4142,11 +4142,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",

--- a/code/build/package.json
+++ b/code/build/package.json
@@ -66,5 +66,10 @@
   "optionalDependencies": {
     "tree-sitter-typescript": "^0.23.2",
     "vscode-gulp-watch": "^5.0.3"
+  },
+  "overrides": {
+    "prebuild-install": {
+      "tar-fs": "2.1.3"
+    }
   }
 }

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -14351,10 +14351,9 @@
       }
     },
     "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
-      "license": "MIT",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -16611,11 +16610,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"

--- a/code/package.json
+++ b/code/package.json
@@ -239,6 +239,12 @@
     },
     "kerberos@2.1.1": {
       "node-addon-api": "7.1.0"
+    },
+    "@vscode/test-web": {
+      "tar-fs": "3.0.9"
+    },
+    "prebuild-install": {
+      "tar-fs": "2.1.3"
     }
   },
   "repository": {

--- a/code/remote/package-lock.json
+++ b/code/remote/package-lock.json
@@ -2343,10 +2343,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
-      "license": "MIT",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",

--- a/code/remote/package.json
+++ b/code/remote/package.json
@@ -47,6 +47,9 @@
     "node-gyp-build": "4.8.1",
     "kerberos@2.1.1": {
       "node-addon-api": "7.1.0"
+    },
+    "prebuild-install": {
+      "tar-fs": "2.1.3"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Update `tar-fs`:
- from `2.1.2` to `2.1.3`
- from `3.0.8` to `3.0.9`


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-8905
https://issues.redhat.com/browse/CRW-8906
https://issues.redhat.com/browse/CRW-8907
https://issues.redhat.com/browse/CRW-8908

### How to test this PR?
`Patch` version was changed within current PR, so I think it should be safe enough.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
