### PR TITLE
Use the latest version of che-e2e image in smoke-test checking

### DIFF
--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -145,8 +145,8 @@ jobs:
             -v ${LOCAL_TEST_DIR}/tests/e2e/video:/tmp/ffmpeg_report:Z \
             -e USERSTORY=SmokeTest \
             -e TS_SELENIUM_VALUE_OPENSHIFT_OAUTH=false \
-            -e TEST_REPO=https://github.com/che-incubator/quarkus-api-example?df=smoke-test.devfile.yaml \
-            quay.io/mmusiien/che-e2e:smoke-test
+            -e TS_SELENIUM_FACTORY_GIT_REPO_URL=https://github.com/che-incubator/quarkus-api-example?df=smoke-test.devfile.yaml \
+            quay.io/eclipse/che-e2e:next
 
       - name: Bump logs
         if: always()

--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -132,8 +132,9 @@ jobs:
             --network="host" \
             -e TS_PLATFORM=kubernetes \
             -e TS_SELENIUM_LOAD_PAGE_TIMEOUT=60000 \
-            -e TS_SELENIUM_USERNAME=che@eclipse.org \
-            -e TS_SELENIUM_PASSWORD=admin \
+            -e TS_API_TEST_KUBERNETES_COMMAND_LINE_TOOL=kubectl \
+            -e TS_SELENIUM_K8S_USERNAME=che@eclipse.org \
+            -e TS_SELENIUM_K8S_PASSWORD=admin \
             -e TS_SELENIUM_BASE_URL=https://$(kubectl get ingress che -n eclipse-che -o jsonpath='{.spec.rules[0].host}') \
             -e DELETE_WORKSPACE_ON_FAILED_TEST=true \
             -e TS_SELENIUM_START_WORKSPACE_TIMEOUT=120000 \

--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -130,6 +130,7 @@ jobs:
             --shm-size=2048m \
             -p 5920:5920 \
             --network="host" \
+            -e TS_PLATFORM=kubernetes \
             -e TS_SELENIUM_LOAD_PAGE_TIMEOUT=60000 \
             -e TS_SELENIUM_USERNAME=che@eclipse.org \
             -e TS_SELENIUM_PASSWORD=admin \


### PR DESCRIPTION
### What does this PR do?
Use the latest version of [che-e2e](https://quay.io/repository/eclipse/che-e2e?tab=tags) image instead of oudated `quay.io/mmusiien/che-e2e:smoke-test`

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23701

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
