### PR TITLE
Fix copilot and git related scripts execution

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
+#### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/736
+
+- code/extensions/git/src/askpass.sh
+- code/extensions/git/src/ssh-askpass.sh
+- code/extensions/git/src/git-editor.sh
+- code/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLITerminalIntegration.ts
+- code/extensions/copilot/src/extension/onboardDebug/vscode-node/copilotDebugCommandContribution.ts
+---
+
 #### @sbouchet
 https://github.com/che-incubator/che-code/pull/728
 

--- a/.rebase/replace/code/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLITerminalIntegration.ts.json
+++ b/.rebase/replace/code/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLITerminalIntegration.ts.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "\t\t} else {\n\t\t\tconst copilotShellScript = `#!/bin/sh\nunset NODE_OPTIONS\nELECTRON_RUN_AS_NODE=1 \"${process.execPath}\" \"${path.join(storageLocation, COPILOT_CLI_SHIM_JS)}\" \"$@\"`;",
+    "by": "\t\t} else {\n\t\t\tconst copilotShellScript = `#!/bin/sh\nunset NODE_OPTIONS\nNODE_DIR=$(dirname \"${process.execPath}\")\nif [ -d \"$NODE_DIR/ld_libs/core\" ]; then\n  LD_LIBRARY_PATH=\"$NODE_DIR/ld_libs/core\\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n  if [ -d \"$NODE_DIR/ld_libs/openssl\" ]; then\n    LD_LIBRARY_PATH=\"$NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH\"\n  fi\nelif [ -d \"$NODE_DIR/ld_libs\" ]; then\n  LD_LIBRARY_PATH=\"$NODE_DIR/ld_libs\\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\nfi\nexport LD_LIBRARY_PATH\nELECTRON_RUN_AS_NODE=1 \"${process.execPath}\" \"${path.join(storageLocation, COPILOT_CLI_SHIM_JS)}\" \"$@\"`;"
+  }
+]

--- a/.rebase/replace/code/extensions/copilot/src/extension/onboardDebug/vscode-node/copilotDebugCommandContribution.ts.json
+++ b/.rebase/replace/code/extensions/copilot/src/extension/onboardDebug/vscode-node/copilotDebugCommandContribution.ts.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "const makeShellScript = (remoteCommand: string, dir: string, callbackUri: vscode.Uri) => `#!/bin/sh\nunset NODE_OPTIONS\nELECTRON_RUN_AS_NODE=1 \"${process.execPath}\" \"${path.join(dir, DEBUG_COMMAND_JS)}\" \"${callbackUri}\" \"${remoteCommand}\" \"$@\"`;",
+    "by": "const makeShellScript = (remoteCommand: string, dir: string, callbackUri: vscode.Uri) => `#!/bin/sh\nunset NODE_OPTIONS\nNODE_DIR=$(dirname \"${process.execPath}\")\nif [ -d \"$NODE_DIR/ld_libs/core\" ]; then\n  LD_LIBRARY_PATH=\"$NODE_DIR/ld_libs/core\\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n  if [ -d \"$NODE_DIR/ld_libs/openssl\" ]; then\n    LD_LIBRARY_PATH=\"$NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH\"\n  fi\nelif [ -d \"$NODE_DIR/ld_libs\" ]; then\n  LD_LIBRARY_PATH=\"$NODE_DIR/ld_libs\\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\nfi\nexport LD_LIBRARY_PATH\nELECTRON_RUN_AS_NODE=1 \"${process.execPath}\" \"${path.join(dir, DEBUG_COMMAND_JS)}\" \"${callbackUri}\" \"${remoteCommand}\" \"$@\"`;"
+  }
+]

--- a/.rebase/replace/code/extensions/git/src/askpass.sh.json
+++ b/.rebase/replace/code/extensions/git/src/askpass.sh.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "#!/bin/sh\nVSCODE_GIT_ASKPASS_PIPE=`mktemp`",
+    "by": "#!/bin/sh\n# The following block was generated with AI assistance (Cursor AI)\n# and reviewed by the maintainers.\n#\n# Ensure the bundled node can find its shared libraries (e.g. libnode.so).\n# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid\n# library version conflicts with user containers; restore the paths needed\n# for the node binary scoped to this script only.\nif [ -n \"$VSCODE_GIT_ASKPASS_NODE\" ]; then\n  ASKPASS_NODE_DIR=$(dirname \"$VSCODE_GIT_ASKPASS_NODE\")\n  if [ -d \"$ASKPASS_NODE_DIR/ld_libs/core\" ]; then\n    LD_LIBRARY_PATH=\"$ASKPASS_NODE_DIR/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n    if [ -d \"$ASKPASS_NODE_DIR/ld_libs/openssl\" ]; then\n      LD_LIBRARY_PATH=\"$ASKPASS_NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH\"\n    fi\n  elif [ -d \"$ASKPASS_NODE_DIR/ld_libs\" ]; then\n    LD_LIBRARY_PATH=\"$ASKPASS_NODE_DIR/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n  fi\n  export LD_LIBRARY_PATH\nfi\nVSCODE_GIT_ASKPASS_PIPE=`mktemp`"
+  }
+]

--- a/.rebase/replace/code/extensions/git/src/git-editor.sh.json
+++ b/.rebase/replace/code/extensions/git/src/git-editor.sh.json
@@ -1,0 +1,6 @@
+[
+  {
+    "from": "#!/bin/sh\n\nELECTRON_RUN_AS_NODE=\"1\" \\\n\"$VSCODE_GIT_EDITOR_NODE\"",
+    "by": "#!/bin/sh\n# The following block was generated with AI assistance (Cursor AI)\n# and reviewed by the maintainers.\n#\n# Ensure the bundled node can find its shared libraries (e.g. libnode.so).\n# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid\n# library version conflicts with user containers; restore the paths needed\n# for the node binary scoped to this script only.\nif [ -n \"$VSCODE_GIT_EDITOR_NODE\" ]; then\n  EDITOR_NODE_DIR=$(dirname \"$VSCODE_GIT_EDITOR_NODE\")\n  if [ -d \"$EDITOR_NODE_DIR/ld_libs/core\" ]; then\n    LD_LIBRARY_PATH=\"$EDITOR_NODE_DIR/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n    if [ -d \"$EDITOR_NODE_DIR/ld_libs/openssl\" ]; then\n      LD_LIBRARY_PATH=\"$EDITOR_NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH\"\n    fi\n  elif [ -d \"$EDITOR_NODE_DIR/ld_libs\" ]; then\n    LD_LIBRARY_PATH=\"$EDITOR_NODE_DIR/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n  fi\n  export LD_LIBRARY_PATH\nfi\n\nELECTRON_RUN_AS_NODE=\"1\" \\\n\"$VSCODE_GIT_EDITOR_NODE\""
+  }
+]

--- a/.rebase/replace/code/extensions/git/src/ssh-askpass.sh.json
+++ b/.rebase/replace/code/extensions/git/src/ssh-askpass.sh.json
@@ -2,5 +2,9 @@
   {
     "from": "#!/bin/sh",
     "by": "#!/bin/sh\nif [ -f /etc/ssh/passphrase ] && command -v ssh-keygen >/dev/null; then\n  if ssh-keygen -y -P \"$(cat /etc/ssh/passphrase)\" -f /etc/ssh/dwo_ssh_key >/dev/null; then\n    cat /etc/ssh/passphrase\n    exit 0\n  fi\nfi"
+  },
+  {
+    "from": "VSCODE_GIT_ASKPASS_PIPE=`mktemp`\nELECTRON_RUN_AS_NODE=\"1\" VSCODE_GIT_ASKPASS_PIPE=\"$VSCODE_GIT_ASKPASS_PIPE\" VSCODE_GIT_ASKPASS_TYPE=\"ssh\" \"$VSCODE_GIT_ASKPASS_NODE\"",
+    "by": "# The following block was generated with AI assistance (Cursor AI)\n# and reviewed by the maintainers.\n#\n# Ensure the bundled node can find its shared libraries (e.g. libnode.so).\n# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid\n# library version conflicts with user containers; restore the paths needed\n# for the node binary scoped to this script only.\nif [ -n \"$VSCODE_GIT_ASKPASS_NODE\" ]; then\n  ASKPASS_NODE_DIR=$(dirname \"$VSCODE_GIT_ASKPASS_NODE\")\n  if [ -d \"$ASKPASS_NODE_DIR/ld_libs/core\" ]; then\n    LD_LIBRARY_PATH=\"$ASKPASS_NODE_DIR/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n    if [ -d \"$ASKPASS_NODE_DIR/ld_libs/openssl\" ]; then\n      LD_LIBRARY_PATH=\"$ASKPASS_NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH\"\n    fi\n  elif [ -d \"$ASKPASS_NODE_DIR/ld_libs\" ]; then\n    LD_LIBRARY_PATH=\"$ASKPASS_NODE_DIR/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"\n  fi\n  export LD_LIBRARY_PATH\nfi\nVSCODE_GIT_ASKPASS_PIPE=`mktemp`\nELECTRON_RUN_AS_NODE=\"1\" VSCODE_GIT_ASKPASS_PIPE=\"$VSCODE_GIT_ASKPASS_PIPE\" VSCODE_GIT_ASKPASS_TYPE=\"ssh\" \"$VSCODE_GIT_ASKPASS_NODE\""
   }
 ]

--- a/code/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLITerminalIntegration.ts
+++ b/code/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLITerminalIntegration.ts
@@ -105,6 +105,16 @@ powershell -ExecutionPolicy Bypass -File "${this.powershellScriptPath}" %*
 		} else {
 			const copilotShellScript = `#!/bin/sh
 unset NODE_OPTIONS
+NODE_DIR=$(dirname "${process.execPath}")
+if [ -d "$NODE_DIR/ld_libs/core" ]; then
+  LD_LIBRARY_PATH="$NODE_DIR/ld_libs/core\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  if [ -d "$NODE_DIR/ld_libs/openssl" ]; then
+    LD_LIBRARY_PATH="$NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH"
+  fi
+elif [ -d "$NODE_DIR/ld_libs" ]; then
+  LD_LIBRARY_PATH="$NODE_DIR/ld_libs\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export LD_LIBRARY_PATH
 ELECTRON_RUN_AS_NODE=1 "${process.execPath}" "${path.join(storageLocation, COPILOT_CLI_SHIM_JS)}" "$@"`;
 			await fs.copyFile(path.join(__dirname, COPILOT_CLI_SHIM_JS), path.join(storageLocation, COPILOT_CLI_SHIM_JS));
 			this.shellScriptPath = path.join(storageLocation, COPILOT_CLI_COMMAND);

--- a/code/extensions/copilot/src/extension/onboardDebug/vscode-node/copilotDebugCommandContribution.ts
+++ b/code/extensions/copilot/src/extension/onboardDebug/vscode-node/copilotDebugCommandContribution.ts
@@ -301,6 +301,16 @@ export class CopilotDebugCommandContribution extends Disposable implements vscod
 
 const makeShellScript = (remoteCommand: string, dir: string, callbackUri: vscode.Uri) => `#!/bin/sh
 unset NODE_OPTIONS
+NODE_DIR=$(dirname "${process.execPath}")
+if [ -d "$NODE_DIR/ld_libs/core" ]; then
+  LD_LIBRARY_PATH="$NODE_DIR/ld_libs/core\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  if [ -d "$NODE_DIR/ld_libs/openssl" ]; then
+    LD_LIBRARY_PATH="$NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH"
+  fi
+elif [ -d "$NODE_DIR/ld_libs" ]; then
+  LD_LIBRARY_PATH="$NODE_DIR/ld_libs\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export LD_LIBRARY_PATH
 ELECTRON_RUN_AS_NODE=1 "${process.execPath}" "${path.join(dir, DEBUG_COMMAND_JS)}" "${callbackUri}" "${remoteCommand}" "$@"`;
 
 const makeBatScript = (ps1Path: string) => `@echo off

--- a/code/extensions/git/src/askpass.sh
+++ b/code/extensions/git/src/askpass.sh
@@ -1,4 +1,23 @@
 #!/bin/sh
+# The following block was generated with AI assistance (Cursor AI)
+# and reviewed by the maintainers.
+#
+# Ensure the bundled node can find its shared libraries (e.g. libnode.so).
+# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid
+# library version conflicts with user containers; restore the paths needed
+# for the node binary scoped to this script only.
+if [ -n "$VSCODE_GIT_ASKPASS_NODE" ]; then
+  ASKPASS_NODE_DIR=$(dirname "$VSCODE_GIT_ASKPASS_NODE")
+  if [ -d "$ASKPASS_NODE_DIR/ld_libs/core" ]; then
+    LD_LIBRARY_PATH="$ASKPASS_NODE_DIR/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    if [ -d "$ASKPASS_NODE_DIR/ld_libs/openssl" ]; then
+      LD_LIBRARY_PATH="$ASKPASS_NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH"
+    fi
+  elif [ -d "$ASKPASS_NODE_DIR/ld_libs" ]; then
+    LD_LIBRARY_PATH="$ASKPASS_NODE_DIR/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  fi
+  export LD_LIBRARY_PATH
+fi
 VSCODE_GIT_ASKPASS_PIPE=`mktemp`
 ELECTRON_RUN_AS_NODE="1" VSCODE_GIT_ASKPASS_PIPE="$VSCODE_GIT_ASKPASS_PIPE" VSCODE_GIT_ASKPASS_TYPE="https" "$VSCODE_GIT_ASKPASS_NODE" "$VSCODE_GIT_ASKPASS_MAIN" $VSCODE_GIT_ASKPASS_EXTRA_ARGS $*
 cat $VSCODE_GIT_ASKPASS_PIPE

--- a/code/extensions/git/src/git-editor.sh
+++ b/code/extensions/git/src/git-editor.sh
@@ -1,4 +1,23 @@
 #!/bin/sh
+# The following block was generated with AI assistance (Cursor AI)
+# and reviewed by the maintainers.
+#
+# Ensure the bundled node can find its shared libraries (e.g. libnode.so).
+# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid
+# library version conflicts with user containers; restore the paths needed
+# for the node binary scoped to this script only.
+if [ -n "$VSCODE_GIT_EDITOR_NODE" ]; then
+  EDITOR_NODE_DIR=$(dirname "$VSCODE_GIT_EDITOR_NODE")
+  if [ -d "$EDITOR_NODE_DIR/ld_libs/core" ]; then
+    LD_LIBRARY_PATH="$EDITOR_NODE_DIR/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    if [ -d "$EDITOR_NODE_DIR/ld_libs/openssl" ]; then
+      LD_LIBRARY_PATH="$EDITOR_NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH"
+    fi
+  elif [ -d "$EDITOR_NODE_DIR/ld_libs" ]; then
+    LD_LIBRARY_PATH="$EDITOR_NODE_DIR/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  fi
+  export LD_LIBRARY_PATH
+fi
 
 ELECTRON_RUN_AS_NODE="1" \
 "$VSCODE_GIT_EDITOR_NODE" "$VSCODE_GIT_EDITOR_MAIN" $VSCODE_GIT_EDITOR_EXTRA_ARGS "$@"

--- a/code/extensions/git/src/ssh-askpass.sh
+++ b/code/extensions/git/src/ssh-askpass.sh
@@ -5,6 +5,25 @@ if [ -f /etc/ssh/passphrase ] && command -v ssh-keygen >/dev/null; then
     exit 0
   fi
 fi
+# The following block was generated with AI assistance (Cursor AI)
+# and reviewed by the maintainers.
+#
+# Ensure the bundled node can find its shared libraries (e.g. libnode.so).
+# In Che, LD_LIBRARY_PATH may be sanitized in terminal sessions to avoid
+# library version conflicts with user containers; restore the paths needed
+# for the node binary scoped to this script only.
+if [ -n "$VSCODE_GIT_ASKPASS_NODE" ]; then
+  ASKPASS_NODE_DIR=$(dirname "$VSCODE_GIT_ASKPASS_NODE")
+  if [ -d "$ASKPASS_NODE_DIR/ld_libs/core" ]; then
+    LD_LIBRARY_PATH="$ASKPASS_NODE_DIR/ld_libs/core${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    if [ -d "$ASKPASS_NODE_DIR/ld_libs/openssl" ]; then
+      LD_LIBRARY_PATH="$ASKPASS_NODE_DIR/ld_libs/openssl:$LD_LIBRARY_PATH"
+    fi
+  elif [ -d "$ASKPASS_NODE_DIR/ld_libs" ]; then
+    LD_LIBRARY_PATH="$ASKPASS_NODE_DIR/ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  fi
+  export LD_LIBRARY_PATH
+fi
 VSCODE_GIT_ASKPASS_PIPE=`mktemp`
 ELECTRON_RUN_AS_NODE="1" VSCODE_GIT_ASKPASS_PIPE="$VSCODE_GIT_ASKPASS_PIPE" VSCODE_GIT_ASKPASS_TYPE="ssh" "$VSCODE_GIT_ASKPASS_NODE" "$VSCODE_GIT_ASKPASS_MAIN" $VSCODE_GIT_ASKPASS_EXTRA_ARGS $*
 cat $VSCODE_GIT_ASKPASS_PIPE

--- a/rebase.sh
+++ b/rebase.sh
@@ -414,7 +414,11 @@ resolve_conflicts() {
       apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/code/browser/workbench/workbench.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/git/src/askpass.sh" ]]; then
+      apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/git/src/ssh-askpass.sh" ]]; then
+      apply_changes_multi_line "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/git/src/git-editor.sh" ]]; then
       apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/base/common/product.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"

--- a/rebase.sh
+++ b/rebase.sh
@@ -498,6 +498,10 @@ resolve_conflicts() {
       apply_code_vs_base_browser_dompurify_changes
     elif [[ "$conflictingFile" == "code/extensions/copilot/src/platform/authentication/vscode-node/copilotTokenManager.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLITerminalIntegration.ts" ]]; then
+      apply_changes_multi_line "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/copilot/src/extension/onboardDebug/vscode-node/copilotDebugCommandContribution.ts" ]]; then
+      apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/copilot/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/copilot/chat-lib/package.json" ]]; then


### PR DESCRIPTION
### What does this PR do?
1. Fixes `copilot` problem in a terminal:
<img width="1507" height="223" alt="Screenshot 2026-06-26 at 12 51 52" src="https://github.com/user-attachments/assets/a3d25c9f-b19c-41bd-8641-2cfa507b0495" />

2. Fixes interactive git editor
<img width="1507" height="295" alt="Screenshot 2026-06-26 at 14 18 01" src="https://github.com/user-attachments/assets/4701808b-0fc2-4621-8ab3-fd15a3e917a1" />

3. Fixes `Git clone` for a private repo
<img width="1507" height="366" alt="Screenshot 2026-06-26 at 13 25 31" src="https://github.com/user-attachments/assets/572a9e0b-0843-4076-b3d0-92fc2bcc3eee" />

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://redhat.atlassian.net/browse/CRW-11371

### How to test this PR?
1. `copilot` use case
- Start workspace - [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-736-amd64)
- create a vanilla VS Code terminal 
- type 
```
copilot
```

**Expected behavior:**
- No error (see the screenshot in the previous section)
- copilot is run or it propose to install copilot CLI
<img width="1507" height="329" alt="Screenshot 2026-06-26 at 13 56 58" src="https://github.com/user-attachments/assets/87bbf794-8a70-4ebe-be8a-048b49207d5d" />


2. Interactive git editor
- Start a workspace - [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=quay.io/rnikitenko/ubi9-minimal:git&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-736-amd64)
- Set `git.terminalGitEditor` to `true` in VS Code settings
- Create a vanilla VS Code terminal 
- Make a change and stage it:
```
 echo test >> file.txt && git add file.txt
 ```
- Run:
```
git commit
```
(without `-m`)
 
**Expected behavior:**

<img width="1507" height="397" alt="Screenshot 2026-06-26 at 14 08 15" src="https://github.com/user-attachments/assets/9461e036-48b8-41a9-8af6-3c4def7da7a8" />


3. `Git clone` for a private repo
- You need to revoke/remove/clean up any git credentials for the instance where you are going to test the use case
- Start workspace - [click here](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/RomanNikitenko/web-nodejs-sample/tree/install-extensions-from-vsix?new&image=quay.io/rnikitenko/ubi9-minimal:git&editor-image=quay.io/che-incubator-pull-requests/che-code:pr-736-amd64)
- Create a vanilla VS Code terminal 
```
git clone https://github.com/RomanNikitenko/private-test-repo.git
```

**Expected behavior:**
<img width="1507" height="490" alt="image" src="https://github.com/user-attachments/assets/85c769e8-3caf-43df-92df-a54862c59da5" />
Device Auth flow is triggered 
<img width="1507" height="490" alt="Screenshot 2026-06-26 at 13 45 49" src="https://github.com/user-attachments/assets/784923ee-d091-46d1-93b3-e056e578384f" />
Private repo cloned successfully
<img width="1507" height="329" alt="Screenshot 2026-06-26 at 13 49 10" src="https://github.com/user-attachments/assets/43cef257-97d2-4b35-9650-077a40f97ce4" />

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for Git-related prompts and editor launch flows by ensuring bundled Node components can find required system libraries.
  * Fixed Copilot CLI and debug startup on Unix-like systems by setting up library paths before launching, reducing startup failures in affected environments.
  * Updated rebase conflict handling so these changes are applied consistently during maintenance workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->