### PR TITLE
downgrading axios for che-api transitive to 0.31.0

### DIFF
--- a/code/extensions/che-api/package-lock.json
+++ b/code/extensions/che-api/package-lock.json
@@ -556,6 +556,39 @@
         "axios": "^0.24.0"
       }
     },
+    "node_modules/@eclipse-che/workspace-telemetry-client/node_modules/axios": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.31.0.tgz",
+      "integrity": "sha512-HGIUj/P74co3rSLBV9SHz9LMgCmrXFEtkfMcC5r6bS5j3dBHUcAje2tS4fmU6WM20kuhvUX04XE58594dpgi1g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@eclipse-che/workspace-telemetry-client/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@eclipse-che/workspace-telemetry-client/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -53,7 +53,10 @@
   "overrides": {
     "minimatch": "^3.1.5",
     "handlebars": "4.7.9",
-    "axios": "^1.15.0"
+    "@eclipse-che/workspace-telemetry-client": {
+      "axios": "^0.31.0"
+    }
+    
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What does this PR do?
addressed comments after #684 merge

### What issues does this PR fix?
[#684 comments](https://github.com/che-incubator/che-code/pull/684#discussion_r3092860135)


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm dependency version management to enforce specific compatibility requirements for internal packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->