### PR TITLE
fix: Replace axios with fetch + https fallback in che-api/github-service

### DIFF
--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -10,6 +10,7 @@
 
 /* eslint-disable header/header */
 
+import * as https from 'https';
 import * as k8s from '@kubernetes/client-node';
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
@@ -67,6 +68,28 @@ export class GithubServiceImpl implements GithubService {
   }
 
   private async fetchGithubUser(token: string): Promise<{ user: GithubUser; scopes: string[] }> {
+    try {
+      this.logger.info('Github Service: fetching GitHub user using fetch...');
+      const result = await this.fetchGithubUserWithFetch(token);
+      this.logger.info('Github Service: successfully fetched GitHub user using fetch');
+      
+      return result;
+    } catch (fetchError: any) {
+      this.logger.warn(`Github Service: fetch failed: ${fetchError.message}${fetchError.cause ? ` (cause: ${fetchError.cause.message})` : ''}`);
+      try {
+        this.logger.info('Github Service: falling back to https module...');
+        const result = await this.fetchGithubUserWithHttps(token);
+        this.logger.info('Github Service: successfully fetched GitHub user using https fallback');
+        
+        return result;
+      } catch (httpsError: any) {
+        this.logger.error(`Github Service: https fallback also failed: ${httpsError.message}`);
+        throw httpsError;
+      }
+    }
+  }
+
+  private async fetchGithubUserWithFetch(token: string): Promise<{ user: GithubUser; scopes: string[] }> {
     const response = await fetch('https://api.github.com/user', {
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -81,6 +104,44 @@ export class GithubServiceImpl implements GithubService {
       .map(scope => scope.trim())
       .filter(scope => scope.length > 0);
     return { user, scopes };
+  }
+
+  private fetchGithubUserWithHttps(token: string): Promise<{ user: GithubUser; scopes: string[] }> {
+    return new Promise((resolve, reject) => {
+      const req = https.request('https://api.github.com/user', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'User-Agent': 'che-code',
+          'Accept': 'application/json',
+        },
+      }, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString();
+          if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`GitHub user request failed: ${res.statusCode} ${res.statusMessage} - ${body}`));
+            return;
+          }
+          try {
+            const user = JSON.parse(body) as GithubUser;
+            const scopesHeader = res.headers['x-oauth-scopes'] ?? '';
+            const scopes = (Array.isArray(scopesHeader) ? scopesHeader[0] : scopesHeader)
+              .split(', ')
+              .map(scope => scope.trim())
+              .filter(scope => scope.length > 0);
+            resolve({ user, scopes });
+          } catch (err) {
+            reject(err);
+          }
+        });
+        res.on('error', reject);
+      });
+      req.setTimeout(60 * 1000);
+      req.on('error', reject);
+      req.end();
+    });
   }
 
   async persistDeviceAuthToken(token: string): Promise<void> {

--- a/code/extensions/che-api/src/impl/github-service-impl.ts
+++ b/code/extensions/che-api/src/impl/github-service-impl.ts
@@ -75,6 +75,10 @@ export class GithubServiceImpl implements GithubService {
       
       return result;
     } catch (fetchError: any) {
+      if (fetchError.httpStatus) {
+        this.logger.warn(`Github Service: fetch failed with HTTP ${fetchError.httpStatus}: ${fetchError.message}`);
+        throw fetchError;
+      }
       this.logger.warn(`Github Service: fetch failed: ${fetchError.message}${fetchError.cause ? ` (cause: ${fetchError.cause.message})` : ''}`);
       try {
         this.logger.info('Github Service: falling back to https module...');
@@ -92,10 +96,13 @@ export class GithubServiceImpl implements GithubService {
   private async fetchGithubUserWithFetch(token: string): Promise<{ user: GithubUser; scopes: string[] }> {
     const response = await fetch('https://api.github.com/user', {
       headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(60_000),
     });
     if (!response.ok) {
       const message = await response.text();
-      throw new Error(`GitHub user request failed: ${response.status} ${response.statusText} - ${message}`);
+      const err: any = new Error(`GitHub user request failed: ${response.status} ${response.statusText} - ${message}`);
+      err.httpStatus = response.status;
+      throw err;
     }
     const user = await response.json() as GithubUser;
     const scopesHeader = response.headers.get('x-oauth-scopes') ?? '';
@@ -138,7 +145,9 @@ export class GithubServiceImpl implements GithubService {
         });
         res.on('error', reject);
       });
-      req.setTimeout(60 * 1000);
+      req.setTimeout(60_000, () => {
+        req.destroy(new Error('GitHub user request timed out after 60000ms'));
+      });
       req.on('error', reject);
       req.end();
     });


### PR DESCRIPTION
### What does this PR do?
See https://github.com/che-incubator/che-code/pull/709

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://github.com/eclipse-che/che/issues/23848

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Assisted-by: Cursor AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable GitHub user retrieval with an HTTPS fallback to reduce lookup failures
  * Improved error handling and timeout protection to avoid long hangs and surface clearer errors
  * Consistent parsing and normalization of GitHub authorization scopes for more predictable behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/che-incubator/che-code/pull/710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->