### PR TITLE
Fix CVE-2026-42338 by updating ip-address to patched version

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -16,6 +16,16 @@ https://github.com/che-incubator/che-code/pull/720
 ---
 
 #### @sbouchet
+https://github.com/che-incubator/che-code/pull/722
+
+- code/package.json
+- code/remote/package.json
+- code/build/npm/gyp/package.json
+- code/extensions/copilot/package.json
+- code/test/mcp/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/716
 
 - code/package.json

--- a/.rebase/add/code/build/npm/gyp/package.json
+++ b/.rebase/add/code/build/npm/gyp/package.json
@@ -1,6 +1,5 @@
 {
     "overrides": {
-        "shell-quote": "^1.8.4",
         "ip-address": "^10.2.0"
     }
 }

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -16,6 +16,7 @@
         "lodash": "^4.18.1",
         "es5-ext": "npm:@unes/es5-ext@0.10.64-1",
         "flatted": "^3.4.2",
-        "shell-quote": "^1.8.4"
+        "shell-quote": "^1.8.4",
+        "ip-address": "^10.2.0"
     }
 }

--- a/.rebase/add/code/remote/package.json
+++ b/.rebase/add/code/remote/package.json
@@ -4,6 +4,7 @@
         "@kubernetes/client-node": "^1.4.0"
     },
     "overrides": {
-        "shell-quote": "^1.8.4"
+        "shell-quote": "^1.8.4",
+        "ip-address": "^10.2.0"
     }
 }

--- a/.rebase/add/code/test/mcp/package.json
+++ b/.rebase/add/code/test/mcp/package.json
@@ -1,5 +1,6 @@
 {
     "overrides": {
-        "shell-quote": "^1.8.4"
+        "shell-quote": "^1.8.4",
+        "ip-address": "^10.2.0"
     }
 }

--- a/code/build/npm/gyp/package-lock.json
+++ b/code/build/npm/gyp/package-lock.json
@@ -438,15 +438,11 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
@@ -486,13 +482,6 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -942,13 +931,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
       "version": "12.0.0",

--- a/code/build/npm/gyp/package.json
+++ b/code/build/npm/gyp/package.json
@@ -6,5 +6,8 @@
   "devDependencies": {
     "node-gyp": "^11.2.0"
   },
+  "overrides": {
+    "ip-address": "^10.2.0"
+  },
   "scripts": {}
 }

--- a/code/extensions/che-api/package-lock.json
+++ b/code/extensions/che-api/package-lock.json
@@ -2542,9 +2542,9 @@
       "integrity": "sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA=="
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -54,7 +54,8 @@
     "@eclipse-che/workspace-telemetry-client": {
       "axios": "^0.32.0"
     },
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "ip-address": "^10.2.0"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/che-commands/package-lock.json
+++ b/code/extensions/che-commands/package-lock.json
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -42,6 +42,9 @@
     "@types/js-yaml": "^4.0.5",
     "@types/node": "22.x"
   },
+  "overrides": {
+    "ip-address": "^10.2.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/che-incubator/che-code.git"

--- a/code/extensions/che-github-authentication/package-lock.json
+++ b/code/extensions/che-github-authentication/package-lock.json
@@ -924,9 +924,9 @@
       "integrity": "sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA=="
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -64,6 +64,9 @@
     "@types/node-fetch": "^2.5.7",
     "@types/uuid": "8.0.0"
   },
+  "overrides": {
+    "ip-address": "^10.2.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/che-incubator/che-code.git"

--- a/code/extensions/che-resource-monitor/package-lock.json
+++ b/code/extensions/che-resource-monitor/package-lock.json
@@ -2514,9 +2514,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -48,7 +48,8 @@
   },
   "overrides": {
     "minimatch": "^3.1.5",
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "ip-address": "^10.2.0"
   },
   "repository": {
     "type": "git",

--- a/code/extensions/copilot/package-lock.json
+++ b/code/extensions/copilot/package-lock.json
@@ -13687,9 +13687,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"

--- a/code/extensions/copilot/package.json
+++ b/code/extensions/copilot/package.json
@@ -6399,7 +6399,8 @@
 		"string_decoder": "npm:string_decoder@1.2.0",
 		"node-gyp": "npm:node-gyp@10.3.1",
 		"zod": "3.25.76",
-		"shell-quote": "^1.8.4"
+		"shell-quote": "^1.8.4",
+		"ip-address": "^10.2.0"
 	},
 	"vscodeCommit": "94c8e2adc50e26ef70af85a0de3a9efed757acaa",
 	"__metadata": {

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -8705,16 +8705,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/express-rate-limit/node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/express/node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -11841,13 +11831,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -12463,11 +12450,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -16946,7 +16928,9 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/ssh2": {
       "version": "1.17.0",
@@ -17931,15 +17915,6 @@
         "universalify": "^0.2.0",
         "url-parse": "^1.5.3"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/code/package.json
+++ b/code/package.json
@@ -268,7 +268,8 @@
     "lodash": "^4.18.1",
     "es5-ext": "npm:@unes/es5-ext@0.10.64-1",
     "flatted": "^3.4.2",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "ip-address": "^10.2.0"
   },
   "repository": {
     "type": "git",

--- a/code/remote/package-lock.json
+++ b/code/remote/package-lock.json
@@ -1586,13 +1586,10 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -1650,11 +1647,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -2163,11 +2155,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/ssh2": {
       "version": "1.17.0",

--- a/code/remote/package.json
+++ b/code/remote/package.json
@@ -57,6 +57,7 @@
     "ssh2": {
       "cpu-features": "0.0.0"
     },
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "ip-address": "^10.2.0"
   }
 }

--- a/code/test/mcp/package-lock.json
+++ b/code/test/mcp/package-lock.json
@@ -753,9 +753,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/code/test/mcp/package.json
+++ b/code/test/mcp/package.json
@@ -24,6 +24,7 @@
     "npm-run-all2": "^8.0.4"
   },
   "overrides": {
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "ip-address": "^10.2.0"
   }
 }

--- a/launcher/package-lock.json
+++ b/launcher/package-lock.json
@@ -3116,9 +3116,9 @@
       "dev": true
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -54,7 +54,8 @@
     "ajv": "6.14.0",
     "minimatch": "^3.1.5",
     "handlebars": "4.7.9",
-    "flatted": "^3.4.2"
+    "flatted": "^3.4.2",
+    "ip-address": "^10.2.0"
   },
   "jest": {
     "collectCoverage": true,

--- a/rebase.sh
+++ b/rebase.sh
@@ -380,6 +380,8 @@ resolve_conflicts() {
       apply_code_package_changes
     elif [[ "$conflictingFile" == "code/build/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/build/npm/gyp/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/build/vite/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/package.json" ]]; then


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2026-42338](https://github.com/advisories/GHSA-v2v4-37r5-5v8g/dependabot)

`ip-address` version is updated to `10.2.0`

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-11174


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version pinning across the project to ensure compatibility and stability.
  * Removed an outdated package override configuration.
  * Improved build script conflict resolution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->