### PR TITLE
Update instructions for building che-code image

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ Upstream `Code-OSS` is stored using Git [subtree](https://git-scm.com/book/en/v2
 
 ## Image build
 
-1. `docker build -f build/dockerfiles/linux-musl.Dockerfile -t linux-musl .`
-2. `docker build -f build/dockerfiles/linux-libc-ubi8.Dockerfile -t linux-libc-ubi8 .`
-3. `docker build -f build/dockerfiles/linux-libc-ubi9.Dockerfile -t linux-libc-ubi9 .`
-4. `export DOCKER_BUILDKIT=1`
-5. `docker build -f build/dockerfiles/assembly.Dockerfile -t che-code .`
+1. `podman build -f build/dockerfiles/linux-musl.Dockerfile -t linux-musl .`
+2. `podman build -f build/dockerfiles/linux-libc-ubi8.Dockerfile -t linux-libc-ubi8 .`
+3. `podman build -f build/dockerfiles/linux-libc-ubi9.Dockerfile -t linux-libc-ubi9 .`
+4. `podman build -f build/dockerfiles/assembly.Dockerfile -t che-code .`
 
 ## Developing with Eclipse Che®
 


### PR DESCRIPTION
### What does this PR do?
Updates instructions for building `che-code` image: use `podman` instead of `docker`

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
no issue

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
