### PR TITLE
CRW-9947: reverting script modifications of etc/passwd

### DIFF
--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -58,6 +58,14 @@ get_openssl_version() {
   fi
 }
 
+# UDI8 support for adding current (arbitrary) user to /etc/passwd and /etc/group
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+  fi
+fi
+
 # list checode
 ls -la /checode/
 


### PR DESCRIPTION
### What does this PR do?
fixes issues when using UBI8 based images, that do not add current user to etc/passwd.

### What issues does this PR fix?
https://issues.redhat.com/browse/CRW-9947

### How to test this PR?
generated image was tested against several samples 
- go
- angular
- empty

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
