### PR TITLE
feat: Add ability to manage extensions installation using a ConfigMap

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
+#### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/605
+
+- code/src/vs/workbench/browser/web.main.ts
+- code/src/vs/server/node/serverServices.ts
+- code/src/vs/server/node/serverEnvironmentService.ts
+- code/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+---
+
 #### @sbouchet
 https://github.com/che-incubator/che-code/pull/607
 

--- a/.rebase/replace/code/src/vs/server/node/serverEnvironmentService.ts.json
+++ b/.rebase/replace/code/src/vs/server/node/serverEnvironmentService.ts.json
@@ -1,0 +1,10 @@
+[
+	{
+		"from": "import { join } from '../../base/common/path.js';",
+		"by": "import { join } from '../../base/common/path.js';\\\nimport { getPolicyFile } from './che/serverServices.js';"
+	},
+	{
+		"from": "override get args(): ServerParsedArgs { return super.args as ServerParsedArgs; }",
+		"by": "override get args(): ServerParsedArgs { return super.args as ServerParsedArgs; }\\\n\\\t@memoize\\\n\\\toverride get policyFile(): URI \\| undefined {\\\n\\\t\\\treturn getPolicyFile() \\|\\| super.policyFile;\\\n\\\t}"
+	}
+]

--- a/.rebase/replace/code/src/vs/server/node/serverServices.ts.json
+++ b/.rebase/replace/code/src/vs/server/node/serverServices.ts.json
@@ -1,0 +1,18 @@
+[
+	{
+		"from": "import { NullPolicyService } from '../../platform/policy/common/policy.js';",
+		"by": "import { PolicyChannel } from '../../platform/policy/common/policyIpc.js';"
+	},
+	{
+		"from": "import { McpGalleryManifestIPCService } from '../../platform/mcp/common/mcpGalleryManifestServiceIpc.js';",
+		"by": "import { McpGalleryManifestIPCService } from '../../platform/mcp/common/mcpGalleryManifestServiceIpc.js';\\\nimport { getPolicyService } from './che/serverServices.js';"
+	},
+    {
+		"from": "const configurationService = new ConfigurationService(environmentService.machineSettingsResource, fileService, new NullPolicyService(), logService);",
+		"by": "const policyService = getPolicyService(environmentService, fileService, logService, disposables);\\\n\\\tconst configurationService = new ConfigurationService(environmentService.machineSettingsResource, fileService, policyService, logService);"
+	},
+	{
+		"from": "socketServer.registerChannel('mcpManagement', new McpManagementChannel(mcpManagementService, (ctx: RemoteAgentConnectionContext) => getUriTransformer(ctx.remoteAuthority)));",
+		"by": "socketServer.registerChannel('mcpManagement', new McpManagementChannel(mcpManagementService, (ctx: RemoteAgentConnectionContext) => getUriTransformer(ctx.remoteAuthority)));\\\n\\\t\\\tsocketServer.registerChannel('policy', new PolicyChannel(policyService));"
+	}
+]

--- a/.rebase/replace/code/src/vs/workbench/browser/web.main.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/web.main.ts.json
@@ -1,0 +1,10 @@
+[
+	{
+		"from": "import { INotificationService, Severity } from '../../platform/notification/common/notification.js';",
+		"by": "import { INotificationService, Severity } from '../../platform/notification/common/notification.js';\\\nimport { getPolicyService } from './che/web.js';"
+	},
+	{
+		"from": "const workspaceService = new WorkspaceService({ remoteAuthority: this.configuration.remoteAuthority, configurationCache }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, logService, new NullPolicyService());",
+		"by": "const workspaceService = new WorkspaceService({ remoteAuthority: this.configuration.remoteAuthority, configurationCache }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, logService, getPolicyService(remoteAgentService,logService, this.configuration.remoteAuthority));"
+	}
+]

--- a/.rebase/replace/code/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts.json
@@ -1,0 +1,7 @@
+[
+    {
+		"from": "if (extension.gallery) {\n\t\t\tif (!extension.gallery.isSigned && shouldRequireRepositorySignatureFor(extension.private, await this.extensionGalleryManifestService.getExtensionGalleryManifest())) {",
+		"by": "if (extension.gallery) {\n\t\t\t// Check if extension is allowed first (before checking platform compatibility or signing)\n\t\t\tconst allowedResult = this.allowedExtensionsService.isAllowed({ id: extension.gallery.identifier.id, publisherDisplayName: extension.gallery.publisherDisplayName });\n\t\t\tif (allowedResult !== true) {\n\t\t\t\treturn new MarkdownString(nls.localize('extension not allowed to install', \\\"This extension cannot be installed because it is not in the allowed list.\\\"));\n\t\t\t}\n\t\t\tif (!extension.gallery.isSigned && shouldRequireRepositorySignatureFor(extension.private, await this.extensionGalleryManifestService.getExtensionGalleryManifest())) {"
+
+	}
+]

--- a/code/src/vs/server/node/che/serverServices.ts
+++ b/code/src/vs/server/node/che/serverServices.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable header/header */
+
+import * as fs from 'fs';
+import { URI } from '../../../base/common/uri.js';
+import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { FileService } from '../../../platform/files/common/fileService.js';
+import { LogService } from '../../../platform/log/common/logService.js';
+import { FilePolicyService } from '../../../platform/policy/common/filePolicyService.js';
+import { IPolicyService, NullPolicyService } from '../../../platform/policy/common/policy.js';
+import { ServerEnvironmentService } from '../serverEnvironmentService.js';
+
+const POLICY_FILE_PATH = '/checode-config/policy.json';
+
+export function getPolicyFile(): URI | undefined {
+	if (fs.existsSync(POLICY_FILE_PATH)) {
+		return URI.file(POLICY_FILE_PATH);
+	}
+	return undefined;
+}
+
+export function getPolicyService(environmentService: ServerEnvironmentService, fileService: FileService, logService: LogService, disposables: DisposableStore): IPolicyService {
+	if (environmentService.policyFile) {
+		logService.info(`Using policy file: ${environmentService.policyFile.fsPath}`);
+		return disposables.add(new FilePolicyService(environmentService.policyFile, fileService, logService));
+	} else {
+		logService.info('Policy file not found');
+		return new NullPolicyService();
+	}
+}

--- a/code/src/vs/server/node/serverEnvironmentService.ts
+++ b/code/src/vs/server/node/serverEnvironmentService.ts
@@ -13,6 +13,7 @@ import { memoize } from '../../base/common/decorators.js';
 import { URI } from '../../base/common/uri.js';
 import { joinPath } from '../../base/common/resources.js';
 import { join } from '../../base/common/path.js';
+import { getPolicyFile } from './che/serverServices.js';
 
 export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 
@@ -240,4 +241,8 @@ export class ServerEnvironmentService extends NativeEnvironmentService implement
 	@memoize
 	get mcpResource(): URI { return joinPath(URI.file(join(this.userDataPath, 'User')), 'mcp.json'); }
 	override get args(): ServerParsedArgs { return super.args as ServerParsedArgs; }
+	@memoize
+	override get policyFile(): URI | undefined {
+		return getPolicyFile() || super.policyFile;
+	}
 }

--- a/code/src/vs/server/node/serverServices.ts
+++ b/code/src/vs/server/node/serverServices.ts
@@ -65,7 +65,7 @@ import { IExtensionsScannerService } from '../../platform/extensionManagement/co
 import { ExtensionsScannerService } from './extensionsScannerService.js';
 import { IExtensionsProfileScannerService } from '../../platform/extensionManagement/common/extensionsProfileScannerService.js';
 import { IUserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfile.js';
-import { NullPolicyService } from '../../platform/policy/common/policy.js';
+import { PolicyChannel } from '../../platform/policy/common/policyIpc.js';
 import { OneDataSystemAppender } from '../../platform/telemetry/node/1dsAppender.js';
 import { LoggerService } from '../../platform/log/node/loggerService.js';
 import { ServerUserDataProfilesService } from '../../platform/userDataProfile/node/userDataProfile.js';
@@ -93,6 +93,7 @@ import { McpManagementChannel } from '../../platform/mcp/common/mcpManagementIpc
 import { AllowedMcpServersService } from '../../platform/mcp/common/allowedMcpServersService.js';
 import { IMcpGalleryManifestService } from '../../platform/mcp/common/mcpGalleryManifest.js';
 import { McpGalleryManifestIPCService } from '../../platform/mcp/common/mcpGalleryManifestServiceIpc.js';
+import { getPolicyService } from './che/serverServices.js';
 
 const eventPrefix = 'monacoworkbench';
 
@@ -139,7 +140,8 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	services.set(IUriIdentityService, uriIdentityService);
 
 	// Configuration
-	const configurationService = new ConfigurationService(environmentService.machineSettingsResource, fileService, new NullPolicyService(), logService);
+	const policyService = getPolicyService(environmentService, fileService, logService, disposables);
+	const configurationService = new ConfigurationService(environmentService.machineSettingsResource, fileService, policyService, logService);
 	services.set(IConfigurationService, configurationService);
 
 	// User Data Profiles
@@ -257,6 +259,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 		socketServer.registerChannel('extensions', channel);
 
 		socketServer.registerChannel('mcpManagement', new McpManagementChannel(mcpManagementService, (ctx: RemoteAgentConnectionContext) => getUriTransformer(ctx.remoteAuthority)));
+		socketServer.registerChannel('policy', new PolicyChannel(policyService));
 
 		// clean up extensions folder
 		remoteExtensionsScanner.whenExtensionsReady().then(() => extensionManagementService.cleanUp());

--- a/code/src/vs/workbench/browser/che/web.ts
+++ b/code/src/vs/workbench/browser/che/web.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable header/header */
+
+import { ILogService } from '../../../platform/log/common/log.js';
+import { IPolicyService, NullPolicyService } from '../../../platform/policy/common/policy.js';
+import { PolicyChannelClient } from '../../../platform/policy/common/policyIpc.js';
+import { IRemoteAgentService } from '../../services/remote/common/remoteAgentService.js';
+
+// Get policy service from remote agent if available, otherwise use NullPolicyService
+export function getPolicyService(remoteAgentService: IRemoteAgentService, logService: ILogService, remoteAuthority?: string): IPolicyService {
+
+    let policyService: IPolicyService;
+    if (remoteAuthority) {
+        try {
+            const connection = remoteAgentService.getConnection();
+            if (connection) {
+                const policyChannel = connection.getChannel('policy');
+                // PolicyChannelClient needs initial policiesData - start with empty object, policies will be loaded when definitions are registered
+                policyService = new PolicyChannelClient({}, policyChannel);
+                logService.info('Policy channel client was created successfully');
+            } else {
+                logService.warn('Failed to get remote aget connection, using NullPolicyService');
+                policyService = new NullPolicyService();
+            }
+        } catch (error) {
+            console.log('/// web main /// connection - ERROR ');
+            logService.warn('Failed to create policy channel client, using NullPolicyService', error);
+            policyService = new NullPolicyService();
+        }
+    } else {
+        logService.warn('Failed to create policy channel client(no remote authority), using NullPolicyService');
+        policyService = new NullPolicyService();
+    }
+    return policyService;
+}

--- a/code/src/vs/workbench/browser/web.main.ts
+++ b/code/src/vs/workbench/browser/web.main.ts
@@ -68,7 +68,6 @@ import { IProgressService } from '../../platform/progress/common/progress.js';
 import { DelayedLogChannel } from '../services/output/common/delayedLogChannel.js';
 import { dirname, joinPath } from '../../base/common/resources.js';
 import { IUserDataProfile, IUserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfile.js';
-import { NullPolicyService } from '../../platform/policy/common/policy.js';
 import { IRemoteExplorerService } from '../services/remote/common/remoteExplorerService.js';
 import { DisposableTunnel, TunnelProtocol } from '../../platform/tunnel/common/tunnel.js';
 import { ILabelService } from '../../platform/label/common/label.js';
@@ -95,6 +94,7 @@ import { ISecretStorageService } from '../../platform/secrets/common/secrets.js'
 import { TunnelSource } from '../services/remote/common/tunnelModel.js';
 import { mainWindow } from '../../base/browser/window.js';
 import { INotificationService, Severity } from '../../platform/notification/common/notification.js';
+import { getPolicyService } from './che/web.js';
 
 export class BrowserMain extends Disposable {
 
@@ -567,7 +567,7 @@ export class BrowserMain extends Disposable {
 		}
 
 		const configurationCache = new ConfigurationCache([Schemas.file, Schemas.vscodeUserData, Schemas.tmp] /* Cache all non native resources */, environmentService, fileService);
-		const workspaceService = new WorkspaceService({ remoteAuthority: this.configuration.remoteAuthority, configurationCache }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, logService, new NullPolicyService());
+		const workspaceService = new WorkspaceService({ remoteAuthority: this.configuration.remoteAuthority, configurationCache }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, logService, getPolicyService(remoteAgentService,logService, this.configuration.remoteAuthority));
 
 		try {
 			await workspaceService.initialize(workspace);

--- a/code/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/code/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -2406,6 +2406,12 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		}
 
 		if (extension.gallery) {
+			// Check if extension is allowed first (before checking platform compatibility or signing)
+			const allowedResult = this.allowedExtensionsService.isAllowed({ id: extension.gallery.identifier.id, publisherDisplayName: extension.gallery.publisherDisplayName });
+			if (allowedResult !== true) {
+				return new MarkdownString(nls.localize('extension not allowed to install', "This extension cannot be installed because it is not in the allowed list."));
+			}
+
 			if (!extension.gallery.isSigned && shouldRequireRepositorySignatureFor(extension.private, await this.extensionGalleryManifestService.getExtensionGalleryManifest())) {
 				return new MarkdownString().appendText(nls.localize('not signed', "This extension is not signed."));
 			}

--- a/rebase.sh
+++ b/rebase.sh
@@ -472,6 +472,12 @@ resolve_conflicts() {
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts" ]]; then
       apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/web.main.ts" ]]; then
+      apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/server/node/serverServices.ts" ]]; then
+      apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/server/node/serverEnvironmentService.ts" ]]; then
+      apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/server/node/extensionHostConnection.ts" ]]; then
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/code/browser/workbench/workbench.html" ]]; then
@@ -495,6 +501,8 @@ resolve_conflicts() {
     elif [[ "$conflictingFile" == "code/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts" ]]; then
       apply_changes "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts" ]]; then
+      apply_multi_line_replace "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts" ]]; then
       apply_multi_line_replace "$conflictingFile"
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"


### PR DESCRIPTION
### What does this PR do?
- Adds ability to manage extensions installation using `vscode-editor-configurations` ConfigMap
- `Install` button is disabled and there is a warning message if an extension is not allowed for installation
<img width="1142" height="303" alt="Screenshot 2025-12-30 at 13 23 51" src="https://github.com/user-attachments/assets/1c5ebd0b-70fa-4ece-b269-c410b34a95a0" />

- It's possible to check allowed extensions list using `Settings` => `extensions.allowed` key:
<img width="1142" height="524" alt="Screenshot 2025-12-30 at 13 39 08" src="https://github.com/user-attachments/assets/dfc7f42c-1681-4869-8539-11283690bd6f" />
- Installed extension will be disabled when administrator adds it to not allowed extensions:
  
<img width="1142" height="337" alt="Screenshot 2025-12-30 at 17 51 40" src="https://github.com/user-attachments/assets/a4819f92-91ec-4a6a-a48e-b55352012243" />


#### Examples of the different extensions.allowed setting values:
<img width="621" height="638" alt="image" src="https://github.com/user-attachments/assets/215e1b26-566b-435e-bb7e-27f80408b71e" />

 

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://issues.redhat.com/browse/CRW-8866
see another part for the issue ^ in https://github.com/che-incubator/che-code/pull/617

### How to test this PR?
- there are different use cases for testing - click any item to expand a use case details
- each use case contains example of the `policy.json` section
- add the corresponding `policy.json` section to the `vscode-editor-configurations` ConfigMap, see https://eclipse.dev/che/docs/stable/administration-guide/editor-configurations-for-microsoft-visual-studio-code/
- restarting a workspace is required to apply the ConfigMap changes

#### 
<details>
<summary><b> 1. Deny All Extensions </b></summary>

```
policy.json: |
    {
      "AllowedExtensions": { 
          "*": false
       }
    }
``` 

**Expected behavior:**
| Extension | Can <br> be  installed |
|:------:|:------:|
| All extensions | - |

</details>

#### 
<details>
<summary><b> 2. Only extensions defined in the "AllowedExtensions" section can be installed </b></summary>

```
policy.json: |
    {
      "AllowedExtensions": { 
          "dbaeumer.vscode-eslint": true,
          "redhat.vscode-yaml": true
       }
    }
``` 

**Expected behavior:**
| Extension | Can <br> be  installed |
|:------:|:------:|
| dbaeumer.vscode-eslint  | + |
| redhat.vscode-yaml | + | 
| other extensions | - |

</details>

#### 
<details>
<summary><b> 3. Defined extensions can not be installed, all other extensions are allowed </b></summary>

```
policy.json: |
    {
      "AllowedExtensions": { 
          "*": true,
          "dbaeumer.vscode-eslint": false,
          "redhat.vscode-yaml": false
       }
    }
``` 

**Expected behavior:**
| Extension | Can <br> be  installed |
|:------:|:------:|
| dbaeumer.vscode-eslint  | - |
| redhat.vscode-yaml | - | 
| other extensions | + |

</details>

#### 
<details>
<summary><b> 4. Do not allow all extensions from a specific publisher (by publisher ID) </b></summary>

```
policy.json: |
    {
      "AllowedExtensions": { 
          "*": true,
          "redhat": false
       }
    }
``` 

**Expected behavior:**
| Extension | Can <br> be  installed |
|:------:|:------:|
|  all `redhat` extensions | - |
| redhat.java | - |
| redhat.vscode-xml | - |
| redhat.vscode-yaml | - |
| redhat.vscode-quarkus | - |
| other extensions | + |

</details>

#### 
<details>
<summary><b> 5. Allow only extensions from a specific publisher (by publisher ID), other extensions are not allowed </b></summary>

```
policy.json: |
    {
      "AllowedExtensions": { 
          "*": false,
          "redhat": true
       }
    }
``` 

**Expected behavior:**
| Extension | Can <br> be  installed |
|:------:|:------:|
|  all `redhat` extensions | + |
| redhat.java | + |
| redhat.vscode-xml | + |
| redhat.vscode-yaml | + |
| redhat.vscode-quarkus | + |
| other extensions | - |

</details>

#### 
<details>
<summary><b> 6. Allow only specified versions of an extension </b></summary>

```
policy.json: |
    {
      "AllowedExtensions": { 
          "*": true,
          "redhat.vscode-xml": ["0.28.0", "0.28.1"]
       }
    }
``` 

**Expected behavior:**
| Extension | Can <br> be  installed |
|:------:|:------:|
|  all `redhat` extensions | + |
| 0.28.0 redhat.vscode-xml | + |
| 0.28.1 redhat.vscode-xml | + |
| another version of redhat.vscode-xml | - |
| other extensions | + |

</details>
 

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
