### PR TITLE
[7.117.x] Add sshd-session binary for inclusion in devworkspace container.

### DIFF
--- a/build/dockerfiles/assembly.sshd.Dockerfile
+++ b/build/dockerfiles/assembly.sshd.Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p /sshd-staging/ubi8 /sshd-staging/ubi9
 # UBI 8
 COPY --from=sshd-ubi8 /usr/sbin/sshd /usr/bin/ssh-keygen /usr/bin/tar /usr/bin/gzip /usr/bin/which /usr/lib64/libnss_wrapper.so /usr/lib64/libpam.so.0 /sshd-staging/ubi8/
 # UBI 9/10
-RUN cp /usr/sbin/sshd /usr/bin/ssh-keygen /usr/bin/tar /usr/bin/gzip /usr/bin/which /usr/lib64/libnss_wrapper.so /usr/lib64/libpam.so.0 /usr/lib64/libeconf.so.0 /usr/lib64/libcrypt.so.2 /sshd-staging/ubi9/
+RUN cp /usr/sbin/sshd /usr/libexec/openssh/sshd-session /usr/bin/ssh-keygen /usr/bin/tar /usr/bin/gzip /usr/bin/which /usr/lib64/libnss_wrapper.so /usr/lib64/libpam.so.0 /usr/lib64/libeconf.so.0 /usr/lib64/libcrypt.so.2 /sshd-staging/ubi9/
 
 # sshd_config is root:root 600
 RUN chmod 644 /etc/ssh/sshd_config

--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -11,6 +11,7 @@
 USER_ID=$(id -u)
 
 sshd_libdir=
+use_sshd_session_path=0
 . /etc/os-release
 case $VERSION_ID in
   "8"*)
@@ -20,14 +21,17 @@ case $VERSION_ID in
   "9"*)
   sshd_libdir=/sshd/ubi9
   export LD_PRELOAD=$sshd_libdir/libeconf.so.0:$sshd_libdir/libpam.so.0:$sshd_libdir/libcrypt.so.2
+  use_sshd_session_path=1
   ;;
   "10"*)
   sshd_libdir=/sshd/ubi9
   export LD_PRELOAD=$sshd_libdir/libeconf.so.0:$sshd_libdir/libpam.so.0:$sshd_libdir/libcrypt.so.2
+  use_sshd_session_path=1
   ;;
   *)
   sshd_libdir=/sshd/ubi9
   export LD_PRELOAD=$sshd_libdir/libeconf.so.0:$sshd_libdir/libpam.so.0:$sshd_libdir/libcrypt.so.2
+  use_sshd_session_path=1
   ;;
 esac
 
@@ -95,6 +99,16 @@ sed -i \
 -e 's|#LogLevel INFO|LogLevel DEBUG1|' \
 -e 's|/usr/libexec/openssh/sftp-server|internal-sftp|' \
   /sshd/sshd_config
+
+# OpenSSH 9.8+
+if [ $use_sshd_session_path -eq 1 ]; then
+  grep -q 'SshdSessionPath' /sshd/sshd_config
+  if [ $? -eq 0 ]; then
+    sed -i "s|SshdSessionPath .*|SshdSessionPath $sshd_libdir/sshd-session|" /sshd/sshd_config
+  else
+    echo "SshdSessionPath $sshd_libdir/sshd-session" >> /sshd/sshd_config
+  fi
+fi
 
 # Provide new path containing host keys
 sed -i \


### PR DESCRIPTION
- Update from OpenSSH 8.7 to 9.9
- This is a backport of https://github.com/che-incubator/che-code/pull/715 .
