### PR TITLE
CRW-11195: Fix CVE-2026-9277 by updating shell-quote to patched version

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,21 +3,16 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
-dd082146741 fix: override shell-quote to 1.8.4 (GHSA-w7jw-789q-3m8p)
-
-- code/build/rspack/package.json
-- code/extensions/copilot/package.json
-- code/extensions/copilot/chat-lib/package.json
-- code/remote/package.json
----
-
-#### @sbouchet
 https://github.com/che-incubator/che-code/pull/720
 
 - code/package.json
 - code/test/automation/package.json
 - code/test/smoke/package.json
 - code/test/mcp/package.json
+- code/build/rspack/package.json
+- code/extensions/copilot/package.json
+- code/extensions/copilot/chat-lib/package.json
+- code/remote/package.json
 ---
 
 #### @sbouchet

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,15 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
+https://github.com/che-incubator/che-code/pull/720
+
+- code/package.json
+- code/test/automation/package.json
+- code/test/smoke/package.json
+- code/test/mcp/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/716
 
 - code/package.json

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,15 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
+dd082146741 fix: override shell-quote to 1.8.4 (GHSA-w7jw-789q-3m8p)
+
+- code/build/rspack/package.json
+- code/extensions/copilot/package.json
+- code/extensions/copilot/chat-lib/package.json
+- code/remote/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/720
 
 - code/package.json

--- a/.rebase/add/code/build/rspack/package.json
+++ b/.rebase/add/code/build/rspack/package.json
@@ -1,0 +1,5 @@
+{
+    "overrides": {
+        "shell-quote": "^1.8.4"
+    }
+}

--- a/.rebase/add/code/extensions/copilot/chat-lib/package.json
+++ b/.rebase/add/code/extensions/copilot/chat-lib/package.json
@@ -1,0 +1,5 @@
+{
+    "overrides": {
+        "shell-quote": "^1.8.4"
+    }
+}

--- a/.rebase/add/code/extensions/copilot/package.json
+++ b/.rebase/add/code/extensions/copilot/package.json
@@ -1,0 +1,5 @@
+{
+    "overrides": {
+        "shell-quote": "^1.8.4"
+    }
+}

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -15,6 +15,7 @@
         "braces": "3.0.3",
         "lodash": "^4.18.1",
         "es5-ext": "npm:@unes/es5-ext@0.10.64-1",
-        "flatted": "^3.4.2"
+        "flatted": "^3.4.2",
+        "shell-quote": "^1.8.4"
     }
 }

--- a/.rebase/add/code/remote/package.json
+++ b/.rebase/add/code/remote/package.json
@@ -2,5 +2,8 @@
     "dependencies": {
         "js-yaml": "^4.1.0",
         "@kubernetes/client-node": "^1.4.0"
+    },
+    "overrides": {
+        "shell-quote": "^1.8.4"
     }
 }

--- a/.rebase/add/code/test/automation/package.json
+++ b/.rebase/add/code/test/automation/package.json
@@ -1,0 +1,5 @@
+{
+    "overrides": {
+        "shell-quote": "^1.8.4"
+    }
+}

--- a/.rebase/add/code/test/mcp/package.json
+++ b/.rebase/add/code/test/mcp/package.json
@@ -1,0 +1,5 @@
+{
+    "overrides": {
+        "shell-quote": "^1.8.4"
+    }
+}

--- a/.rebase/add/code/test/smoke/package.json
+++ b/.rebase/add/code/test/smoke/package.json
@@ -1,0 +1,5 @@
+{
+    "overrides": {
+        "shell-quote": "^1.8.4"
+    }
+}

--- a/code/build/rspack/package-lock.json
+++ b/code/build/rspack/package-lock.json
@@ -3627,9 +3627,9 @@
       "license": "ISC"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/code/build/rspack/package.json
+++ b/code/build/rspack/package.json
@@ -11,6 +11,9 @@
     "@rspack/core": "^1.3.18",
     "@vscode/esm-url-webpack-plugin": "^1.0.1-3"
   },
+  "overrides": {
+    "shell-quote": "^1.8.4"
+  },
   "dependencies": {
     "@vscode/component-explorer": "^0.2.1-8",
     "@vscode/component-explorer-webpack-plugin": "^0.3.1-5"

--- a/code/extensions/copilot/chat-lib/package-lock.json
+++ b/code/extensions/copilot/chat-lib/package-lock.json
@@ -4165,10 +4165,14 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}

--- a/code/extensions/copilot/chat-lib/package.json
+++ b/code/extensions/copilot/chat-lib/package.json
@@ -44,6 +44,9 @@
 		"typescript": "^5.8.3",
 		"vitest": "^3.0.5"
 	},
+	"overrides": {
+		"shell-quote": "^1.8.4"
+	},
 	"keywords": [
 		"chat",
 		"ai",

--- a/code/extensions/copilot/package-lock.json
+++ b/code/extensions/copilot/package-lock.json
@@ -19595,10 +19595,14 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}

--- a/code/extensions/copilot/package.json
+++ b/code/extensions/copilot/package.json
@@ -6398,7 +6398,8 @@
 		"@aminya/node-gyp-build": "npm:node-gyp-build@4.8.1",
 		"string_decoder": "npm:string_decoder@1.2.0",
 		"node-gyp": "npm:node-gyp@10.3.1",
-		"zod": "3.25.76"
+		"zod": "3.25.76",
+		"shell-quote": "^1.8.4"
 	},
 	"vscodeCommit": "94c8e2adc50e26ef70af85a0de3a9efed757acaa",
 	"__metadata": {

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -16573,9 +16573,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/code/package.json
+++ b/code/package.json
@@ -267,7 +267,8 @@
     "braces": "3.0.3",
     "lodash": "^4.18.1",
     "es5-ext": "npm:@unes/es5-ext@0.10.64-1",
-    "flatted": "^3.4.2"
+    "flatted": "^3.4.2",
+    "shell-quote": "^1.8.4"
   },
   "repository": {
     "type": "git",

--- a/code/remote/package-lock.json
+++ b/code/remote/package-lock.json
@@ -2075,9 +2075,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/code/remote/package.json
+++ b/code/remote/package.json
@@ -56,6 +56,7 @@
     },
     "ssh2": {
       "cpu-features": "0.0.0"
-    }
+    },
+    "shell-quote": "^1.8.4"
   }
 }

--- a/code/test/automation/package-lock.json
+++ b/code/test/automation/package-lock.json
@@ -815,10 +815,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",

--- a/code/test/automation/package.json
+++ b/code/test/automation/package.json
@@ -31,5 +31,8 @@
     "cpx2": "3.0.0",
     "nodemon": "^3.1.9",
     "npm-run-all2": "^8.0.4"
+  },
+  "overrides": {
+    "shell-quote": "^1.8.4"
   }
 }

--- a/code/test/mcp/package-lock.json
+++ b/code/test/mcp/package-lock.json
@@ -1289,9 +1289,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/code/test/mcp/package.json
+++ b/code/test/mcp/package.json
@@ -22,5 +22,8 @@
     "@types/node": "22.x",
     "@types/node-fetch": "^2.5.10",
     "npm-run-all2": "^8.0.4"
+  },
+  "overrides": {
+    "shell-quote": "^1.8.4"
   }
 }

--- a/code/test/smoke/package-lock.json
+++ b/code/test/smoke/package-lock.json
@@ -540,10 +540,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/code/test/smoke/package.json
+++ b/code/test/smoke/package.json
@@ -19,5 +19,8 @@
     "@types/node": "22.x",
     "@types/node-fetch": "^2.5.10",
     "npm-run-all2": "^8.0.4"
+  },
+  "overrides": {
+    "shell-quote": "^1.8.4"
   }
 }

--- a/rebase.sh
+++ b/rebase.sh
@@ -490,9 +490,21 @@ resolve_conflicts() {
       apply_code_vs_base_browser_dompurify_changes
     elif [[ "$conflictingFile" == "code/extensions/copilot/src/platform/authentication/vscode-node/copilotTokenManager.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/copilot/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/copilot/chat-lib/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/build/rspack/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/markdown-language-features/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/mermaid-chat-features/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/test/automation/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/test/mcp/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/test/smoke/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
     else
       # Smart fallback: check if the file has che-specific changes


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2026-9277](https://github.com/advisories/GHSA-w7jw-789q-3m8p).

`shell-quote` version is updated to `1.8.4`

### What issues does this PR fix?
https://github.com/che-incubator/che-code/security/dependabot/519
https://github.com/che-incubator/che-code/security/dependabot/520
https://github.com/che-incubator/che-code/security/dependabot/521
https://github.com/che-incubator/che-code/security/dependabot/522

https://redhat.atlassian.net/browse/CRW-12134

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated and consistently pinned `shell-quote` across the main package plus related automation, MCP, smoke test, build, extension, and remote environments by using dependency overrides.
  * Improved rebase conflict handling to better re-apply stored `package.json` changes for multiple affected areas.
  * Refreshed the changelog entry for the referenced code update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->