### PR TITLE
Fix CVE-2026-33228 by updating flatted to patched version

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,7 +3,7 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
-https://github.com/che-incubator/che-code/commit/e148ccad43841a4610ca572f9b69b13bf7b2442e
+https://github.com/che-incubator/che-code/pull/708
 
 - code/package.json
 ---

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,12 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
+https://github.com/che-incubator/che-code/commit/e148ccad43841a4610ca572f9b69b13bf7b2442e
+
+- code/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/698
 
 - code/package.json

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -63,6 +63,7 @@
                 "minimatch": "^5.1.9"
             }
         },
-        "es5-ext": "npm:@unes/es5-ext@0.10.64-1"
+        "es5-ext": "npm:@unes/es5-ext@0.10.64-1",
+        "flatted": "^3.4.2"
     }
 }

--- a/code/extensions/che-remote/package-lock.json
+++ b/code/extensions/che-remote/package-lock.json
@@ -2518,10 +2518,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -61,7 +61,8 @@
     "ajv": "6.14.0",
     "minimatch": "^3.1.5",
     "handlebars": "4.7.9",
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "flatted": "^3.4.2"
   },
   "repository": {
     "type": "git",

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -7388,10 +7388,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",

--- a/code/package.json
+++ b/code/package.json
@@ -287,7 +287,8 @@
         "minimatch": "^5.1.9"
       }
     },
-    "es5-ext": "npm:@unes/es5-ext@0.10.64-1"
+    "es5-ext": "npm:@unes/es5-ext@0.10.64-1",
+    "flatted": "^3.4.2"
   },
   "repository": {
     "type": "git",

--- a/launcher/package-lock.json
+++ b/launcher/package-lock.json
@@ -2754,10 +2754,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/form-data": {
       "version": "4.0.5",

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -53,7 +53,8 @@
     },
     "ajv": "6.14.0",
     "minimatch": "^3.1.5",
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "flatted": "^3.4.2"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
### What does this PR do?
Add `flatted` `^3.4.2` override in code/package.json to fix prototype pollution vulnerability via parse(). Update rebase add rule accordingly.


### What issues does this PR fix?
this PR fixes [CVE-2026-33228](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh)

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version overrides across multiple modules to enhance stability and maintain consistency throughout the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/che-incubator/che-code/pull/708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->