### PR TITLE
fix rebase rules leftovers after #666 merge

### DIFF
--- a/.rebase/replace/code/build/gulpfile.cli.js.json
+++ b/.rebase/replace/code/build/gulpfile.cli.js.json
@@ -1,7 +1,7 @@
 [
     {
         "from": "const untar = require('gulp-untar');\n\tconst gunzip = require('gulp-gunzip');",
-        "by": "const untar = require('gulp-decompress');"
+        "by": "const decompress = require('gulp-decompress');"
     },
     {
         "from": ".pipe(gunzip())\n\t\t.pipe(untar())",

--- a/.rebase/replace/code/build/gulpfile.reh.js.json
+++ b/.rebase/replace/code/build/gulpfile.reh.js.json
@@ -1,7 +1,7 @@
 [
     {
         "from": "const untar = require('gulp-untar');",
-        "by": "const untar = require('gulp-decompress');"
+        "by": "const decompress = require('gulp-decompress');"
     },
     {
         "from": "flatmap(stream => stream.pipe(gunzip()).pipe(untar()))",


### PR DESCRIPTION
### What does this PR do?
fix rebase rules after #666 work

### What issues does this PR fix?

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the build configuration by consolidating archive extraction dependencies into a unified approach for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->