### PR TITLE
fix: allow screen readers determine lang (crw-10251)

### DIFF
--- a/build/scripts/code-sshd-page/server.js
+++ b/build/scripts/code-sshd-page/server.js
@@ -46,7 +46,7 @@ const server = http.createServer((req, res) => {
 
     res.end(`
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>${process.env["DEVWORKSPACE_NAME"]}</title>
     <link rel="stylesheet" href="page-style.css">

--- a/build/scripts/jetbrains-sshd-page/server.js
+++ b/build/scripts/jetbrains-sshd-page/server.js
@@ -45,7 +45,7 @@ const server = http.createServer((req, res) => {
 
     res.end(`
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>${process.env["DEVWORKSPACE_NAME"]}</title>
     <link rel="stylesheet" href="page-style.css">


### PR DESCRIPTION
partially fixes https://redhat.atlassian.net/browse/CRW-10251

### What does this PR do?
Adds the lang property to the status page so that screen readers can determine the language in the page

### What issues does this PR fix?


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Declared the document language (lang="en") on site HTML root elements to improve accessibility, screen-reader behavior, and document structure across pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->