### PR TITLE
Fix CVE-2026-40895 by updating follow-redirects to patched version

### DIFF
--- a/code/extensions/che-api/package-lock.json
+++ b/code/extensions/che-api/package-lock.json
@@ -2194,9 +2194,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -54,8 +54,8 @@
     "handlebars": "4.7.9",
     "@eclipse-che/workspace-telemetry-client": {
       "axios": "^0.31.0"
-    }
-    
+    },
+    "follow-redirects": "^1.16.0"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-remote/package-lock.json
+++ b/code/extensions/che-remote/package-lock.json
@@ -2524,9 +2524,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -60,7 +60,8 @@
     "lodash": "^4.17.23",
     "ajv": "6.14.0",
     "minimatch": "^3.1.5",
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "follow-redirects": "^1.16.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2026-40895](https://github.com/follow-redirects/follow-redirects/security/advisories/GHSA-r4q5-vmmm-2653).
`follow-redirects` version is updated to `1.16.0`

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-10774


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions across extension packages to ensure compatibility and maintain system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->