### PR TITLE
Adapt to a non-writeable /etc/passwd file in sshd Dockerfile.

### DIFF
--- a/build/dockerfiles/dev.sshd.Dockerfile
+++ b/build/dockerfiles/dev.sshd.Dockerfile
@@ -55,7 +55,11 @@ COPY --chown=0:0 /build/scripts/sshd.start /
 RUN mkdir /opt/www
 COPY /build/scripts/server.js /opt/www/
 
-ENV USER_NAME=dev
+# Lock down /etc/passwd until fixed in UDI
+RUN chmod 644 /etc/passwd
+
+# Bypass nologin shell for random generated user
+RUN cp /bin/bash /sbin/nologin
 
 EXPOSE 2022 3400
 


### PR DESCRIPTION
The UDI image currently permits writing to `/etc/passwd`, and sets the default user to have a login shell. Make `/etc/passwd` non-writable and "disable" `/sbin/nologin` (by replacing it with `/bin/bash`) to ensure the user starting the SSHD service may continue to log into the container over SSH.

https://github.com/devfile/developer-images/blob/1e7d0a51e8aa8c77a5477b344c1a4421949ac07b/base/ubi9/entrypoint.sh#L28-L34

If you launch with https://raw.githubusercontent.com/eclipse-che/che-operator/refs/heads/main/editors-definitions/che-code-sshd-next.yaml (for some reason https://github.com/che-incubator/che-code/actions/runs/18010358799/job/51241080781 failed), and change the `dev` user's login shell to `/sbin/nologin`, then you won't be able to connect anymore via. ssh. This will be the default shell once `/etc/passwd` becomes non-writeable.

CC'ing @azatsarynnyy 