### PR TITLE
fix: Fix 'Restart Workspace from Local Devfile' for empty workspace use case

### DIFF
--- a/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
@@ -133,7 +133,7 @@ export class DevWorkspaceAssistant {
 		const url = this.getWorkspaceUrl();
 		const patch = JSON.stringify([{ op: 'replace', path: '/spec/started', value: false }]);
 
-		await this.requestService.request({
+		const context = await this.requestService.request({
 			type: 'PATCH',
 			url,
 			data: patch,
@@ -141,6 +141,10 @@ export class DevWorkspaceAssistant {
 			timeout: 10000,
 			callSite: 'che-remote.devWorkspaceAssistant.stop',
 		}, CancellationToken.None);
+
+		if (context.res.statusCode && context.res.statusCode >= 400) {
+			throw new Error(`Failed to stop workspace: HTTP ${context.res.statusCode}`);
+		}
 	}
 
 	/**
@@ -195,15 +199,25 @@ export class DevWorkspaceAssistant {
 
 	private async doRestart(): Promise<void> {
 		this._isStopping = true;
-		await this.stopWorkspaceViaDashboardApi();
-		await this.waitForStopped();
-		this.startWorkspace();
+		try {
+			await this.stopWorkspaceViaDashboardApi();
+			await this.waitForStopped();
+			this.startWorkspace();
+		} catch (e) {
+			this._isStopping = false;
+			throw e;
+		}
 	}
 
 	async stopWorkspaceAndRedirectToDashboard(): Promise<void> {
 		this._isStopping = true;
-		await this.stopWorkspaceViaDashboardApi();
-		this.goToDashboard();
+		try {
+			await this.stopWorkspaceViaDashboardApi();
+			this.goToDashboard();
+		} catch (e) {
+			this._isStopping = false;
+			throw e;
+		}
 	}
 
 	startWorkspace(): void {

--- a/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
@@ -47,6 +47,7 @@ export class DevWorkspaceAssistant {
 	private static readonly POLL_INTERVAL_MS = 2000;
 	private static readonly STOP_TIMEOUT_MS = 10000;
 
+	private _isStopping = false;
 	private dashboardUrl: string | undefined;
 	private getDevWorkspaceUrl: string | undefined;
 	private startingDevWorkspaceUrl: string | undefined;
@@ -188,13 +189,19 @@ export class DevWorkspaceAssistant {
 		);
 	}
 
+	get isStopping(): boolean {
+		return this._isStopping;
+	}
+
 	private async doRestart(): Promise<void> {
+		this._isStopping = true;
 		await this.stopWorkspaceViaDashboardApi();
 		await this.waitForStopped();
 		this.startWorkspace();
 	}
 
 	async stopWorkspaceAndRedirectToDashboard(): Promise<void> {
+		this._isStopping = true;
 		await this.stopWorkspaceViaDashboardApi();
 		this.goToDashboard();
 	}

--- a/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
@@ -10,7 +10,7 @@
 /* eslint-disable header/header */
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
-import { CommandsRegistry, ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
 import { asJson, IRequestService } from '../../../../../platform/request/common/request.js';
 import { IEnvironmentVariableService } from '../../../terminal/common/environmentVariable.js';
 import { IProgressService, ProgressLocation } from '../../../../../platform/progress/common/progress.js';
@@ -44,12 +44,14 @@ export class DevWorkspaceAssistant {
 	static INACTIVITY_REASON = 'inactivity';
 	static RUN_TIMEOUT_REASON = 'run-timeout';
 
+	private static readonly POLL_INTERVAL_MS = 2000;
+	private static readonly STOP_TIMEOUT_MS = 10000;
+
 	private dashboardUrl: string | undefined;
 	private getDevWorkspaceUrl: string | undefined;
 	private startingDevWorkspaceUrl: string | undefined;
 
 	constructor(
-		private commandService: ICommandService,
 		private requestService: IRequestService,
 		private environmentVariableService: IEnvironmentVariableService,
 		private progressService: IProgressService) {
@@ -121,9 +123,58 @@ export class DevWorkspaceAssistant {
 		this.getDevWorkspaceUrl = `${dashboardUrl}/dashboard/api/namespace/${workspaceNamespace}/devworkspaces/${workspaceName}`;
 	}
 
-	async restartWorkspace(): Promise<void> {
-		await this.commandService.executeCommand('che-remote.command.stopWorkspace');
+	/**
+	 * Stop the workspace via the Dashboard PATCH API.
+	 * This runs entirely on the browser side, so it works even after the
+	 * extension host (remote server) has died.
+	 */
+	private async stopWorkspaceViaDashboardApi(): Promise<void> {
+		const url = this.getWorkspaceUrl();
+		const patch = JSON.stringify([{ op: 'replace', path: '/spec/started', value: false }]);
 
+		await this.requestService.request({
+			type: 'PATCH',
+			url,
+			data: patch,
+			headers: { 'Content-Type': 'application/json' },
+			timeout: 10000,
+			callSite: 'che-remote.devWorkspaceAssistant.stop',
+		}, CancellationToken.None);
+	}
+
+	/**
+	 * Poll the Dashboard API until the workspace reaches STOPPED (or FAILED) status.
+	 * Resolves on timeout so the redirect to Dashboard can still proceed.
+	 */
+	private waitForStopped(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const timeoutId = setTimeout(() => {
+				clearInterval(intervalId);
+				resolve();
+			}, DevWorkspaceAssistant.STOP_TIMEOUT_MS);
+
+			const intervalId = setInterval(async () => {
+				try {
+					const result = await this.getDevWorkspace();
+					const phase = result.status?.phase;
+
+					if (phase === DevWorkspaceStatus.STOPPED) {
+						clearTimeout(timeoutId);
+						clearInterval(intervalId);
+						resolve();
+					} else if (phase === DevWorkspaceStatus.FAILED) {
+						clearTimeout(timeoutId);
+						clearInterval(intervalId);
+						reject(new Error(`Workspace entered ${phase} state: ${result.status?.message}`));
+					}
+				} catch (e) {
+					// Dashboard API may be temporarily unreachable during shutdown
+				}
+			}, DevWorkspaceAssistant.POLL_INTERVAL_MS);
+		});
+	}
+
+	async restartWorkspace(): Promise<void> {
 		this.progressService.withProgress(
 			{
 				location: ProgressLocation.Dialog,
@@ -132,25 +183,19 @@ export class DevWorkspaceAssistant {
 				title: 'Workspace is restarting...',
 				sticky: true
 			},
-			() => new Promise(() => {}),
+			() => this.doRestart(),
 			() => this.startWorkspace()
 		);
+	}
 
-		setInterval(async () => {
-			try {
-				const result = await this.getDevWorkspace();
-				if (DevWorkspaceStatus.STOPPED === result.status.phase) {
-					this.startWorkspace();
-				}
-
-			} catch (e) {
-				console.error(e);
-			}
-		}, 2000);
+	private async doRestart(): Promise<void> {
+		await this.stopWorkspaceViaDashboardApi();
+		await this.waitForStopped();
+		this.startWorkspace();
 	}
 
 	async stopWorkspaceAndRedirectToDashboard(): Promise<void> {
-		await this.commandService.executeCommand('che-remote.command.stopWorkspace');
+		await this.stopWorkspaceViaDashboardApi();
 		this.goToDashboard();
 	}
 

--- a/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
@@ -95,6 +95,10 @@ export class CheDisconnectionHandler {
 			return;
 		}
 
+		if (this.devWorkspaceAssistant.isStopping) {
+			return;
+		}
+
 		this.status = DisconnectionHandlerStatus.IN_PROGRESS;
 		let devWorkspace;
 		try {

--- a/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
@@ -69,7 +69,7 @@ export class CheDisconnectionHandler {
 		environmentVariableService: IEnvironmentVariableService,
 		progressService: IProgressService
 	) {
-		this.devWorkspaceAssistant = new DevWorkspaceAssistant(commandService, requestService, environmentVariableService, progressService);
+		this.devWorkspaceAssistant = new DevWorkspaceAssistant(requestService, environmentVariableService, progressService);
 	}
 
 	private canHandle(millisSinceLastIncomingData: number): boolean {


### PR DESCRIPTION
### What does this PR do?

- **Problem:** I found that `Restart Workspace from Local Devfile` command hangs when used in workspaces without a pre-cloned git repo. The `restartWorkspace()` method calls `stopWorkspace` via the extension host, but the extension host dies when the workspace stops, leaving the `await` hanging forever — the browser never redirects.
- **Fix:** Stop the workspace via the Dashboard REST API directly from the browser side, instead of going through the extension host. Poll the Dashboard API for workspace STOPPED status, then redirect.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://redhat.atlassian.net/browse/CRW-9559

### How to test this PR?
#### `Restart Workspace from Local Devfile` use case
1. Go to the Dashboard
2. Set `quay.io/che-incubator-pull-requests/che-code:pr-746-amd64` in the `Editor Image` field
3. Click `Empty Workspace`
4. Click `Clone Repository` in the `Explorer` when the workspace starts
5. Set `https://github.com/RomanNikitenko/web-nodejs-sample.git` => `Clone from URL` => `Select as Repository Destination`: `/projects` => `Add to Workspace`
6. `F1` => `Restart Workspace from Local Devfile`

Expected result: 
- the workspace should be restarted successfully
- `Cannot reconnect. Please reload the window.` dialog is not displayed.

#### `Stop Workspace` command use case
`Stop Workspace` command is also affected by the current PR changes  
1. Go to the Dashboard
2. Set `quay.io/che-incubator-pull-requests/che-code:pr-746-amd64` in the `Editor Image` field
3. Create any workspace
4. `F1` => `Stop Workspace` when the workspace is ready to use

Expected result: 
- the workspace should be stopped successfully
- user should be redirected to the dashboard

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace stop and restart actions now use the dashboard’s browser-side API for smoother control and more reliable state handling.
  * A stopping indicator is now tracked so the app can better avoid duplicate disconnect handling during shutdown.

* **Bug Fixes**
  * Improved workspace shutdown flow to wait for the stopped state or time out gracefully before redirecting.
  * Reduced reliance on client-side polling and command execution for stop/restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->