### PR TITLE
Update try-in-web-ide action to version 1.5

### DIFF
--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Add DevSandbox link
-        uses: redhat-actions/try-in-web-ide@v1.4
+        uses: redhat-actions/try-in-web-ide@v1.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add_comment: true
           add_status: false
       - name: Add Dogfooding link
-        uses: redhat-actions/try-in-web-ide@v1.4
+        uses: redhat-actions/try-in-web-ide@v1.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add_comment: true


### PR DESCRIPTION
follow-up of https://github.com/eclipse-che/che/issues/23861

### What does this PR do?


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the web IDE link automation used in pull request workflows to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->