### PR TITLE
[7.109.x] Update tar-fs to 2.1.4 and 3.1.1

### DIFF
--- a/code/build/package-lock.json
+++ b/code/build/package-lock.json
@@ -4143,10 +4143,11 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",

--- a/code/build/package.json
+++ b/code/build/package.json
@@ -69,7 +69,7 @@
   },
   "overrides": {
     "prebuild-install": {
-      "tar-fs": "2.1.3"
+      "tar-fs": "2.1.4"
     }
   }
 }

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -14694,9 +14694,10 @@
       }
     },
     "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -16954,10 +16955,11 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"

--- a/code/package.json
+++ b/code/package.json
@@ -241,10 +241,10 @@
       "node-addon-api": "7.1.0"
     },
     "@vscode/test-web": {
-      "tar-fs": "3.0.9"
+      "tar-fs": "3.1.1"
     },
     "prebuild-install": {
-      "tar-fs": "2.1.3"
+      "tar-fs": "2.1.4"
     }
   },
   "repository": {

--- a/code/remote/package-lock.json
+++ b/code/remote/package-lock.json
@@ -2524,9 +2524,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",

--- a/code/remote/package.json
+++ b/code/remote/package.json
@@ -49,7 +49,7 @@
       "node-addon-api": "7.1.0"
     },
     "prebuild-install": {
-      "tar-fs": "2.1.3"
+      "tar-fs": "2.1.4"
     },
     "request": {
       "form-data": "2.5.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "che-code",
-  "version": "7.109.0",
+  "version": "7.109.1-next",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "che-code",
-      "version": "7.109.0",
+      "version": "7.109.1-next",
       "license": "EPL-2.0"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "che-code",
-  "version": "7.109.0-next",
+  "version": "7.109.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "che-code",
-      "version": "7.109.0-next",
+      "version": "7.109.0",
       "license": "EPL-2.0"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "che-code",
-  "version": "7.109.0",
+  "version": "7.109.1-next",
   "description": "Run Code-OSS on kubernetes",
   "scripts": {
     "prepare": "cd code && npm install && npm run download-builtin-extensions",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "che-code",
-  "version": "7.109.0-next",
+  "version": "7.109.0",
   "description": "Run Code-OSS on kubernetes",
   "scripts": {
     "prepare": "cd code && npm install && npm run download-builtin-extensions",


### PR DESCRIPTION
### What does this PR do?
Update tar-fs:

from 2.1.3 to 2.1.4
from 3.0.9 to 3.1.1

### What issues does this PR fix?
backport of https://github.com/che-incubator/che-code/pull/572


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
