### PR TITLE
CRW-10865: fix es5-ext library quarantine by virus scanners

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
+#### @sbouchet
+https://github.com/che-incubator/che-code/pull/698
+
+- code/package.json
+---
+
 #### @RomanNikitenko
 https://github.com/che-incubator/che-code/pull/689
 

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -62,6 +62,7 @@
             "glob": {
                 "minimatch": "^5.1.9"
             }
-        }
+        },
+        "es5-ext": "npm:@unes/es5-ext@0.10.64-1"
     }
 }

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -5669,6 +5669,23 @@
         "type": "^1.0.1"
       }
     },
+    "node_modules/d/node_modules/es5-ext": {
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/debounce": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.1.0.tgz",
@@ -6539,22 +6556,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.63",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.63.tgz",
-      "integrity": "sha512-hUCZd2Byj/mNKjfP9jXrdVZ62B8KuA/VoK7X8nUh5qT+AxDmcbvZz041oDVZdbIN1qW6XY9VDNwzkvKnZvK2TQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "esniff": "^2.0.1",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -6571,6 +6572,23 @@
         "d": "1",
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-iterator/node_modules/es5-ext": {
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/es6-symbol": {
@@ -6593,6 +6611,23 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-weak-map/node_modules/es5-ext": {
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/escalade": {
@@ -6806,6 +6841,23 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/esniff/node_modules/es5-ext": {
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/esniff/node_modules/type": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
@@ -6893,6 +6945,23 @@
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/event-emitter/node_modules/es5-ext": {
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/event-stream": {
@@ -11074,6 +11143,23 @@
         "es5-ext": "~0.10.2"
       }
     },
+    "node_modules/lru-queue/node_modules/es5-ext": {
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -11233,6 +11319,23 @@
         "lru-queue": "^0.1.0",
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
+      }
+    },
+    "node_modules/memoizee/node_modules/es5-ext": {
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/memory-fs": {
@@ -15170,6 +15273,23 @@
       "dependencies": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
+      }
+    },
+    "node_modules/timers-ext/node_modules/es5-ext": {
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/tiny-inflate": {

--- a/code/package.json
+++ b/code/package.json
@@ -286,7 +286,8 @@
       "glob": {
         "minimatch": "^5.1.9"
       }
-    }
+    },
+    "es5-ext": "npm:@unes/es5-ext@0.10.64-1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What does this PR do?
aliases es5-ext package to a fork that does not provide postinstall script.

https://github.com/medikoo/es5-ext/issues/186

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-10865


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
