### PR TITLE
Update nodejs-20-minimal to nodejs-22-minimal in che-code-sshd.

### DIFF
--- a/build/dockerfiles/assembly.sshd.Dockerfile
+++ b/build/dockerfiles/assembly.sshd.Dockerfile
@@ -16,7 +16,7 @@ RUN microdnf -y install libsecret openssh-server nss_wrapper-libs \
     microdnf -y clean all --enablerepo='*'
 
 # UBI 9/10
-FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:9.7
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.7
 
 USER 0
 


### PR DESCRIPTION
[Node.js 20 is EOL](https://nodejs.org/en/about/eol#eol-versions)

CC'ing @azatsarynnyy 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version from 20 to 22 in the build environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/che-incubator/che-code/pull/707)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->