### PR TITLE
fix: Fix "build-che-dev-image" job

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -146,6 +146,11 @@ jobs:
       - name: Checkout che-code source code
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        run: |
+          rm -rf /opt/hostedtoolcache
+          df -h
+
       - name: Cleanup docker images
         run: |
           docker system prune -af


### PR DESCRIPTION
### What does this PR do?
Fixes `build-che-dev-image` job

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23699

### How to test this PR?
The job should pass successfully

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
