### PR TITLE
Improve support when running under FIPS mode.

### DIFF
--- a/build/scripts/code-sshd-page/server.js
+++ b/build/scripts/code-sshd-page/server.js
@@ -37,7 +37,7 @@ const server = http.createServer((req, res) => {
 
     let genKey = "PRIVATE KEY NOT FOUND";
     try {
-      genKey = fs.readFileSync(`/sshd/ssh_client_ed25519_key`, 'utf8');
+      genKey = fs.readFileSync(`/sshd/ssh_client_key`, 'utf8');
     } catch (err) {
      // continue
     }
@@ -113,7 +113,7 @@ const server = http.createServer((req, res) => {
   HostName 127.0.0.1
   User ${username}
   Port 2022
-  IdentityFile "$\{HOME\}/.ssh/ssh_client_ed25519_key"
+  IdentityFile "$\{HOME\}/.ssh/ssh_client_key"
   UserKnownHostsFile /dev/null</pre>
         </div>
         <div class="clipboard">
@@ -126,7 +126,7 @@ const server = http.createServer((req, res) => {
         </div>
         </div>
         <p>
-        Where <code class="path">$\{HOME\}/.ssh/ssh_client_ed25519_key</code> should be replaced by the absolute path to the private key file on your local system.
+        Where <code class="path">$\{HOME\}/.ssh/ssh_client_key</code> should be replaced by the absolute path to the private key file on your local system.
         </p>
         </li>
       </ol>

--- a/build/scripts/code-sshd-page/server.js
+++ b/build/scripts/code-sshd-page/server.js
@@ -114,7 +114,8 @@ const server = http.createServer((req, res) => {
   User ${username}
   Port 2022
   IdentityFile "$\{HOME\}/.ssh/ssh_client_key"
-  UserKnownHostsFile /dev/null</pre>
+  UserKnownHostsFile /dev/null
+  StrictHostKeyChecking no</pre>
         </div>
         <div class="clipboard">
           <a href="#">

--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -79,11 +79,10 @@ fi
 mkdir /var/tmp/ssh
 chmod 755 /var/tmp/ssh
 
-# Generate SSH Host keys
-$sshd_libdir/ssh-keygen -q -N "" -t dsa -f /var/tmp/ssh/ssh_host_dsa_key && \
-$sshd_libdir/ssh-keygen -q -N "" -t rsa -b 4096 -f /var/tmp/ssh/ssh_host_rsa_key && \
-$sshd_libdir/ssh-keygen -q -N "" -t ecdsa -f /var/tmp/ssh/ssh_host_ecdsa_key && \
-$sshd_libdir/ssh-keygen -q -N "" -t ed25519 -f /var/tmp/ssh/ssh_host_ed25519_key
+echo 'Generating SSH host keys ..'
+$sshd_libdir/ssh-keygen -q -N "" -t rsa -b 4096 -f /var/tmp/ssh/ssh_host_rsa_key || true
+$sshd_libdir/ssh-keygen -q -N "" -t ecdsa -f /var/tmp/ssh/ssh_host_ecdsa_key || true
+$sshd_libdir/ssh-keygen -q -N "" -t ed25519 -f /var/tmp/ssh/ssh_host_ed25519_key || true
 
 # Ensure appropriate permissions
 chmod 600 /var/tmp/ssh/ssh_host_* /sshd/sshd_config
@@ -107,10 +106,12 @@ sed -i \
 # Use keys that have been configured, and generate them otherwise
 mkdir -p $HOME/.ssh
 if [ -f /etc/ssh/dwo_ssh_key.pub ]; then
+  echo 'Using pre-configured SSH client key.'
   cp /etc/ssh/dwo_ssh_key.pub $HOME/.ssh/authorized_keys
 else
-  $sshd_libdir/ssh-keygen -q -N '' -t ed25519 -f /sshd/ssh_client_ed25519_key
-  cp /sshd/ssh_client_ed25519_key.pub $HOME/.ssh/authorized_keys
+  echo 'Generating SSH client key..'
+  $sshd_libdir/ssh-keygen -q -N '' -t ecdsa -f /sshd/ssh_client_key
+  cp /sshd/ssh_client_key.pub $HOME/.ssh/authorized_keys
 fi
 
 cp /sshd/sshd_config /var/tmp/ssh/


### PR DESCRIPTION
When operating under FIPS mode, ssh-keygen can fail with :
```
$ ssh-keygen -q -N "" -t dsa -f /var/tmp/ssh/ssh_host_dsa_key
DSA Keys are not allowed in FIPS mode
```

The purpose of generating multiple host keys with `ssh-keygen` , is to ensure we support some method of verification that is acceptable to the client.  However some of these may fail to generate either now or in the future. We should still continue as other keys may succeed, and can do this by disabling failure on non-zero exit code in that block.

- Multiple host keys are generated to support as many clients
- Under FIPS mode, certain key algorithms/lengths may fail to be generated with ssh-keygen
- Allow the sshd.start script to continue despite the failures
- Remove DSA key generation as it is not included in SSHD HostKey config

The corresponding change in `devspaces-remote-ssh` that will support this : https://github.com/redhat-developer/devspaces-remote-ssh/commit/2e89e8d0162b5c246feabfe6724293fc4a654e24 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit status messages for SSH host-key and client-key setup.
  * Clarifies when a pre-configured client key is used versus when a new key is generated.
  * Generated client key handling changed and the resulting public key is now installed; user-facing examples and instructions updated.

* **Bug Fixes**
  * Host-key generation now proceeds with per-key error tolerance to avoid premature failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->