### PR TITLE
Add CodeRabbit pre-merge checks for upstream change validation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,13 +37,21 @@ reviews:
           and `**/package-lock.json`), then the PR MUST also include corresponding
           rebase rules in the `.rebase/` directory AND an entry in `.rebase/CHANGELOG.md`.
 
+          Important:
+          - A file can be under `code/` and still be Che-only (for example `code/src/.../che/...` newly created by Che). Do not create a rule for such files if they are not upstream VS Code files.
+          - Still create rules for the upstream file(s) that import/use those Che-only helpers.
+
           The PR template has a checklist section "Does this PR contain changes that
           override default upstream Code-OSS behavior?" with three checkboxes. If the
           PR touches files under `code/`, all three checkboxes should be checked.
 
           PASS if:
           - No files under `code/` are changed (excluding che extensions and lock files), OR
-          - Files under `code/` are changed AND `.rebase/` rules and `.rebase/CHANGELOG.md`
-            are also updated in the same PR.
+          - Newly added Che-only files with no upstream counterpart, OR
+          - Files under `code/` are changed AND `.rebase/` rules, `.rebase/CHANGELOG.md`,
+            and `rebase.sh` conflict routing are also updated in the same PR.
 
-          FAIL if files under `code/` are changed but `.rebase/` is not updated.
+          FAIL if files under `code/` are changed but any of the following are missing:
+          - `.rebase/` rule files (add/override/replace as appropriate)
+          - `.rebase/CHANGELOG.md` entry
+          - `rebase.sh` routing for the new rule files (e.g. elif branch in resolve_conflicts)

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 tone_instructions: |
-  You are a concise code reviewer. Focus only on critical logic, security, and performance issues. 
+  You are a concise code reviewer. Focus only on critical logic, security, and performance issues.
   Avoid trivial style issues or minor formatting suggestions.
 
 reviews:
@@ -17,3 +17,33 @@ reviews:
   # suppress walkthrough/summary comment when no findings
   collapse_walkthrough: true
   changed_files_summary: false
+
+  # Pre-merge checks
+  pre_merge_checks:
+    title:
+      mode: error
+      requirements: >
+        Title must be concise (under 72 characters) and clearly describe the change.
+        Use imperative mood (e.g. "Fix", "Add", "Update", not "Fixed", "Added", "Updated").
+    description:
+      mode: warning
+    docstrings:
+      mode: off
+    custom_checks:
+      - name: Rebase rules for upstream changes
+        mode: error
+        instructions: >
+          If the PR modifies files under `code/` (excluding `code/extensions/che-*/**`
+          and `**/package-lock.json`), then the PR MUST also include corresponding
+          rebase rules in the `.rebase/` directory AND an entry in `.rebase/CHANGELOG.md`.
+
+          The PR template has a checklist section "Does this PR contain changes that
+          override default upstream Code-OSS behavior?" with three checkboxes. If the
+          PR touches files under `code/`, all three checkboxes should be checked.
+
+          PASS if:
+          - No files under `code/` are changed (excluding che extensions and lock files), OR
+          - Files under `code/` are changed AND `.rebase/` rules and `.rebase/CHANGELOG.md`
+            are also updated in the same PR.
+
+          FAIL if files under `code/` are changed but `.rebase/` is not updated.


### PR DESCRIPTION
### What does this PR do?
follow-up of #672 

Added pre-merge check for rebase rules

### What issues does this PR fix?
related to https://github.com/eclipse-che/che/issues/23749

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened pre-merge checks to require accompanying rebase artifacts, a changelog entry, and conflict-routing updates when core code changes are present.
  * Minor cleanup: removed an extraneous trailing space in configuration text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->