### PR TITLE
Add dependency version pin guidance to add-rebase-rules skill

### DIFF
--- a/.claude/skills/add-rebase-rules/SKILL.md
+++ b/.claude/skills/add-rebase-rules/SKILL.md
@@ -51,6 +51,11 @@ Important:
      - `.rebase/override/<path>` when overriding existing values must be explicit
    - It is valid to use both for one file.
    - Keep file formatting consistent with existing `.rebase` JSON style (2-space indentation).
+   - **Choosing add vs override for dependency version pins (e.g. CVE fixes):**
+     - If the dependency already exists in the upstream `package.json` (in `dependencies`, `devDependencies`, etc.) and we need a different version → use `.rebase/override/` with the correct section. This is an override of an existing upstream value.
+     - If the fix uses npm `overrides` (the npm feature that pins transitive dependency versions) and the override key does not exist in upstream's `overrides` section → use `.rebase/add/`. This is additive content absent from upstream.
+     - Never use `.rebase/replace/` (text replacement) for `package.json` version changes — always use the JSON merge mechanism (add or override).
+     - Place each entry in the file where the dependency actually lives in upstream. For example, if `@vitest/coverage-v8` is a devDependency of `code/extensions/copilot/package.json`, its override rule belongs in `.rebase/override/code/extensions/copilot/package.json`, not in a sibling package.
 
 4. Create or update replace rules for non-JSON files
    - File path: `.rebase/replace/<original-path>.json`

--- a/.claude/skills/add-rebase-rules/SKILL.md
+++ b/.claude/skills/add-rebase-rules/SKILL.md
@@ -54,7 +54,7 @@ Important:
    - **Choosing add vs override for dependency version pins (e.g. CVE fixes):**
      - If the dependency already exists in the upstream `package.json` (in `dependencies`, `devDependencies`, etc.) and we need a different version → use `.rebase/override/` with the correct section. This is an override of an existing upstream value.
      - If the fix uses npm `overrides` (the npm feature that pins transitive dependency versions) and the override key does not exist in upstream's `overrides` section → use `.rebase/add/`. This is additive content absent from upstream.
-     - Never use `.rebase/replace/` (text replacement) for `package.json` version changes — always use the JSON merge mechanism (add or override).
+     - Prefer the JSON merge mechanism (add or override) over `.rebase/replace/` for `package.json` changes. However, `.rebase/replace/` is acceptable when the change cannot be expressed by JSON merge alone — for example, **replacing one dependency with a different package** (e.g. swapping `gulp-untar` for `gulp-decompress` — see `.rebase/replace/code/package.json.json`) or **inserting a new entry at a specific position** among existing keys.
      - Place each entry in the file where the dependency actually lives in upstream. For example, if `@vitest/coverage-v8` is a devDependency of `code/extensions/copilot/package.json`, its override rule belongs in `.rebase/override/code/extensions/copilot/package.json`, not in a sibling package.
 
 4. Create or update replace rules for non-JSON files


### PR DESCRIPTION
## Summary
- Clarify when to use `.rebase/add/` vs `.rebase/override/` for dependency version pins (e.g. CVE fixes)
- Override for existing upstream deps that need a different version, add for npm overrides absent from upstream
- Never use `.rebase/replace/` (text replacement) for `package.json` version changes
- Place each entry in the file where the dependency actually lives in upstream

## Test plan
- [ ] Review the guidance in `.claude/skills/add-rebase-rules/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for creating dependency version rules.
  * Added instructions for choosing override or add rules, including npm overrides.
  * Clarified where dependency entries should be placed and when replacement rules should not be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->