### PR TITLE
Update tar-fs to 2.1.4 and 3.1.1

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,7 +3,7 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
-https://github.com/che-incubator/che-code/pull/
+https://github.com/che-incubator/che-code/pull/572
 
 - code/package.json
 - code/build/package.json

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,14 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
+https://github.com/che-incubator/che-code/pull/
+
+- code/package.json
+- code/build/package.json
+- code/remote/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/563
 
 - code/package.json

--- a/.rebase/add/code/build/package.json
+++ b/.rebase/add/code/build/package.json
@@ -1,7 +1,7 @@
 {
     "overrides": {
         "prebuild-install": {
-            "tar-fs": "2.1.3"
+            "tar-fs": "2.1.4"
         }
     }
 }

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -18,10 +18,10 @@
             "nanoid": "3.3.8"
         },
         "@vscode/test-web": {
-            "tar-fs": "3.0.9"
+            "tar-fs": "3.1.1"
         },
         "prebuild-install": {
-            "tar-fs": "2.1.3"
+            "tar-fs": "2.1.4"
         }
     }
 }

--- a/.rebase/add/code/remote/package.json
+++ b/.rebase/add/code/remote/package.json
@@ -6,7 +6,7 @@
     },
     "overrides": {
         "prebuild-install": {
-            "tar-fs": "2.1.3"
+            "tar-fs": "2.1.4"
         },
         "request": {
             "form-data": "2.5.5"

--- a/code/build/package-lock.json
+++ b/code/build/package-lock.json
@@ -4143,10 +4143,11 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",

--- a/code/build/package.json
+++ b/code/build/package.json
@@ -69,7 +69,7 @@
   },
   "overrides": {
     "prebuild-install": {
-      "tar-fs": "2.1.3"
+      "tar-fs": "2.1.4"
     }
   }
 }

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -14694,9 +14694,10 @@
       }
     },
     "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -16954,10 +16955,11 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"

--- a/code/package.json
+++ b/code/package.json
@@ -241,10 +241,10 @@
       "node-addon-api": "7.1.0"
     },
     "@vscode/test-web": {
-      "tar-fs": "3.0.9"
+      "tar-fs": "3.1.1"
     },
     "prebuild-install": {
-      "tar-fs": "2.1.3"
+      "tar-fs": "2.1.4"
     }
   },
   "repository": {

--- a/code/remote/package-lock.json
+++ b/code/remote/package-lock.json
@@ -2524,9 +2524,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",

--- a/code/remote/package.json
+++ b/code/remote/package.json
@@ -49,7 +49,7 @@
       "node-addon-api": "7.1.0"
     },
     "prebuild-install": {
-      "tar-fs": "2.1.3"
+      "tar-fs": "2.1.4"
     },
     "request": {
       "form-data": "2.5.5"


### PR DESCRIPTION
### What does this PR do?
Update `tar-fs`:

from `2.1.3` to `2.1.4`
from `3.0.9` to `3.1.1`

### What issues does this PR fix?
https://issues.redhat.com/browse/CRW-9449
https://issues.redhat.com/browse/CRW-9464


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
