### PR TITLE
[7.115.x] Inject the username of the Dev Workspace into the URI for Toolbox.

### DIFF
--- a/build/scripts/jetbrains-sshd-page/server.js
+++ b/build/scripts/jetbrains-sshd-page/server.js
@@ -60,7 +60,7 @@ const server = http.createServer((req, res) => {
       }())
 
       function openToolbox() {
-        const tbxLink = "jetbrains://gateway/com.redhat.devtools.toolbox?dwID=${process.env['DEVWORKSPACE_ID']}&dwName=${process.env['DEVWORKSPACE_NAME']}&key=${encodeURIComponent(keyMessage)}&project=${process.env['PROJECT_SOURCE']}"
+        const tbxLink = "jetbrains://gateway/com.redhat.devtools.toolbox?dwID=${process.env['DEVWORKSPACE_ID']}&dwName=${process.env['DEVWORKSPACE_NAME']}&username=${username}&key=${encodeURIComponent(keyMessage)}&project=${process.env['PROJECT_SOURCE']}"
         console.log("Opening Toolbox App...");
         window.open(tbxLink, "_self");
       }


### PR DESCRIPTION
This is a cherry-pick of https://github.com/che-incubator/che-code/pull/663 .

- The username that is authorized to access the Dev Workspace over SSH should be passed into the 'jetbrains' URI so that the Toolbox client is able to re-use it for authentication