### PR TITLE
Fix handlebars vulnerabilities by overriding to patched version

### DIFF
--- a/code/extensions/che-api/package-lock.json
+++ b/code/extensions/che-api/package-lock.json
@@ -2396,9 +2396,9 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -51,7 +51,8 @@
     "webpack-node-externals": "^3.0.0"
   },
   "overrides": {
-    "minimatch": "^3.1.5"
+    "minimatch": "^3.1.5",
+    "handlebars": "4.7.9"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-port/package-lock.json
+++ b/code/extensions/che-port/package-lock.json
@@ -2086,9 +2086,9 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/code/extensions/che-port/package.json
+++ b/code/extensions/che-port/package.json
@@ -54,7 +54,8 @@
     "jsdom": {
       "form-data": "3.0.4"
     },
-    "minimatch": "^3.1.5"
+    "minimatch": "^3.1.5",
+    "handlebars": "4.7.9"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-remote/package-lock.json
+++ b/code/extensions/che-remote/package-lock.json
@@ -2754,9 +2754,9 @@
       "dev": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -59,7 +59,8 @@
     },
     "lodash": "^4.17.23",
     "ajv": "6.14.0",
-    "minimatch": "^3.1.5"
+    "minimatch": "^3.1.5",
+    "handlebars": "4.7.9"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-resource-monitor/package-lock.json
+++ b/code/extensions/che-resource-monitor/package-lock.json
@@ -2355,9 +2355,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -47,7 +47,8 @@
     "ts-jest": "29.4.5"
   },
   "overrides": {
-    "minimatch": "^3.1.5"
+    "minimatch": "^3.1.5",
+    "handlebars": "4.7.9"
   },
   "repository": {
     "type": "git",

--- a/launcher/package-lock.json
+++ b/launcher/package-lock.json
@@ -2952,9 +2952,9 @@
       "dev": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -52,7 +52,8 @@
       "ajv": "^8.18.0"
     },
     "ajv": "6.14.0",
-    "minimatch": "^3.1.5"
+    "minimatch": "^3.1.5",
+    "handlebars": "4.7.9"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
### What does this PR do?
Override handlebars to `4.7.9` in `che-api`, `che-port`, `che-remote`, `che-resource-monitor`, and `launcher` to fix 8 vulnerabilities including critical JS injection (CVSS 9.8) and multiple high severity issues affecting versions 4.0.0-4.7.8.

Especially fixing:

CVE-2026-33937
CVE-2026-33938
CVE-2026-33939
CVE-2026-33940
CVE-2026-33941

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-10614
https://redhat.atlassian.net/browse/CRW-10615
https://redhat.atlassian.net/browse/CRW-10616
https://redhat.atlassian.net/browse/CRW-10617
https://redhat.atlassian.net/browse/CRW-10618
https://redhat.atlassian.net/browse/CRW-10619
https://redhat.atlassian.net/browse/CRW-10620
https://redhat.atlassian.net/browse/CRW-10621
https://redhat.atlassian.net/browse/CRW-10622
https://redhat.atlassian.net/browse/CRW-10623


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency pinning across application modules to ensure consistent library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->