### PR TITLE
Fix CVEs by updating axios to patched versions

### DIFF
--- a/code/extensions/che-api/package-lock.json
+++ b/code/extensions/che-api/package-lock.json
@@ -12,7 +12,7 @@
         "@devfile/api": "^2.3.0-1738854228",
         "@eclipse-che/workspace-telemetry-client": "^0.0.1-1685523760",
         "@kubernetes/client-node": "^1.4.0",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "fs-extra": "^11.2.0",
         "inversify": "^6.0.2",
         "js-yaml": "^4.1.0",
@@ -554,14 +554,6 @@
       "dependencies": {
         "@eclipse-che/api": "^7.38.1",
         "axios": "^0.24.0"
-      }
-    },
-    "node_modules/@eclipse-che/workspace-telemetry-client/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1305,14 +1297,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
@@ -3933,9 +3925,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@devfile/api": "^2.3.0-1738854228",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "@kubernetes/client-node": "^1.4.0",
     "fs-extra": "^11.2.0",
     "inversify": "^6.0.2",
@@ -52,7 +52,8 @@
   },
   "overrides": {
     "minimatch": "^3.1.5",
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "axios": "^1.15.0"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-remote/package-lock.json
+++ b/code/extensions/che-remote/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@eclipse-che/che-devworkspace-generator": "7.113.0",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "https": "^1.0.0",
         "js-yaml": "^4.0.0",
         "vscode-nls": "^5.0.0"
@@ -1525,14 +1525,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
@@ -4391,9 +4391,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "vscode-nls": "^5.0.0",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "@eclipse-che/che-devworkspace-generator": "7.113.0",
     "https": "^1.0.0",
     "js-yaml": "^4.0.0"


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2025-62718](https://github.com/advisories/GHSA-3p68-rc4w-qgx5/dependabot) and  [CVE-2026-40175](https://github.com/advisories/GHSA-fvcv-3m26-pcqx/dependabot).

`axios` version is updated to `1.15.0`

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-10707
https://redhat.atlassian.net/browse/CRW-10709
https://redhat.atlassian.net/browse/CRW-10691
https://redhat.atlassian.net/browse/CRW-10693
https://redhat.atlassian.net/browse/CRW-10695

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated axios library to version 1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->