### PR TITLE
[7.119] fix: set buildType 'prod' in copilot extension

### DIFF
--- a/code/extensions/copilot/.esbuild.ts
+++ b/code/extensions/copilot/.esbuild.ts
@@ -325,6 +325,11 @@ async function main() {
 	if (process.env['BUILD_SOURCEVERSION']) {
 		console.log('Running in CI environment, applying package.json patch for correct versioning and pre-release status...');
 		applyPackageJsonPatch();
+	} else if (!isWatch && !isDev) {
+		const packageJsonPath = path.join(import.meta.dirname, './package.json');
+		const pkgJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+		pkgJson.buildType = 'prod';
+		fs.writeFileSync(packageJsonPath, JSON.stringify(pkgJson, null, '\t'));
 	}
 
 	await typeScriptServerPluginPackageJsonInstall();


### PR DESCRIPTION
### What does this PR do?
Backport https://github.com/che-incubator/che-code/pull/735

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Assisted-by: Cursor AI