### PR TITLE
build: Add ability to manage mangler workers number using env variable

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,13 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/584
+
+- code/build/lib/mangle/index.js
+- code/build/lib/mangle/index.ts
+---
+
+#### @RomanNikitenko
 https://github.com/che-incubator/che-code/pull/573
 
 - code/src/vs/platform/extensionManagement/common/extensionManagement.ts

--- a/.rebase/replace/code/build/lib/mangle/index.ts.json
+++ b/.rebase/replace/code/build/lib/mangle/index.ts.json
@@ -2,5 +2,13 @@
     {
         "from": "// Module passed around as type",
         "by": "// che-api contains few interfaces (with Symbol usage) that are not handled correctly by the mangle logic\\\n\\\t\\\t'devfile-service',\\\n\\\t\\\t'github-service',\\\n\\\t\\\t'telemetry-service',\\\n\\\t\\\t'workspace-service',\\\n\\\n\\\t\\\t// Module passed around as type"
+    },
+    {
+        "from": "maxWorkers: 4,",
+        "by": "maxWorkers: ((): number => {\\\n\\\t\\\t\\\t\\\tconst envVal = Number(process.env['VSCODE_MANGLE_WORKERS'] ?? '');\\\n\\\t\\\t\\\t\\\tif (Number.isFinite(envVal) \\&\\& envVal > 0) {\\\n\\\t\\\t\\\t\\\t\\\tconst maxWorkersNumber = Math.min(8, Math.max(1, Math.floor(envVal)));\\\n\\\t\\\t\\\t\\\t\\\tthis.log(`env.VSCODE_MANGLE_WORKERS is set to ${envVal}, using ${maxWorkersNumber} number of maxWorkers`);\\\n\\\t\\\t\\\t\\\t\\\treturn maxWorkersNumber;\\\n\\\t\\\t\\\t\\\t}\\\n\\\t\\\t\\\t\\\tthis.log(`env.VSCODE_MANGLE_WORKERS is not set, using the default number of maxWorkers: ${this.defaultWorkersNumber}`);\\\n\\\t\\\t\\\t\\\treturn this.defaultWorkersNumber;\\\n\\\t\\\t\\\t})(),"
+    },
+    {
+        "from": "private readonly renameWorkerPool: workerpool.WorkerPool;",
+        "by": "private readonly renameWorkerPool: workerpool.WorkerPool;\\\n\\\tprivate readonly defaultWorkersNumber = 4;"
     }
 ]

--- a/code/build/lib/mangle/index.js
+++ b/code/build/lib/mangle/index.js
@@ -352,12 +352,22 @@ class Mangler {
     allClassDataByKey = new Map();
     allExportedSymbols = new Set();
     renameWorkerPool;
+    defaultWorkersNumber = 4;
     constructor(projectPath, log = () => { }, config) {
         this.projectPath = projectPath;
         this.log = log;
         this.config = config;
         this.renameWorkerPool = workerpool_1.default.pool(path_1.default.join(__dirname, 'renameWorker.js'), {
-            maxWorkers: 4,
+            maxWorkers: (() => {
+                const envVal = Number(process.env['VSCODE_MANGLE_WORKERS'] ?? '');
+                if (Number.isFinite(envVal) && envVal > 0) {
+                    const maxWorkersNumber = Math.min(8, Math.max(1, Math.floor(envVal)));
+                    this.log(`env.VSCODE_MANGLE_WORKERS is set to ${envVal}, using ${maxWorkersNumber} number of maxWorkers`);
+                    return maxWorkersNumber;
+                }
+                this.log(`env.VSCODE_MANGLE_WORKERS is not set, using the default number of maxWorkers: ${this.defaultWorkersNumber}`);
+                return this.defaultWorkersNumber;
+            })(),
             minWorkers: 'max'
         });
     }


### PR DESCRIPTION
**TODO:** 
- [x] remove https://github.com/che-incubator/che-code/pull/584/commits/f9b427de9fab61d429d4ffde37dc6f487777782a 

### What does this PR do?
- Adds ability to manage mangler workers number using `VSCODE_MANGLE_WORKERS` env variable
- An example of usage is: 
```
VSCODE_MANGLE_WORKERS=3 GOMAXPROCS=2 NODE_DEBUG=worker NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min
``` 
Usually 4 workers are used, but in that case ^ 3 workers will be used.
- ability to configure mangler workers number can be helpful to avoid the following error:
```
Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory" 
```
- commit https://github.com/che-incubator/che-code/pull/584/commits/f9b427de9fab61d429d4ffde37dc6f487777782a was added only for testing goal and will be removed after reviewing and testing the PR changes

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
the PR changes allows to fix downstream build failure:
```
Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory" 
```


### How to test this PR?
- current PR at the moment contains commit https://github.com/che-incubator/che-code/pull/584/commits/f9b427de9fab61d429d4ffde37dc6f487777782a  for testing
- it configures build system to use 3 workers (default value is 4), so in the PR's jobs logs you can find something like:
```
[10:54:36] [mangler] env.VSCODE_MANGLE_WORKERS is set to 3, using 3 number of maxWorkers
#13 2.936 WORKER 23: [0] create new worker /checode-compilation/build/lib/mangle/renameWorker.js { stdout: false, stderr: false } isInternal: false
#13 2.936 WORKER 23: instantiating Worker. url: file:///checode-compilation/build/lib/mangle/renameWorker.js doEval: false
#13 2.937 WORKER 23: [0] created Worker with ID 1
#13 2.939 WORKER 23: [0] create new worker /checode-compilation/build/lib/mangle/renameWorker.js { stdout: false, stderr: false } isInternal: false
#13 2.939 WORKER 23: instantiating Worker. url: file:///checode-compilation/build/lib/mangle/renameWorker.js doEval: false
#13 2.939 WORKER 23: [0] created Worker with ID 2
#13 2.941 WORKER 23: [0] create new worker /checode-compilation/build/lib/mangle/renameWorker.js { stdout: false, stderr: false } isInternal: false
#13 2.941 WORKER 23: instantiating Worker. url: file:///checode-compilation/build/lib/mangle/renameWorker.js doEval: false
#13 2.941 WORKER 23: [0] created Worker with ID 3
#13 15.27 [10:54:48] [mangler] Done collecting. Classes: 9153. Exported symbols: 11218
```
- so you can see that 3 workers were configured and then created

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
