### PR TITLE
Fix starting editor when a required library is absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Upstream `Code-OSS` is stored using Git [subtree](https://git-scm.com/book/en/v2
 4. `export DOCKER_BUILDKIT=1`
 5. `docker build -f build/dockerfiles/assembly.Dockerfile -t che-code .`
 
+## Running Che Code image locally
+- `podman run --rm -it -p 3100:3100 -e CODE_HOST=0.0.0.0 quay.io/che-incubator/che-code:next`
+- It's expected that Che extensions do not work locally
+- The default terminal is available only when the Che extensions are disabled (via the Extensions panel).
+
 ## Developing with Eclipse Che®
 
 This project includes [Devfile](devfile.yaml) that simplifies developing Che-Code in Eclipse Che.

--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2021-2024 Red Hat, Inc.
+# Copyright (c) 2021-2025 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -22,5 +22,6 @@ libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
 if [ -n "$libc" ]; then
     /checode-linux-musl/node /checode-linux-musl/out/server-main.js --host "${CODE_HOST}" --port 3100
 else
+    export LD_LIBRARY_PATH="/checode-linux-libc/ubi8/ld_libs:$LD_LIBRARY_PATH"
     /checode-linux-libc/ubi8/node /checode-linux-libc/ubi8/out/server-main.js --host "${CODE_HOST}" --port 3100
 fi


### PR DESCRIPTION
### What does this PR do?
Fixes running che-code image **locally**.
Without these changes there is an error about an absent library.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
no issue, the problem was reported in a slack channel

### How to test this PR?
- try to run editor image locally on your machine:
`podman run --rm -it -p 3100:3100 -e CODE_HOST=0.0.0.0 quay.io/che-incubator-pull-requests/che-code:pr-608-amd64`
 
### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
