### PR TITLE
Fix CVE-2024-37890 by updating ws to patched version

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,13 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
+https://github.com/che-incubator/che-code/pull/
+
+- code/package.json
+- code/remote/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/698
 
 - code/package.json

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,7 +3,7 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
-https://github.com/che-incubator/che-code/pull/
+https://github.com/che-incubator/che-code/pull/711
 
 - code/package.json
 - code/remote/package.json

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -1,10 +1,10 @@
 {
     "dependencies": {
-        "ws": "8.2.3",
+        "ws": "8.17.1",
         "js-yaml": "^4.1.0"
     },
     "devDependencies": {
-        "@types/ws": "8.2.0",
+        "@types/ws": "8.5.14",
         "@types/js-yaml": "^4.0.5",
         "@types/minimatch": "^3.0.5"
     },

--- a/.rebase/add/code/remote/package.json
+++ b/.rebase/add/code/remote/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "ws": "8.2.3",
+        "ws": "8.17.1",
         "js-yaml": "^4.1.0",
         "@kubernetes/client-node": "^1.4.0"
     },

--- a/code/extensions/che-terminal/package-lock.json
+++ b/code/extensions/che-terminal/package-lock.json
@@ -12,12 +12,12 @@
         "fs-extra": "^11.2.0",
         "js-yaml": "^4.1.0",
         "vscode-nls": "^5.2.0",
-        "ws": "8.2.3"
+        "ws": "8.17.1"
       },
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",
         "@types/js-yaml": "^4.0.5",
-        "@types/ws": "8.2.0"
+        "@types/ws": "8.5.14"
       },
       "engines": {
         "vscode": "^1.72.0"
@@ -48,10 +48,11 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
-      "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+      "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -121,15 +122,16 @@
       "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/code/extensions/che-terminal/package.json
+++ b/code/extensions/che-terminal/package.json
@@ -42,12 +42,12 @@
     "fs-extra": "^11.2.0",
     "js-yaml": "^4.1.0",
     "vscode-nls": "^5.2.0",
-    "ws": "8.2.3"
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/js-yaml": "^4.0.5",
-    "@types/ws": "8.2.0"
+    "@types/ws": "8.5.14"
   },
   "repository": {
     "type": "git",

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -55,7 +55,7 @@
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
-        "ws": "8.2.3",
+        "ws": "8.17.1",
         "yauzl": "^3.0.0",
         "yazl": "^2.4.3"
       },
@@ -84,7 +84,7 @@
         "@types/wicg-file-system-access": "^2023.10.7",
         "@types/windows-foreground-love": "^0.3.0",
         "@types/winreg": "^1.2.30",
-        "@types/ws": "8.2.0",
+        "@types/ws": "8.5.14",
         "@types/yauzl": "^2.10.0",
         "@types/yazl": "^2.4.2",
         "@typescript-eslint/utils": "^8.45.0",
@@ -2152,9 +2152,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
-      "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+      "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16631,16 +16631,16 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/code/package.json
+++ b/code/package.json
@@ -118,7 +118,7 @@
     "vscode-textmate": "^9.3.0",
     "yauzl": "^3.0.0",
     "yazl": "^2.4.3",
-    "ws": "8.2.3",
+    "ws": "8.17.1",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
@@ -224,7 +224,7 @@
     "webpack-stream": "^7.0.0",
     "xml2js": "^0.5.0",
     "yaserver": "^0.4.0",
-    "@types/ws": "8.2.0",
+    "@types/ws": "8.5.14",
     "@types/js-yaml": "^4.0.5",
     "zx": "^8.8.5"
   },

--- a/code/remote/package-lock.json
+++ b/code/remote/package-lock.json
@@ -45,7 +45,7 @@
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
-        "ws": "8.2.3",
+        "ws": "8.17.1",
         "yauzl": "^3.0.0",
         "yazl": "^2.4.3"
       }
@@ -1857,16 +1857,16 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/code/remote/package.json
+++ b/code/remote/package.json
@@ -41,7 +41,7 @@
     "vscode-textmate": "^9.3.0",
     "yauzl": "^3.0.0",
     "yazl": "^2.4.3",
-    "ws": "8.2.3",
+    "ws": "8.17.1",
     "js-yaml": "^4.1.0"
   },
   "overrides": {

--- a/rebase.sh
+++ b/rebase.sh
@@ -131,21 +131,6 @@ apply_code_package_changes() {
   git add code/package.json > /dev/null 2>&1
 }
 
-# Apply changes on code/remote/package.json file
-apply_code_remote_package_changes() {
-  
-  echo "  ⚙️ reworking code/remote/package.json..."
-  
-  # reset the file from what is upstream
-  git checkout --theirs code/remote/package.json > /dev/null 2>&1
-  
-  # now apply again the changes
-  override_json_file code/remote/package.json
-  
-  # resolve the change
-  git add code/remote/package.json > /dev/null 2>&1
-}
-
 # Apply changes on $1 package.json file
 # A path to the file should be passed, for example: code/build/package.json 
 apply_package_changes_by_path() {
@@ -417,6 +402,8 @@ resolve_conflicts() {
     echo " ➡️  Analyzing conflict for $conflictingFile"
     if [[ "$conflictingFile" == "code/package.json" ]]; then
       apply_code_package_changes
+    elif [[ "$conflictingFile" == "code/remote/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/build/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/build/npm/gyp/package.json" ]]; then


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2024-37890](https://github.com/advisories/GHSA-3h5v-q93c-6h6q/dependabot).
`ws` version is updated to `8.17.1`
`@types/ws` updated to latest available version

### What issues does this PR fix?
https://github.com/che-incubator/che-code/security/dependabot/34
https://github.com/che-incubator/che-code/security/dependabot/48
https://github.com/che-incubator/che-code/security/dependabot/69

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new top changelog entry referencing the recent PR.

* **Chores**
  * Upgraded WebSocket dependency across packages from 8.2.3 to 8.17.1.
  * Updated corresponding TypeScript type definitions from 8.2.0 to 8.5.14.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/che-incubator/che-code/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->