### PR TITLE
CRW-9702: fix CVE-2025-66031 node-forge ASN.1 Unbounded Recursion

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,12 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
+https://github.com/che-incubator/che-code/pull/607
+
+- code/extensions/vscode-api-tests/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/589
 
 - code/package.json

--- a/.rebase/override/code/extensions/vscode-api-tests/package.json
+++ b/.rebase/override/code/extensions/vscode-api-tests/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "node-forge": "^1.3.2"
+  }
+}

--- a/code/extensions/vscode-api-tests/package-lock.json
+++ b/code/extensions/vscode-api-tests/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "22.x",
         "@types/node-forge": "^1.3.11",
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.3.2",
         "straightforward": "^4.2.2"
       },
       "engines": {
@@ -157,10 +157,11 @@
       "dev": true
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }

--- a/code/extensions/vscode-api-tests/package.json
+++ b/code/extensions/vscode-api-tests/package.json
@@ -268,7 +268,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "22.x",
     "@types/node-forge": "^1.3.11",
-    "node-forge": "^1.3.1",
+    "node-forge": "^1.3.2",
     "straightforward": "^4.2.2"
   },
   "repository": {

--- a/rebase.sh
+++ b/rebase.sh
@@ -203,6 +203,30 @@ apply_code_extensions_microsoft_authentication_package_lock_changes() {
   git add code/extensions/microsoft-authentication/package-lock.json > /dev/null 2>&1
 }
 
+# Apply changes on code/extensions/vscode-api-tests/package-lock.json file
+apply_code_extensions_vscode_api_tests_package_lock_changes() {
+
+  echo "  ⚙️ reworking code/extensions/vscode-api-tests/package-lock.json..."
+  
+  conflicted_files=$(git diff --name-only --diff-filter=U)
+
+  # Check if code/extensions/vscode-api-tests/package.json is in the list
+  if echo "$conflicted_files" | grep -q "^code/extensions/vscode-api-tests/package.json$"; then
+      echo "Conflict for the code/extensions/vscode-api-tests/package.json should be fixed first!"
+      apply_package_changes_by_path "code/extensions/vscode-api-tests/package.json"
+  fi
+  
+  # reset the file from what is upstream
+  git checkout --ours code/extensions/vscode-api-tests/package-lock.json > /dev/null 2>&1
+
+  # update package-lock.json
+  npm install --ignore-scripts --prefix code/extensions/vscode-api-tests
+
+  # resolve the change
+  git add code/extensions/vscode-api-tests/package-lock.json > /dev/null 2>&1
+}
+
+
 # Apply changes on code/remote/package-lock.json file
 apply_code_remote_package_lock_changes() {
 
@@ -420,6 +444,10 @@ resolve_conflicts() {
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/microsoft-authentication/package-lock.json" ]]; then
       apply_code_extensions_microsoft_authentication_package_lock_changes
+    elif [[ "$conflictingFile" == "code/extensions/vscode-api-tests/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/vscode-api-tests/package-lock.json" ]]; then
+      apply_code_extensions_vscode_api_tests_package_lock_changes
     elif [[ "$conflictingFile" == "code/build/lib/mangle/index.js" ]]; then
       apply_mangle_index_js_changes
     elif [[ "$conflictingFile" == "code/build/lib/mangle/index.ts" ]]; then


### PR DESCRIPTION
### What does this PR do?
override `node-forge` version to 1.3.2

### What issues does this PR fix?
https://issues.redhat.com/browse/CRW-9702


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
