### PR TITLE
Use the default AuthorizedKeysFile value for VS Code SSH support.

### DIFF
--- a/build/dockerfiles/dev.sshd.Dockerfile
+++ b/build/dockerfiles/dev.sshd.Dockerfile
@@ -32,7 +32,6 @@ RUN chmod 644 /opt/ssh/ssh_host_* /opt/ssh/sshd_config
 # Use non-privileged port, set user authorized keys, disable strict checks
 RUN sed -i \
 -e 's|#Port 22|Port 2022|' \
--e 's|AuthorizedKeysFile	.ssh/authorized_keys|AuthorizedKeysFile /home/user/ssh/authorized_keys|' \
 -e 's|#StrictModes yes|StrictModes=no|' \
 -e 's|#PidFile /var/run/sshd.pid|PidFile /tmp/sshd.pid|' \
 -e 's|#LogLevel INFO|LogLevel DEBUG3|' \

--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -8,12 +8,11 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-rm -rf /home/user/ssh
-mkdir -p /home/user/ssh
+mkdir -p $HOME/.ssh
 if [ -f /etc/ssh/dwo_ssh_key.pub ]; then
-  cp /etc/ssh/dwo_ssh_key.pub /home/user/ssh/authorized_keys
+  cp /etc/ssh/dwo_ssh_key.pub $HOME/.ssh/authorized_keys
 else
-  cp /opt/ssh/ssh_client_ed25519_key.pub /home/user/ssh/authorized_keys
+  cp /opt/ssh/ssh_client_ed25519_key.pub $HOME/.ssh/authorized_keys
 fi
 
 # start


### PR DESCRIPTION
- While, /home/user is the expected home folder under UDI, using $HOME should make the Dockerfile portable
- Avoid clearing $HOME/.ssh/ on each startup

This is a cherry-pick of https://github.com/che-incubator/che-code/pull/586 .