### PR TITLE
fix: Add LD_LIBRARY_PATH for bundled Node in CLI scripts

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
+#### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/689
+
+- code/resources/server/bin/helpers/browser-linux.sh
+- code/resources/server/bin/remote-cli/code-linux.sh
+---
+
 #### @vitaliy-guliy
 https://github.com/che-incubator/che-code/commit/a26b43847e5afd707ebffbddef712893fb77a379
 

--- a/.rebase/replace/code/resources/server/bin/helpers/browser-linux.sh.json
+++ b/.rebase/replace/code/resources/server/bin/helpers/browser-linux.sh.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "CLI_SCRIPT=\"$ROOT/out/server-cli.js\"\n\"$ROOT/node\" \"$CLI_SCRIPT\" \"$APP_NAME\" \"$VERSION\" \"$COMMIT\" \"$EXEC_NAME\" \"--openExternal\" \"$@\"",
+    "by": "CLI_SCRIPT=\"$ROOT/out/server-cli.js\"\n\n# The following block was generated with AI assistance (Cursor AI)\n# and reviewed by the maintainers.\n#\n# Ensure the bundled node can find its shared libraries (e.g. libnode.so).\n# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid\n# library version conflicts with user containers; restore the paths needed\n# for the node binary scoped to this script only.\nif [ -d \"$ROOT/ld_libs/core\" ]; then\n  LD_LIBRARY_PATH=\"$ROOT/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n  if [ -d \"$ROOT/ld_libs/openssl\" ]; then\n    LD_LIBRARY_PATH=\"$ROOT/ld_libs/openssl:$LD_LIBRARY_PATH\"\n  fi\nelif [ -d \"$ROOT/ld_libs\" ]; then\n  LD_LIBRARY_PATH=\"$ROOT/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\nfi\nexport LD_LIBRARY_PATH\n\n\"$ROOT/node\" \"$CLI_SCRIPT\" \"$APP_NAME\" \"$VERSION\" \"$COMMIT\" \"$EXEC_NAME\" \"--openExternal\" \"$@\""
+  }
+]

--- a/.rebase/replace/code/resources/server/bin/remote-cli/code-linux.sh.json
+++ b/.rebase/replace/code/resources/server/bin/remote-cli/code-linux.sh.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "CLI_SCRIPT=\"$ROOT/out/server-cli.js\"\n\"$ROOT/node\" \"$CLI_SCRIPT\" \"$APP_NAME\" \"$VERSION\" \"$COMMIT\" \"$EXEC_NAME\" \"$@\"",
+    "by": "CLI_SCRIPT=\"$ROOT/out/server-cli.js\"\n\n# The following block was generated with AI assistance (Cursor AI)\n# and reviewed by the maintainers.\n#\n# Ensure the bundled node can find its shared libraries (e.g. libnode.so).\n# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid\n# library version conflicts with user containers; restore the paths needed\n# for the node binary scoped to this script only.\nif [ -d \"$ROOT/ld_libs/core\" ]; then\n  LD_LIBRARY_PATH=\"$ROOT/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n  if [ -d \"$ROOT/ld_libs/openssl\" ]; then\n    LD_LIBRARY_PATH=\"$ROOT/ld_libs/openssl:$LD_LIBRARY_PATH\"\n  fi\nelif [ -d \"$ROOT/ld_libs\" ]; then\n  LD_LIBRARY_PATH=\"$ROOT/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\nfi\nexport LD_LIBRARY_PATH\n\n\"$ROOT/node\" \"$CLI_SCRIPT\" \"$APP_NAME\" \"$VERSION\" \"$COMMIT\" \"$EXEC_NAME\" \"$@\""
+  }
+]

--- a/code/resources/server/bin/helpers/browser-linux.sh
+++ b/code/resources/server/bin/helpers/browser-linux.sh
@@ -9,4 +9,22 @@ VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
+
+# The following block was generated with AI assistance (Cursor AI)
+# and reviewed by the maintainers.
+#
+# Ensure the bundled node can find its shared libraries (e.g. libnode.so).
+# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid
+# library version conflicts with user containers; restore the paths needed
+# for the node binary scoped to this script only.
+if [ -d "$ROOT/ld_libs/core" ]; then
+  LD_LIBRARY_PATH="$ROOT/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  if [ -d "$ROOT/ld_libs/openssl" ]; then
+    LD_LIBRARY_PATH="$ROOT/ld_libs/openssl:$LD_LIBRARY_PATH"
+  fi
+elif [ -d "$ROOT/ld_libs" ]; then
+  LD_LIBRARY_PATH="$ROOT/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export LD_LIBRARY_PATH
+
 "$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$VERSION" "$COMMIT" "$EXEC_NAME" "--openExternal" "$@"

--- a/code/resources/server/bin/remote-cli/code-linux.sh
+++ b/code/resources/server/bin/remote-cli/code-linux.sh
@@ -9,4 +9,22 @@ VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
+
+# The following block was generated with AI assistance (Cursor AI)
+# and reviewed by the maintainers.
+#
+# Ensure the bundled node can find its shared libraries (e.g. libnode.so).
+# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid
+# library version conflicts with user containers; restore the paths needed
+# for the node binary scoped to this script only.
+if [ -d "$ROOT/ld_libs/core" ]; then
+  LD_LIBRARY_PATH="$ROOT/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  if [ -d "$ROOT/ld_libs/openssl" ]; then
+    LD_LIBRARY_PATH="$ROOT/ld_libs/openssl:$LD_LIBRARY_PATH"
+  fi
+elif [ -d "$ROOT/ld_libs" ]; then
+  LD_LIBRARY_PATH="$ROOT/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export LD_LIBRARY_PATH
+
 "$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"

--- a/rebase.sh
+++ b/rebase.sh
@@ -521,6 +521,10 @@ resolve_conflicts() {
       apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/build/gulpfile.reh.ts" ]]; then
       apply_changes "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/resources/server/bin/helpers/browser-linux.sh" ]]; then
+      apply_changes_multi_line "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/resources/server/bin/remote-cli/code-linux.sh" ]]; then
+      apply_changes_multi_line "$conflictingFile"
     else
       echo "$conflictingFile file cannot be automatically rebased. Aborting"
       exit 1


### PR DESCRIPTION
See https://github.com/che-incubator/che-code/pull/687

### What does this PR do?
Ensure the bundled node can find its shared libraries (e.g. libnode.so) when code-oss CLI is used.

- in che-code `LD_LIBRARY_PATH` may be sanitized in terminal sessions to avoid library version conflicts with user containers; 
- the changes restore the paths needed for the node binary scoped to this script only

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23811

### How to test this PR?
#### 1. code-oss use case
1. Start a workspace (see prepared samples below)
2. Open a terminal
3. `code-oss --version && code-oss --install-extension /projects/web-nodejs-sample/redhat.java-1.43.1.vsix`

Expected behavior:
- Version should be displayed
- `Language Support for Java(TM) by Red Hat` extension should be installed
 
<img width="1085" height="458" alt="image" src="https://github.com/user-attachments/assets/22fe08fb-8c83-4802-a42e-1dfa11f92664" />

#### 2. `browser-linux.sh` script use case
1. Start a workspace (see prepared samples below)
2. Open a terminal
3. `$BROWSER https://example.com`
4. the following command also should work for containers with python  
`python3 -c "import webbrowser; webbrowser.open('https://example.com')"`
 

Expected behavior:
- Proposal to open a website should be displayed
<img width="1085" height="592" alt="Screenshot 2026-04-17 at 13 06 16" src="https://github.com/user-attachments/assets/dc295a64-8867-4827-bab9-21596dc41314" />

#### Images for testing
I've tested the functionality for the following images:

| Image | CLI works | Link to start a workspace |
| :-------------: | :-------------: | :-------------: |
| |udi |  |
| quay.io/devfile/universal-developer-image:ubi8-latest | 🟢 | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=quay.io/devfile/universal-developer-image:ubi8-latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| quay.io/devfile/universal-developer-image:ubi9-latest |  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=quay.io/devfile/universal-developer-image:ubi9-latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| quay.io/devfile/universal-developer-image:ubi10-latest |  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=quay.io/devfile/universal-developer-image:ubi10-latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| |ubi-8 |  |
| registry.access.redhat.com/ubi8-minimal:latest| 🟢 | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi8-minimal:latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| registry.access.redhat.com/ubi8-minimal:8.10|  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi8-minimal:8.10&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| registry.access.redhat.com/ubi8-minimal:8.9|  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi8-minimal:8.9&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| |ubi-9 |  |
| registry.access.redhat.com/ubi9-minimal:latest| 🟢 | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi9-minimal:latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| registry.access.redhat.com/ubi9-minimal:9.7|  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi9-minimal:9.7&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| registry.access.redhat.com/ubi9-minimal:9.6|  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi9-minimal:9.6&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| |ubi-10 |  |
| registry.access.redhat.com/ubi10-minimal:latest| 🟢 | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi10-minimal:latest&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| registry.access.redhat.com/ubi10-minimal:10.1 |  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi10-minimal:10.1&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |
| registry.access.redhat.com/ubi10-minimal:10.0|  | [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=registry.access.redhat.com/ubi10-minimal:10.0&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-689-amd64) |

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved library resolution for bundled Node.js runtime on Linux systems.
  * Updated build configuration and conflict resolution logic for Linux shell scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->