### PR TITLE
[DO NOT MERGE] Add checkout step for che e2e tests

### DIFF
--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -128,6 +128,10 @@ jobs:
       - name: Pull Universal Base Image
         run: |
           minikube image pull quay.io/devfile/universal-developer-image:ubi9-latest
+          
+      - name: Checkout che e2e tests                                                                                                                                                                                                        
+        run: |                                                                                                                                                                                                                              
+          git clone --depth 1 https://github.com/eclipse-che/che ${LOCAL_TEST_DIR} 
 
       - name: Run Smoke test
         run: |
@@ -148,6 +152,7 @@ jobs:
             -e TS_SELENIUM_LOG_LEVEL=TRACE \
             -e TS_WAIT_LOADER_PRESENCE_TIMEOUT=120000 \
             -e TS_COMMON_DASHBOARD_WAIT_TIMEOUT=30000 \
+            -v ${LOCAL_TEST_DIR}/tests/e2e:/tmp/e2e:Z \ 
             -v ${LOCAL_TEST_DIR}/tests/e2e/report:/tmp/e2e/report:Z \
             -v ${LOCAL_TEST_DIR}/tests/e2e/video:/tmp/ffmpeg_report:Z \
             -e USERSTORY=SmokeTest \

--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -26,53 +26,9 @@ jobs:
   smoke-test:
     runs-on: ubuntu-22.04
     steps:
-
-      - name: Checkout che-code source code
-        uses: actions/checkout@v4
-
-      - name: Prepare Che-Code Dockerfile ( remove tests )
-        run: |
-          #
-          # truncate Dockerfile, remove section that runs tests
-          #
-          cp -f build/dockerfiles/linux-libc-ubi9.Dockerfile build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
-          REMOVE_FROM="### Beginning of tests"
-          REMOVE_TO="### Ending of tests"
-          sed -i "/${REMOVE_FROM}/,/${REMOVE_TO}/{/${REMOVE_FROM}/n;/${REMOVE_TO}/!d;}" build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
-
-          #
-          # show the Dockerfile
-          #
-          cat build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile
-
-      - name: Compile Che-Code editor
-        run: |
-          #
-          # build linux-libc-ubi9:latest docker image
-          #
-          docker image prune -a -f
-          docker build --memory-swap -1 --memory 12g -f build/dockerfiles/linux-libc-ubi9.no-test.Dockerfile -t linux-libc-ubi9 .
-
-      - name: Build Che-Code Docker image
-        run: |
-          #
-          # build che-code:latest docker image
-          #
-          cp -f build/dockerfiles/assembly.Dockerfile build/dockerfiles/assembly.copy.Dockerfile
-          REPLACE_FROM="FROM linux-musl as linux-musl-content"
-          sed -i -r -e "s|${REPLACE_FROM}||" build/dockerfiles/assembly.copy.Dockerfile
-          REPLACE_FROM="COPY --from=linux-musl-content --chown=0:0 /checode-linux-musl /mnt/rootfs/checode-linux-musl"
-          sed -i -r -e "s|${REPLACE_FROM}||" build/dockerfiles/assembly.copy.Dockerfile
-          REPLACE_FROM="FROM linux-libc-ubi8 as linux-libc-ubi8-content"
-          sed -i -r -e "s|${REPLACE_FROM}||" build/dockerfiles/assembly.copy.Dockerfile
-          REPLACE_FROM="COPY --from=linux-libc-ubi8-content --chown=0:0 /checode-linux-libc/ubi8 /mnt/rootfs/checode-linux-libc/ubi8"
-          sed -i -r -e "s|${REPLACE_FROM}||" build/dockerfiles/assembly.copy.Dockerfile
-          
-          export DOCKER_BUILDKIT=1
-          docker build -f build/dockerfiles/assembly.copy.Dockerfile -t che-code .
-
-          docker tag che-code:latest che-code:next
-          docker save -o /tmp/che-code-latest.tar che-code:latest che-code:next
+      - name: Checkout che e2e tests                                                                                                                                                                                                        
+        run: |                                                                                                                                                                                                                              
+          git clone --depth 1 https://github.com/eclipse-che/che ${LOCAL_TEST_DIR}/che
 
       - name: Display docker images
         run: |
@@ -103,11 +59,6 @@ jobs:
       - name: Deploy Che
         run: |
           #
-          # load che-code images from /tmp/che-code-latest.tar
-          #
-          eval $(minikube docker-env) && docker load -i  /tmp/che-code-latest.tar && rm /tmp/che-code-latest.tar
-
-          #
           # deploy Che
           #
           chectl server:deploy \
@@ -115,7 +66,6 @@ jobs:
             --platform minikube \
             --k8spodwaittimeout=480000 \
             --k8spodreadytimeout=480000 \
-            --che-operator-cr-patch-yaml "${GITHUB_WORKSPACE}/build/test/github-minikube-checluster-patch.yaml"
 
           #
           # apply patch
@@ -129,10 +79,6 @@ jobs:
         run: |
           minikube image pull quay.io/devfile/universal-developer-image:ubi9-latest
           
-      - name: Checkout che e2e tests                                                                                                                                                                                                        
-        run: |                                                                                                                                                                                                                              
-          git clone --depth 1 https://github.com/eclipse-che/che ${LOCAL_TEST_DIR} 
-
       - name: Run Smoke test
         run: |
           docker run \
@@ -152,12 +98,12 @@ jobs:
             -e TS_SELENIUM_LOG_LEVEL=TRACE \
             -e TS_WAIT_LOADER_PRESENCE_TIMEOUT=120000 \
             -e TS_COMMON_DASHBOARD_WAIT_TIMEOUT=30000 \
-            -v ${LOCAL_TEST_DIR}/tests/e2e:/tmp/e2e:Z \ 
-            -v ${LOCAL_TEST_DIR}/tests/e2e/report:/tmp/e2e/report:Z \
-            -v ${LOCAL_TEST_DIR}/tests/e2e/video:/tmp/ffmpeg_report:Z \
+            -v ${LOCAL_TEST_DIR}/che/tests/e2e:/tmp/e2e:Z \
+            -v ${LOCAL_TEST_DIR}/che/tests/e2e/report:/tmp/e2e/report:Z \
+            -v ${LOCAL_TEST_DIR}/che/tests/e2e/video:/tmp/ffmpeg_report:Z \
             -e USERSTORY=SmokeTest \
             -e TS_SELENIUM_VALUE_OPENSHIFT_OAUTH=false \
-            -e TS_SELENIUM_FACTORY_GIT_REPO_URL=https://github.com/che-incubator/quarkus-api-example?df=smoke-test.devfile.yaml \
+            -e TS_SELENIUM_FACTORY_GIT_REPO_URL=https://github.com/che-incubator/quarkus-api-example \
             quay.io/eclipse/che-e2e:next
 
       - name: Bump logs
@@ -182,7 +128,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: e2e-artifacts
-          path: /tmp/tests
+          path: /tmp/che/tests
       
       - name: Store k8s logs
         if: always()

--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -26,10 +26,6 @@ jobs:
   smoke-test:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout che e2e tests                                                                                                                                                                                                        
-        run: |                                                                                                                                                                                                                              
-          git clone --depth 1 https://github.com/eclipse-che/che ${LOCAL_TEST_DIR}/che
-
       - name: Display docker images
         run: |
           docker images
@@ -98,7 +94,6 @@ jobs:
             -e TS_SELENIUM_LOG_LEVEL=TRACE \
             -e TS_WAIT_LOADER_PRESENCE_TIMEOUT=120000 \
             -e TS_COMMON_DASHBOARD_WAIT_TIMEOUT=30000 \
-            -v ${LOCAL_TEST_DIR}/che/tests/e2e:/tmp/e2e:Z \
             -v ${LOCAL_TEST_DIR}/che/tests/e2e/report:/tmp/e2e/report:Z \
             -v ${LOCAL_TEST_DIR}/che/tests/e2e/video:/tmp/ffmpeg_report:Z \
             -e USERSTORY=SmokeTest \


### PR DESCRIPTION
Add a step to checkout che e2e tests before running smoke tests.

### What does this PR do?
Verify if Smoke Test failure for the che-code is a test container image problem, or test code problem.

### What issues does this PR fix?
https://github.com/eclipse-che/che/issues/23779

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined PR smoke-test workflow by removing local image build/load steps and related build-time checks.
  * Simplified deployment invocation by dropping an extra operator patch argument.
  * Updated smoke-test asset locations and repository reference for end-to-end tests, and changed e2e artifact upload path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->