### PR TITLE
ci: Fix publishing images

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -141,28 +141,18 @@ jobs:
           SHORT_SHA1=$(git rev-parse --short=7 HEAD)
           if [[ ${{env.BRANCH_NAME}} == main ]]; then         
             docker manifest create quay.io/che-incubator/che-code:next --amend quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --amend quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}}
-            docker manifest annotate quay.io/che-incubator/che-code:next quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --os linux --arch amd64
-            docker manifest annotate quay.io/che-incubator/che-code:next quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}} --os linux --arch arm64
             docker manifest push quay.io/che-incubator/che-code:next          
           
             docker manifest create quay.io/che-incubator/che-code:insiders --amend quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --amend quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}}
-            docker manifest annotate quay.io/che-incubator/che-code:insiders quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --os linux --arch amd64
-            docker manifest annotate quay.io/che-incubator/che-code:insiders quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}} --os linux --arch arm64
             docker manifest push quay.io/che-incubator/che-code:insiders          
           
             docker manifest create quay.io/che-incubator/che-code:insiders-${SHORT_SHA1} --amend quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --amend quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}}
-            docker manifest annotate quay.io/che-incubator/che-code:insiders-${SHORT_SHA1} quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --os linux --arch amd64
-            docker manifest annotate quay.io/che-incubator/che-code:insiders-${SHORT_SHA1} quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}} --os linux --arch arm64
             docker manifest push quay.io/che-incubator/che-code:insiders-${SHORT_SHA1}          
           elif [[ ${{env.BRANCH_NAME}} =~ ^7\.[0-9]+\.[0-9]+$ ]]; then         
             docker manifest create quay.io/che-incubator/che-code:${{ env.BRANCH_NAME }} --amend quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --amend quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}}
-            docker manifest annotate quay.io/che-incubator/che-code:${{ env.BRANCH_NAME }} quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --os linux --arch amd64
-            docker manifest annotate quay.io/che-incubator/che-code:${{ env.BRANCH_NAME }} quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}} --os linux --arch arm64
             docker manifest push quay.io/che-incubator/che-code:${{ env.BRANCH_NAME }}     
           
             docker manifest create quay.io/che-incubator/che-code:latest --amend quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --amend quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}}
-            docker manifest annotate quay.io/che-incubator/che-code:latest quay.io/che-incubator/che-code:amd64-${{env.tag_suffix}} --os linux --arch amd64
-            docker manifest annotate quay.io/che-incubator/che-code:latest quay.io/che-incubator/che-code:arm64-${{env.tag_suffix}} --os linux --arch arm64
             docker manifest push quay.io/che-incubator/che-code:latest     
           fi          
 


### PR DESCRIPTION
Generated-by: Cursor AI

### What does this PR do?

This change fixes the publish job in `.github/workflows/image-publish.yml` failing after merges to main.
The workflow was calling `docker manifest annotate` for `amd64-*` and `arm64-*` source tags. Those source tags are now manifest lists, and annotate fails with:
`<image>:amd64-<tag> is a manifest list`.

Since platform metadata is already present from the Buildx `--platform ... --push` flow, explicit annotation is no longer needed. The publish step now relies on `docker manifest create --amend ... --amend ...` followed by `docker manifest push`, which is compatible with current source image format.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23745

### How to test this PR?
- [ ] Merge to main and verify image-publish passes.
- [ ] Confirm publish step no longer fails with is a manifest list.
- [ ] Verify resulting tags are published:
quay.io/che-incubator/che-code:next
quay.io/che-incubator/che-code:insiders
quay.io/che-incubator/che-code:insiders-<short_sha>
- [ ] Inspect manifests and confirm both platforms are present (linux/amd64, linux/arm64).

Check manifest command: `podman manifest inspect quay.io/che-incubator/che-code:next`

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
