### PR TITLE
fix: disable experimental onboarding modal on first launch

### DIFF
--- a/.rebase/replace/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "\t\t'workbench.welcomePage.experimentalOnboarding': {\n\t\t\tscope: ConfigurationScope.APPLICATION,\n\t\t\ttype: 'boolean',\n\t\t\tdefault: true,",
+    "by": "\t\t'workbench.welcomePage.experimentalOnboarding': {\n\t\t\tscope: ConfigurationScope.APPLICATION,\n\t\t\ttype: 'boolean',\n\t\t\tdefault: false,"
+  }
+]

--- a/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -341,7 +341,7 @@ configurationRegistry.registerConfiguration({
 		'workbench.welcomePage.experimentalOnboarding': {
 			scope: ConfigurationScope.APPLICATION,
 			type: 'boolean',
-			default: true,
+			default: false,
 			tags: ['experimental'],
 			description: localize('workbench.welcomePage.experimentalOnboarding', "When enabled, show the new onboarding experience instead of the classic walkthrough on first launch.")
 		}

--- a/rebase.sh
+++ b/rebase.sh
@@ -418,6 +418,8 @@ resolve_conflicts() {
       apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts" ]]; then
+      apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/web.main.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/server/node/serverServices.ts" ]]; then


### PR DESCRIPTION
### What does this PR do?
- the upstream VS Code onboarding wizard (`Welcome to VS Code / Sign in`) blocks the UI with a modal overlay on first launch 
- disable it by defaulting `workbench.welcomePage.experimentalOnboarding` to `false`
- restoring the classic Welcome tab behavior

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://redhat.atlassian.net/browse/CRW-11373

### How to test this PR?
- Start a workspace in Incognito window
- Without PR changes the following window is displayed when the workspace started
<img width="963" height="559" alt="image" src="https://github.com/user-attachments/assets/493ba855-9d55-4e21-a07c-0b47e1a9b9c3" />

- the window should be absent when you use editor with the current PR changes

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Assisted-by: Cursor AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * The experimental onboarding experience is now disabled by default. The new onboarding interface will no longer appear automatically on first launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->