### PR TITLE
Open URI to be handled by Code-based editor.

### DIFF
--- a/build/scripts/code-sshd-page/page-style.css
+++ b/build/scripts/code-sshd-page/page-style.css
@@ -16,6 +16,9 @@ pre {
   display: table-cell;
   width: 98%;
   padding: 10px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-all;
 }
 
 /* Inline code */

--- a/build/scripts/code-sshd-page/page-utils.js
+++ b/build/scripts/code-sshd-page/page-utils.js
@@ -9,7 +9,7 @@
 
 function copyToClipboard(id) {
   var copyText = document.getElementById(id);
-  navigator.clipboard.writeText(copyText.innerHTML);
+  navigator.clipboard.writeText(copyText.innerText);
 }
 
 function initializePlatformContent() {
@@ -36,4 +36,9 @@ function syncDocsContent() {
   var extensionElem = document.getElementById("docs-extension");
   var manualElem = document.getElementById("docs-manual");
   docsElem.innerHTML = useExtension ? extensionElem.innerHTML : manualElem.innerHTML;
+}
+
+function openDevspacesURI(namespace, podName, userName, dwName, encodedKeyMessage, encodedUrl) {
+  const gatewayLink = `vscode://redhat.devspaces-remote-ssh?namespace=${namespace}&podName=${podName}&userName=${userName}&dwName=${dwName}&key=${encodedKeyMessage}&url=${encodedUrl}`;
+  window.open(gatewayLink, "_self");
 }

--- a/build/scripts/code-sshd-page/server.js
+++ b/build/scripts/code-sshd-page/server.js
@@ -16,7 +16,7 @@ const port = 3400;
 
 let username = "UNKNOWN";
 try {
-  username = fs.readFileSync(`/sshd/username`, 'utf8');
+  username = fs.readFileSync('/sshd/username', 'utf8');
 } catch (error) {
   // continue
 }
@@ -28,21 +28,30 @@ const server = http.createServer((req, res) => {
 
     let hasUserPrefSSHKey = fs.existsSync('/etc/ssh/dwo_ssh_key.pub');
 
-    let pubKey = "PUBLIC KEY COULD NOT BE DISPLAYED";
+    let userPubKey = "PUBLIC KEY COULD NOT BE DISPLAYED";
     try {
-      pubKey = fs.readFileSync('/etc/ssh/dwo_ssh_key.pub', 'utf8');
+      userPubKey = fs.readFileSync('/etc/ssh/dwo_ssh_key.pub', 'utf8');
+    } catch (err) {
+     // continue
+    }
+
+    let userKey = '';
+    try {
+      userKey = fs.readFileSync('/etc/ssh/dwo_ssh_key', 'utf8');
     } catch (err) {
      // continue
     }
 
     let genKey = "PRIVATE KEY NOT FOUND";
     try {
-      genKey = fs.readFileSync(`/sshd/ssh_client_key`, 'utf8');
+      genKey = fs.readFileSync('/sshd/ssh_client_key', 'utf8');
     } catch (err) {
      // continue
     }
 
-    let keyMessage = hasUserPrefSSHKey ? pubKey : genKey;
+    let keyMessage = hasUserPrefSSHKey ? userPubKey : genKey;
+    let encodedKeyMessage = Buffer.from(hasUserPrefSSHKey ? userKey : genKey).toString('base64url');
+    let encodedUrl = encodeURIComponent(process.env["CHE_DASHBOARD_URL"]);
 
     res.end(`
 <!DOCTYPE html>
@@ -75,10 +84,22 @@ const server = http.createServer((req, res) => {
             <li class="extension-li"><code>Remote - SSH</code> from the <a href="https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh">VS Code Marketplace</a> <b>OR</b> <code>Open Remote - SSH</code> from the <a href="https://open-vsx.org/extension/jeanp413/open-remote-ssh">OpenVSX Registry</a></li>
           </ul>
         </li>
-        <li class="extension-li">From the "Remote Explorer" view, select the <code>Connect to Dev Spaces</code> command and input the URL of this page.</li>
-          <ul>
-            <li class="extension-li">It should be of the form : <code>https://$\{CLUSTER_URL\}/$\{USER\}/$\{DEVWORKSPACE_NAME\}/3400/</code></li>
-          </ul>
+        <li class="extension-li">Click the URI below (you may need to accept the prompt allowing this page to open the link with your VS Code-based editor) <b>OR</b> from the "Remote Explorer" view, select the <code>Connect to Dev Spaces</code> command and input the URI below.</li>
+        <div class="parent">
+          <div>
+            <a href="vscode://redhat.devspaces-remote-ssh?namespace=${process.env["DEVWORKSPACE_NAMESPACE"]}&podName=${process.env["HOSTNAME"]}&userName=${username}&dwName=${process.env["DEVWORKSPACE_NAME"]}&key=${encodedKeyMessage}&url=${encodedUrl}">
+              <pre id="uri-connection">vscode://redhat.devspaces-remote-ssh?namespace=${process.env["DEVWORKSPACE_NAMESPACE"]}&podName=${process.env["HOSTNAME"]}&userName=${username}&dwName=${process.env["DEVWORKSPACE_NAME"]}&key=${encodedKeyMessage}&url=${encodedUrl}</pre>
+            </a>
+          </div>
+          <div class="clipboard">
+            <a href="#">
+            <svg class="clipboard-img-pre" onclick="copyToClipboard('uri-connection')" title="Copy" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 20 20">
+              <path fill="currentColor" d="M12 0H2C.9 0 0 .9 0 2v10h1V2c0-.6.4-1 1-1h10V0z"></path>
+              <path fill="currentColor" d="M18 20H8c-1.1 0-2-.9-2-2V8c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2zM8 7c-.6 0-1 .4-1 1v10c0 .6.4 1 1 1h10c.6 0 1-.4 1-1V8c0-.6-.4-1-1-1H8z"></path>
+            </svg>
+            </a>
+          </div>
+        </div>
       </ol>
     </div>
     <div id="docs-manual" hidden>
@@ -136,7 +157,10 @@ const server = http.createServer((req, res) => {
       <p>If the connection fails for an unknown reason, consider disabling the setting <code>remote.SSH.useExecServer</code> (set to false)</p>
       <p>For any other issues, relating to the use of a VS Code-based editor and the "Remote - SSH", the "Remote - SSH" logs from the "Output" view are very helpful in diagnosing the issue.</p>
     </div>
-    <script>initializePlatformContent();</script>
+    <script>
+      initializePlatformContent();
+      openDevspacesURI("${process.env["DEVWORKSPACE_NAMESPACE"]}", "${process.env["HOSTNAME"]}", "${username}", "${process.env["DEVWORKSPACE_NAME"]}", "${encodedKeyMessage}", "${encodedUrl}");
+    </script>
   </body>
 </html>
     `);


### PR DESCRIPTION
- Automatically open a vscode://redhat.devspaces-remote-ssh URI that
  will be handled by an active Code based editor with
  redhat.devspaces-remote-ssh extension installed
- Replace the usage of the page URL with the vscode-based URI
- Use innerText instead of innerHTML for clipboard copying in pre tags
- pre tags should automatically wrap text

<img width="981" height="500" alt="image" src="https://github.com/user-attachments/assets/a113e1bd-6400-45a0-a56d-e3b7943b8d87" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved code block wrapping for better readability.

* **Bug Fixes**
  * Fixed clipboard copy to copy plain text instead of rendered markup.

* **New Features**
  * Added click-to-connect and copyable VS Code remote-SSH URI support, including automatic connect behavior for DevWorkspace sessions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/che-incubator/che-code/pull/704)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->