### PR TITLE
Use internal-sftp for the sftp subsytem of the SSHD service.

### DIFF
--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -94,6 +94,7 @@ sed -i \
 -e 's|#StrictModes yes|StrictModes=no|' \
 -e 's|#PidFile /var/run/sshd.pid|PidFile /tmp/sshd.pid|' \
 -e 's|#LogLevel INFO|LogLevel DEBUG1|' \
+-e 's|/usr/libexec/openssh/sftp-server|internal-sftp|' \
   /sshd/sshd_config
 
 # Provide new path containing host keys


### PR DESCRIPTION
- Fixes https://redhat.atlassian.net/browse/CRW-10763

1. Create a "Visual Studio Code Desktop (SSH)" workspace on the dogfooding cluster.
2. In a local VS Code instance, install [`redhat.devspaces-remote-ssh`](https://marketplace.visualstudio.com/items?itemName=redhat.devspaces-remote-ssh) & [`ms-vscode-remote.remote-ssh`](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)  from the VS Code Marketplace and then set `"remote.SSH.localServerDownload": "always"`
<img width="866" height="233" alt="Screenshot From 2026-04-24 00-39-46" src="https://github.com/user-attachments/assets/248613cb-9a40-47aa-9785-3a0e91530552" />

4. Attempt to connect to the developer workspace using the instructions on the landing page. Basically just use the URL of the form `https://${CLUSTER_URL}/${USER}/${DEVWORKSPACE_NAME}/3400/`.

After authenticating in the browser (popup) and hitting continue an extra (2nd) time (fallback to sftp), the "Remote - SSH" output logs will show :

```
...
...
[10:44:34.451] Detected fingerprint confirmation message
[10:44:34.452] Showing fingerprint confirmation dialog
[10:44:36.612] >  
[10:44:37.844] Got fingerprint response: yes
[10:44:37.846] "Copy server to host" wrote data to terminal: "yes"
[10:44:37.877] > yes
> Warning: Permanently added '[127.0.0.1]:5198' (ED25519) to the list of known hosts.
[10:44:38.299] > scp: Connection closed
[10:44:38.554] "Copy server to host" terminal command done
[10:44:39.666] >  
[10:44:42.615] >  
[10:44:45.707] >  
[10:44:48.620] >  
[10:44:51.623] >  
[10:44:54.623] >  
```

>**[10:44:38.299] > scp: Connection closed** 

So the connection was basically dropped.

This happens because the SSHD is configured to transfer files using an external sftp service (eg. `/usr/libexec/openssh/sftp-server` ). However that doesn't exist, and we can't install openssh-server as we don't control the developer container. Easy solution is to use SSHD's internal sftp implementation, `internal-sftp`.

Now try doing the same thing, but instead of "Visual Studio Code Desktop (SSH)", use [`quay.io/che-incubator-pull-requests/che-code:pr-693-amd64`](https://quay.io/che-incubator-pull-requests/che-code:pr-693-amd64). It should succeed. You will see the actual download progressing in the "Remote -SSH" output view.

**Note:** Because the default setting for `remote.SSH.localServerDownload` is `auto`, which falls back to "scp-ing" the downloaded server to the remote (after downloading directly on the remote fails), there isn't any need to really change the setting except for a faster connection and less errors in the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * SSH daemon configuration updated to switch the SFTP subsystem to the built-in internal SFTP implementation, changing which SFTP server is invoked at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->