### PR TITLE
Fix: Replace axios with fetch + https fallback in che-api/github-service

### DIFF
--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -10,6 +10,7 @@
 
 /* eslint-disable header/header */
 
+import * as https from 'https';
 import * as k8s from '@kubernetes/client-node';
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
@@ -67,6 +68,28 @@ export class GithubServiceImpl implements GithubService {
   }
 
   private async fetchGithubUser(token: string): Promise<{ user: GithubUser; scopes: string[] }> {
+    try {
+      this.logger.info('Github Service: fetching GitHub user using fetch...');
+      const result = await this.fetchGithubUserWithFetch(token);
+      this.logger.info('Github Service: successfully fetched GitHub user using fetch');
+      
+      return result;
+    } catch (fetchError: any) {
+      this.logger.warn(`Github Service: fetch failed: ${fetchError.message}${fetchError.cause ? ` (cause: ${fetchError.cause.message})` : ''}`);
+      try {
+        this.logger.info('Github Service: falling back to https module...');
+        const result = await this.fetchGithubUserWithHttps(token);
+        this.logger.info('Github Service: successfully fetched GitHub user using https fallback');
+        
+        return result;
+      } catch (httpsError: any) {
+        this.logger.error(`Github Service: https fallback also failed: ${httpsError.message}`);
+        throw httpsError;
+      }
+    }
+  }
+
+  private async fetchGithubUserWithFetch(token: string): Promise<{ user: GithubUser; scopes: string[] }> {
     const response = await fetch('https://api.github.com/user', {
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -81,6 +104,44 @@ export class GithubServiceImpl implements GithubService {
       .map(scope => scope.trim())
       .filter(scope => scope.length > 0);
     return { user, scopes };
+  }
+
+  private fetchGithubUserWithHttps(token: string): Promise<{ user: GithubUser; scopes: string[] }> {
+    return new Promise((resolve, reject) => {
+      const req = https.request('https://api.github.com/user', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'User-Agent': 'che-code',
+          'Accept': 'application/json',
+        },
+      }, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString();
+          if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`GitHub user request failed: ${res.statusCode} ${res.statusMessage} - ${body}`));
+            return;
+          }
+          try {
+            const user = JSON.parse(body) as GithubUser;
+            const scopesHeader = res.headers['x-oauth-scopes'] ?? '';
+            const scopes = (Array.isArray(scopesHeader) ? scopesHeader[0] : scopesHeader)
+              .split(', ')
+              .map(scope => scope.trim())
+              .filter(scope => scope.length > 0);
+            resolve({ user, scopes });
+          } catch (err) {
+            reject(err);
+          }
+        });
+        res.on('error', reject);
+      });
+      req.setTimeout(60 * 1000);
+      req.on('error', reject);
+      req.end();
+    });
   }
 
   async persistDeviceAuthToken(token: string): Promise<void> {


### PR DESCRIPTION


### What does this PR do?
- Axios does not properly handle HTTPS requests through HTTP proxies that require CONNECT tunneling (e.g., ZScaler). This causes GitHub API calls to fail with hostname mismatch errors in corporate proxy environments.
- Replace axios with a fetch-first approach with an https module fallback, matching the pattern used by the upstream github-authentication extension. 
- The https fallback handles environments where custom CA certificates (NODE_EXTRA_CA_CERTS) are not picked up by fetch/undici.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23848

### How to test this PR?
I tested it locally on my machine:
- using `mitmproxy`: `mitmdump --listen-port 8080`
- run editor container:
```
podman run --rm -it -p 3100:3100 \
  -e CODE_HOST=0.0.0.0 \
  -e HTTPS_PROXY=http://host.containers.internal:8080 \
  -e HTTP_PROXY=http://host.containers.internal:8080 \
  -e NODE_EXTRA_CA_CERTS=/public-certs/mitmproxy-ca.crt \
  -v ~/.mitmproxy/mitmproxy-ca-cert.pem:/public-certs/mitmproxy-ca.crt:ro \
  quay.io/che-incubator/che-code:next
``` 
- additional command on the VS Code side to trigger the corresponding che-api request (it requires changes to VS Code core + rebuilding image)

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Assisted-by: Cursor AI