### PR TITLE
fix: Fix starting ubi9-9.6 based workspaces

### DIFF
--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -48,7 +48,7 @@ RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
     else \
       LIBKEYBOARD=""; echo "Warning: arch $(uname -m) not supported"; \
     fi; } \
-    && yum install -y $LIBSECRET $LIBKEYBOARD make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbcommon krb5-devel bash tar gzip rsync patch npm \
+    && yum install -y --nobest --setopt=install_weak_deps=False --exclude=openssl* --exclude=openssl-libs* $LIBSECRET $LIBKEYBOARD make cmake gcc gcc-c++ git git-core-doc openssh less libX11-devel libxkbcommon krb5-devel bash tar gzip rsync patch npm \
     && yum -y clean all && rm -rf /var/cache/yum
 
 #########################################################


### PR DESCRIPTION
### What does this PR do?


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23692

### How to test this PR?
- ubi9-9.6 based workspace https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com#https://github.com/RomanNikitenko/web-nodejs-sample?image=registry.access.redhat.com/ubi9/nodejs-22:9.6&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-629-amd64
- ubi9-9.7 based workspace https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com#https://github.com/RomanNikitenko/web-nodejs-sample?image=registry.access.redhat.com/ubi9/nodejs-22:9.7&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-629-amd64

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
