### PR TITLE
[7.109.x] CRW-9383: only root.root perms for /etc/passwd

### DIFF
--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -29,10 +29,11 @@ COPY --from=linux-libc-ubi9-content --chown=0:0 /checode-linux-libc/ubi9 /mnt/ro
 RUN mkdir -p /mnt/rootfs/projects && mkdir -p /mnt/rootfs/home/che && mkdir -p /mnt/rootfs/bin/
 RUN cat /mnt/rootfs/etc/passwd | sed s#root:x.*#root:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g > /mnt/rootfs/home/che/.passwd.template \
     && cat /mnt/rootfs/etc/group | sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g > /mnt/rootfs/home/che/.group.template
-RUN for f in "/mnt/rootfs/bin/" "/mnt/rootfs/home/che" "/mnt/rootfs/etc/passwd" "/mnt/rootfs/etc/group" "/mnt/rootfs/projects" ; do\
+RUN for f in "/mnt/rootfs/bin/" "/mnt/rootfs/home/che" "/mnt/rootfs/etc/group" "/mnt/rootfs/projects" ; do\
            chgrp -R 0 ${f} && \
            chmod -R g+rwX ${f}; \
        done
+RUN chmod -R g-w /mnt/rootfs/etc/passwd
 
 COPY --from=machine-exec --chown=0:0 /go/bin/che-machine-exec /mnt/rootfs/bin/machine-exec
 COPY --chmod=755 /build/scripts/*.sh /mnt/rootfs/

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -58,14 +58,6 @@ get_openssl_version() {
   fi
 }
 
-# Boilerplate code for arbitrary user support
-if ! whoami >/dev/null 2>&1; then
-  if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
-    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
-  fi
-fi
-
 # list checode
 ls -la /checode/
 

--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -13,21 +13,6 @@
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 
-if ! grep -Fq "${USER_ID}" /etc/passwd; then
-    # current user is an arbitrary
-    # user (its uid is not in the
-    # container /etc/passwd). Let's fix that
-    cat ${HOME}/.passwd.template | \
-    sed "s/\${USER_ID}/${USER_ID}/g" | \
-    sed "s/\${GROUP_ID}/${GROUP_ID}/g" | \
-    sed "s/\${HOME}/\/che-vscode/g" > /etc/passwd
-
-    cat ${HOME}/.group.template | \
-    sed "s/\${USER_ID}/${USER_ID}/g" | \
-    sed "s/\${GROUP_ID}/${GROUP_ID}/g" | \
-    sed "s/\${HOME}/\/che-vscode/g" > /etc/group
-fi
-
 if [ -z "$CODE_HOST" ]; then
   CODE_HOST="127.0.0.1"
 fi


### PR DESCRIPTION
### What does this PR do?
backport of #578 

### What issues does this PR fix?


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
