### PR TITLE
Update documentation link for Toolbox

### DIFF
--- a/build/scripts/jetbrains-sshd-page/server.js
+++ b/build/scripts/jetbrains-sshd-page/server.js
@@ -78,7 +78,7 @@ const server = http.createServer((req, res) => {
     </div>
 
     <h4 class="center">Can't open the workspace?</h4>
-    <p class="center">If your browser doesn't ask you to open Toolbox, make sure the prerequisites mentioned in <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/latest/html/user_guide/ides-in-workspaces#toolbox" target="_blank">the documentation</a> are met.</p>
+    <p class="center">If your browser doesn't ask you to open Toolbox, make sure the prerequisites mentioned in <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/latest/html/user_guide/assembly_customizing-workspaces_user_guide#proc_connecting-jetbrains-toolbox-to-devspaces_user_guide" target="_blank">the documentation</a> are met.</p>
 
     <!-- Provide an alternative way to open IDE, in case the browser can't show a pop-up -->
     <p class="center"><a href="javascript:;" onclick="openToolbox()"><b>Open the workspace over Toolbox</b></a></p>


### PR DESCRIPTION
### What does this PR do?


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation link in the workspace connection help flow to direct to the correct Red Hat documentation section for connecting JetBrains Toolbox.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/che-incubator/che-code/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->