### PR TITLE
Inject the username of the Dev Workspace into the URI for Toolbox.

### DIFF
--- a/build/scripts/jetbrains-sshd-page/server.js
+++ b/build/scripts/jetbrains-sshd-page/server.js
@@ -60,7 +60,7 @@ const server = http.createServer((req, res) => {
       }())
 
       function openToolbox() {
-        const tbxLink = "jetbrains://gateway/com.redhat.devtools.toolbox?dwID=${process.env['DEVWORKSPACE_ID']}&dwName=${process.env['DEVWORKSPACE_NAME']}&key=${encodeURIComponent(keyMessage)}&project=${process.env['PROJECT_SOURCE']}"
+        const tbxLink = "jetbrains://gateway/com.redhat.devtools.toolbox?dwID=${process.env['DEVWORKSPACE_ID']}&dwName=${process.env['DEVWORKSPACE_NAME']}&username=${username}&key=${encodeURIComponent(keyMessage)}&project=${process.env['PROJECT_SOURCE']}"
         console.log("Opening Toolbox App...");
         window.open(tbxLink, "_self");
       }


### PR DESCRIPTION
- The username that is authorized to access the Dev Workspace over SSH should be passed into the 'jetbrains' URI so that the Toolbox client is able to re-use it for authentication

I was attempting to connect to the che-code-sshd when it is configured to act as a JetBrains Toolbox server.

```
$ id
uid=1001120000(user) gid=0(root) groups=0(root),1001120000(user)
...
...
$ cat /tmp/sshd.log
...
...
debug1: attempt 0 failures 0 [preauth]
Invalid user 1001270000 from ::1 port 33494
debug1: userauth-request for user 1001270000 service ssh-connection method publickey [preauth]
```

For some reason it was using what appears to be a completely invalid user. `1001270000` doesn't exist. It should actually just use `user`.

If you look at https://github.com/redhat-developer/devspaces-toolbox-plugin/blob/024f5833ea14d69583f391701c6642ab7d2fe1e7/plugin/src/main/kotlin/com/redhat/devtools/toolbox/environment/SshEnvironmentContentsViewFactory.kt#L72 , you'll see the username is hardcoded. There is no way to know ahead of time what the user name will be.

Also, the landing page never sends the user name through the URI, and the Dev Spaces Toolbox plugin never reads it in : https://github.com/redhat-developer/devspaces-toolbox-plugin/blob/024f5833ea14d69583f391701c6642ab7d2fe1e7/plugin/src/main/kotlin/com/redhat/devtools/toolbox/DevSpacesRemoteProvider.kt#L60-L63 .

This PR adds the user name to the URI, and I have a separate PR to fix the Dev Spaces ToolBox plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved username identification when connecting to JetBrains toolbox integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->