### PR TITLE
CRW-7545: bind machine-exec to localhost only

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -63,7 +63,7 @@ ls -la /checode/
 
 # Start the machine-exec component in background
 export MACHINE_EXEC_PORT=3333
-nohup /checode/bin/machine-exec --url "0.0.0.0:${MACHINE_EXEC_PORT}" &
+nohup /checode/bin/machine-exec --url "127.0.0.1:${MACHINE_EXEC_PORT}" &
 
 # Start the checode component based on musl or libc
 


### PR DESCRIPTION
### What does this PR do?
limit the machine-exec connection to `localhost` only


### What issues does this PR fix?
fixes https://issues.redhat.com/browse/CRW-7545


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
