### PR TITLE
Fix CVE-2026-4926 by updating path-to-regexp to patched versions

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,13 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
+https://github.com/che-incubator/che-code/pull/
+
+- code/package.json
+- code/test/mcp/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/659
 
 - code/package.json

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,7 +3,7 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
-https://github.com/che-incubator/che-code/pull/
+https://github.com/che-incubator/che-code/pull/677
 
 - code/package.json
 - code/test/mcp/package.json

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -19,7 +19,8 @@
             "nanoid": "3.3.8"
         },
         "@vscode/test-web": {
-            "tar-fs": "3.1.1"
+            "tar-fs": "3.1.1",
+            "path-to-regexp": "8.4.0"
         },
         "prebuild-install": {
             "tar-fs": "2.1.4"

--- a/.rebase/add/code/test/mcp/package.json
+++ b/.rebase/add/code/test/mcp/package.json
@@ -2,6 +2,7 @@
     "overrides": {
         "qs": "6.14.1",
         "ajv": "6.14.0",
-        "minimatch": "^3.1.5"
+        "minimatch": "^3.1.5",
+        "path-to-regexp": "8.4.0"
     }
 }

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -13231,9 +13231,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/code/package.json
+++ b/code/package.json
@@ -241,7 +241,8 @@
       "node-addon-api": "7.1.0"
     },
     "@vscode/test-web": {
-      "tar-fs": "3.1.1"
+      "tar-fs": "3.1.1",
+      "path-to-regexp": "8.4.0"
     },
     "prebuild-install": {
       "tar-fs": "2.1.4"

--- a/code/test/mcp/package-lock.json
+++ b/code/test/mcp/package-lock.json
@@ -2168,12 +2168,13 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {

--- a/code/test/mcp/package.json
+++ b/code/test/mcp/package.json
@@ -31,6 +31,7 @@
   "overrides": {
     "qs": "6.14.1",
     "ajv": "6.14.0",
-    "minimatch": "^3.1.5"
+    "minimatch": "^3.1.5",
+    "path-to-regexp": "8.4.0"
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR fixes CVE-2026-4926.

`path-to-regexp` versions is updated to latest version `8.4.0`

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-10598
https://redhat.atlassian.net/browse/CRW-10600

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency override configurations to ensure consistency across the project's development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->