### PR TITLE
fix: Add required dev dependecy

### DIFF
--- a/code/extensions/che-api/package-lock.json
+++ b/code/extensions/che-api/package-lock.json
@@ -26,6 +26,7 @@
         "@types/node": "22.x",
         "jest": "29.7.0",
         "ts-jest": "29.4.5",
+        "typescript": "^5.9.2",
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
@@ -4514,7 +4515,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -46,6 +46,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/node": "22.x",
     "jest": "29.7.0",
+    "typescript": "^5.9.2",
     "ts-jest": "29.4.5",
     "webpack-node-externals": "^3.0.0"
   },

--- a/code/extensions/che-port/package-lock.json
+++ b/code/extensions/che-port/package-lock.json
@@ -19,7 +19,8 @@
         "@types/js-yaml": "^4.0.5",
         "@types/node": "22.x",
         "jest": "29.7.0",
-        "ts-jest": "29.4.5"
+        "ts-jest": "29.4.5",
+        "typescript": "^5.9.2"
       },
       "engines": {
         "vscode": "^1.63.0"
@@ -3997,7 +3998,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/code/extensions/che-port/package.json
+++ b/code/extensions/che-port/package.json
@@ -41,7 +41,8 @@
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.5.0",
     "@types/js-yaml": "^4.0.5",
-    "@types/node": "22.x"
+    "@types/node": "22.x",
+    "typescript": "^5.9.2"
   },
   "overrides": {
     "@devfile/api": {

--- a/code/extensions/che-resource-monitor/package-lock.json
+++ b/code/extensions/che-resource-monitor/package-lock.json
@@ -21,7 +21,8 @@
         "@types/node": "22.x",
         "add": "^2.0.6",
         "jest": "29.7.0",
-        "ts-jest": "29.4.5"
+        "ts-jest": "29.4.5",
+        "typescript": "^5.9.2"
       },
       "engines": {
         "vscode": "^1.63.0"
@@ -4485,7 +4486,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -43,6 +43,7 @@
     "@types/node": "22.x",
     "add": "^2.0.6",
     "jest": "29.7.0",
+    "typescript": "^5.9.2",
     "ts-jest": "29.4.5"
   },
   "repository": {


### PR DESCRIPTION
Assisted-by: Cursor AI

### What does this PR do?
- Adds `typescript` as an explicit `devDependency` in the che extensions.
- Aligns the version to the shared `code/extensions/package.json` to keep consistency across extensions

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
`npm --prefix code install` leads to the changes in the package-lock files:

<img width="1361" height="612" alt="image" src="https://github.com/user-attachments/assets/0bb02074-69a0-4dad-9a4c-2cb75924f230" />
 

### How to test this PR?
1. Run `npm --prefix code install` 
2. Check - there are no git changes in the lock files for che extensions
3. 
### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
