### PR TITLE
Fix publising the `next` tag on commits to `main` branch

### DIFF
--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -78,7 +78,7 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && mkdir -p /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH} \
     && echo "caching /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node" \
     && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
-    && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
+    && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs \

--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -78,7 +78,7 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && mkdir -p /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH} \
     && echo "caching /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node" \
     && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
-    && NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
+    && NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs \

--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -78,7 +78,7 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && mkdir -p /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH} \
     && echo "caching /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node" \
     && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
-    && NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
+    && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -77,7 +77,7 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && mkdir -p /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH} \
     && echo "caching /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node" \
     && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
-    && NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
+    && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -77,7 +77,7 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && mkdir -p /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH} \
     && echo "caching /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node" \
     && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
-    && NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
+    && NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -113,8 +113,8 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
       ARCH=$(uname -m) && \
       yum install --nobest -y procps \
         https://rpmfind.net/linux/epel/9/Everything/x86_64/Packages/e/epel-release-9-10.el9.noarch.rpm \
-        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-9.0-32.el9.noarch.rpm \
-        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-32.el9.noarch.rpm; \
+        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-9.0-24.el9.noarch.rpm \
+        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-24.el9.noarch.rpm; \
     fi
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -113,8 +113,8 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
       ARCH=$(uname -m) && \
       yum install --nobest -y procps \
         https://rpmfind.net/linux/epel/9/Everything/x86_64/Packages/e/epel-release-9-10.el9.noarch.rpm \
-        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-9.0-24.el9.noarch.rpm \
-        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-24.el9.noarch.rpm; \
+        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-9.0-32.el9.noarch.rpm \
+        https://rpmfind.net/linux/centos-stream/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-32.el9.noarch.rpm; \
     fi
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -77,7 +77,7 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && mkdir -p /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH} \
     && echo "caching /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node" \
     && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
-    && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
+    && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs \

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -58,7 +58,7 @@ RUN NODE_VERSION=$(cat /checode-compilation/remote/.npmrc | grep target | cut -d
     # workaround to fix build
     && cp -r /checode-compilation/node_modules/tslib /checode-compilation/remote/node_modules/
 
-RUN VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-alpine-min
+RUN VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-alpine-min
 RUN cp -r ../vscode-reh-web-linux-alpine /checode
 
 RUN chmod a+x /checode/out/server-main.js \

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -58,7 +58,7 @@ RUN NODE_VERSION=$(cat /checode-compilation/remote/.npmrc | grep target | cut -d
     # workaround to fix build
     && cp -r /checode-compilation/node_modules/tslib /checode-compilation/remote/node_modules/
 
-RUN NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-alpine-min
+RUN VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-alpine-min
 RUN cp -r ../vscode-reh-web-linux-alpine /checode
 
 RUN chmod a+x /checode/out/server-main.js \

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -58,7 +58,7 @@ RUN NODE_VERSION=$(cat /checode-compilation/remote/.npmrc | grep target | cut -d
     # workaround to fix build
     && cp -r /checode-compilation/node_modules/tslib /checode-compilation/remote/node_modules/
 
-RUN NODE_OPTIONS="--max-old-space-size=4096" ./node_modules/.bin/gulp vscode-reh-web-linux-alpine-min
+RUN NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-alpine-min
 RUN cp -r ../vscode-reh-web-linux-alpine /checode
 
 RUN chmod a+x /checode/out/server-main.js \

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "prepare": "cd code && npm install && npm run download-builtin-extensions",
     "watch": "cd code && npm run watch",
     "server": "cd code && VSCODE_DEV=1 node out/server-main.js --host 0.0.0.0 --without-connection-token",
-    "build": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=4096 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64",
-    "build:min": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=4096 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64-min",
+    "build": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64",
+    "build:min": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64-min",
     "rebuild-native-modules": "cd code && npm rebuild"
   },
   "license": "EPL-2.0"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "prepare": "cd code && npm install && npm run download-builtin-extensions",
     "watch": "cd code && npm run watch",
     "server": "cd code && VSCODE_DEV=1 node out/server-main.js --host 0.0.0.0 --without-connection-token",
-    "build": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64",
-    "build:min": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64-min",
+    "build": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=4096 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64",
+    "build:min": "cd code && VSCODE_MANGLE_WORKERS=2 node --max-old-space-size=4096 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64-min",
     "rebuild-native-modules": "cd code && npm rebuild"
   },
   "license": "EPL-2.0"


### PR DESCRIPTION
### What does this PR do?
Decreases `VSCODE_MANGLE_WORKERS` to 2 from the default 4,
and increases JS memory heap for Gulp build.
This should consume less memory when building,
so it should unblock publishing the `next` image tags
on the commits to the `main` branch.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
fixes https://github.com/eclipse-che/che/issues/23693

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
