### PR TITLE
Fix 'JavaScript heap out of memory' error for build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "prepare": "cd code && npm install && npm run download-builtin-extensions",
     "watch": "cd code && npm run watch",
     "server": "cd code && VSCODE_DEV=1 node out/server-main.js --host 0.0.0.0 --without-connection-token",
-    "build": "cd code && node ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64",
-    "build:min": "cd code && node ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64-min",
+    "build": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=4096 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64",
+    "build:min": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=4096 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64-min",
     "rebuild-native-modules": "cd code && npm rebuild"
   },
   "license": "EPL-2.0"


### PR DESCRIPTION
### What does this PR do?
- Fixes `JavaScript heap out of memory` error for build commands
- The solution depends on the resources of the machine where build commands are going to be run
- I tested the current solution for the development on the dogfooding instance - it works for the resources used for che-in-che development
- I guess other values for `VSCODE_MANGLE_WORKERS` and `max-old-space-size` should be used when the commands run locally on a machine that has less resources
 


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23662

### How to test this PR?
1. Create a workspace for the Che-Code repo on the dogfooding instance
2. Create a terminal
3. Try `npm run build` or `npm run build:min` command in the terminal
4. The commands should complete successfully - no `JavaScript heap out of memory` error

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
