### PR TITLE
Ensure connected SSHD session inherits PATH from parent process.

### DIFF
--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -65,11 +65,14 @@ fi
 # Common tools needed to set up service
 mkdir -p $HOME/bin
 cp $sshd_libdir/tar $sshd_libdir/gzip $sshd_libdir/which $HOME/bin/
-echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.profile
 
 # Set up environment variables injected into PID 1 (.profile & .bashrc)
-env | grep -v 'PATH=' | sed 's|^|export |' >> $HOME/.profile
-cat $HOME/.profile >> $HOME/.bashrc
+grep -q 'export DEVWORKSPACE_NAME=' $HOME/.profile
+if [ ! $? -eq 0 ]; then
+  env | sed 's|^|export |' >> $HOME/.profile
+  echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.profile
+  cat $HOME/.profile >> $HOME/.bashrc
+fi
 
 # Configure SSHD as non-root user
 


### PR DESCRIPTION
### What issues does this PR fix?

1. Create a DevWorkspace using the "Visual Studio Code (Desktop) (SSH) editor, and an empty workspace.
2. From the web terminal for the UDI image : `echo $PATH | tr ':' '\n'` and you'll see `/home/tooling/go/bin` present.
3. Now connect to that same workspace over SSH and perform the same command from (2). You won't find `/home/tooling/go/bin` on the path.

The problem is the first line at https://github.com/che-incubator/che-code/blob/cf1d4481bfabbc407520858db339d9216e0b7323/build/scripts/sshd.start#L68

The single quotes mean the PATH references on the right-hand-side is never expanded and at runtime it's too late. We even avoid injecting it at https://github.com/che-incubator/che-code/blob/cf1d4481bfabbc407520858db339d9216e0b7323/build/scripts/sshd.start#L69-L71 because we just modified it above.

This PR should fix this so that it inherits the PATH from the parent, but also includes the `$HOME/bin` location where the additional scripts needed for the SSHD setup are present.

- [x] I have not tested this thoroughly at all but seems to fix the issue. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved startup environment initialization to avoid repeatedly appending PATH entries and to conditionally propagate environment variables into user shell initialization.
  * Ensures more predictable PATH configuration and reduces duplicate entries during application startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->