### PR TITLE
Add @rgrunber as codeowner to the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default Owners
-* @azatsarynnyy @RomanNikitenko @vitaliy-guliy
+* @rgrunber @azatsarynnyy @RomanNikitenko @vitaliy-guliy


### PR DESCRIPTION
### What does this PR do?
Adds @rgrunber to the `codeowners` list

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
