### PR TITLE
chore: universal-developer-image already provides Google Cloud CLI

### DIFF
--- a/build/dockerfiles/dev.Dockerfile
+++ b/build/dockerfiles/dev.Dockerfile
@@ -18,29 +18,6 @@ RUN dnf -y install patch libsecret libX11-devel libxkbcommon \
     util-linux-user && \
     dnf -y clean all --enablerepo='*'
 
-# Pin gcloud CLI to a tested release from the official RHEL/CentOS repository.
-# See https://cloud.google.com/sdk/docs/release-notes for recent versions.
-ARG GCLOUD_CLI_VERSION=563.0.0
-RUN printf '%s\n' \
-    '[google-cloud-cli]' \
-    'name=Google Cloud CLI' \
-    'baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64' \
-    'enabled=1' \
-    'gpgcheck=1' \
-    'repo_gpgcheck=0' \
-    'gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg' \
-    > /etc/yum.repos.d/google-cloud-sdk.repo && \
-    dnf makecache --repo=google-cloud-cli && \
-    dnf list --showduplicates google-cloud-cli 2>/dev/null \
-        | grep -q "${GCLOUD_CLI_VERSION}" || \
-    { echo "ERROR: google-cloud-cli version ${GCLOUD_CLI_VERSION} not found in repo."; \
-      echo "Available versions (most recent last):"; \
-      dnf list --showduplicates google-cloud-cli 2>/dev/null | tail -10; \
-      exit 1; } && \
-    dnf -y install libxcrypt-compat google-cloud-cli-${GCLOUD_CLI_VERSION} && \
-    dnf -y clean all --enablerepo='*' && \
-    gcloud --version
-
 COPY --chmod=664 /build/conf/dev/.p10k.zsh /home/user/.p10k.zsh
 
 # zsh support


### PR DESCRIPTION
### What does this PR do?
No need to add Google Cloud CLI at dev image level, as universal-developer-image already provides it. 
See https://github.com/devfile/developer-images/pull/253

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Google Cloud CLI from the development Docker build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->