### PR TITLE
feat: Ability to add KeyBindings using a ConfigMap

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -560,3 +560,11 @@ https://github.com/che-incubator/che-code/pull/695
 
 - code/build/npm/preinstall.ts
 ---
+
+#### @RomanNikitenko
+https://github.com/che-incubator/che-code/pull/754
+
+- code/src/vs/server/node/webClientServer.ts
+- code/src/vs/workbench/browser/web.api.ts
+- code/src/vs/workbench/browser/web.main.ts
+---

--- a/.rebase/replace/code/src/vs/server/node/webClientServer.ts.json
+++ b/.rebase/replace/code/src/vs/server/node/webClientServer.ts.json
@@ -1,10 +1,14 @@
 [
     {
         "from": "import type * as http from 'http';",
-        "by": "import * as http from 'http';\nimport { getCheRedirectLocation } from './che/webClientServer.js';"
+        "by": "import * as http from 'http';\nimport { getCheInitialKeybindings, getCheRedirectLocation } from './che/webClientServer.js';"
     },
     {
         "from": "\t\t\tconst newLocation = url.format({ pathname: basePath, query: newQuery });\n\t\t\tresponseHeaders['Location'] = newLocation;",
         "by": "\t\t\tresponseHeaders['Location'] = getCheRedirectLocation(req, newQuery);"
+    },
+    {
+        "from": "callbackRoute: callbackRoute\n\t\t};",
+        "by": "callbackRoute: callbackRoute,\n\t\t\tcheInitialKeybindings: getCheInitialKeybindings(),\n\t\t};"
     }
 ]

--- a/.rebase/replace/code/src/vs/server/node/webClientServer.ts.json
+++ b/.rebase/replace/code/src/vs/server/node/webClientServer.ts.json
@@ -9,6 +9,6 @@
     },
     {
         "from": "callbackRoute: callbackRoute\n\t\t};",
-        "by": "callbackRoute: callbackRoute,\n\t\t\tcheInitialKeybindings: getCheInitialKeybindings(),\n\t\t};"
+        "by": "callbackRoute: callbackRoute,\n\t\t\tcheInitialKeybindings: await getCheInitialKeybindings(),\n\t\t};"
     }
 ]

--- a/.rebase/replace/code/src/vs/workbench/browser/web.api.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/web.api.ts.json
@@ -1,0 +1,6 @@
+[
+    {
+        "from": "readonly configurationDefaults?: Record<string, unknown>;\n\n\t//#endregion\n\n\t//#region Profile options",
+        "by": "readonly configurationDefaults?: Record<string, unknown>;\n\n\t//#endregion\n\n\t/**\n\t * Initial keybindings content from ConfigMap (JSON array string).\n\t * When set, keybindings are merged into IndexedDB on every workspace start.\n\t */\n\treadonly cheInitialKeybindings?: string;\n\n\t//#region Profile options"
+    }
+]

--- a/.rebase/replace/code/src/vs/workbench/browser/web.main.ts.json
+++ b/.rebase/replace/code/src/vs/workbench/browser/web.main.ts.json
@@ -1,10 +1,14 @@
 [
   {
     "from": "import { INotificationService, Severity } from '../../platform/notification/common/notification.js';",
-    "by": "import { INotificationService, Severity } from '../../platform/notification/common/notification.js';\nimport { getPolicyService } from './che/web.js';"
+    "by": "import { INotificationService, Severity } from '../../platform/notification/common/notification.js';\nimport { CheKeybindingsInitializer, getPolicyService } from './che/web.js';"
   },
   {
     "from": "const workspaceService = new WorkspaceService({ remoteAuthority: this.configuration.remoteAuthority, configurationCache }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, logService, policyService);",
     "by": "const workspaceService = new WorkspaceService({ remoteAuthority: this.configuration.remoteAuthority, configurationCache }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, logService, getPolicyService(remoteAgentService,logService, this.configuration.remoteAuthority));"
+  },
+  {
+    "from": "const userDataInitializationService = new UserDataInitializationService(userDataInitializers);",
+    "by": "if (environmentService.options.cheInitialKeybindings) {\n\t\t\tuserDataInitializers.push(new CheKeybindingsInitializer(environmentService.options.cheInitialKeybindings, fileService, userDataProfilesService, logService));\n\t\t}\n\t\tconst userDataInitializationService = new UserDataInitializationService(userDataInitializers);"
   }
 ]

--- a/code/src/vs/server/node/che/webClientServer.ts
+++ b/code/src/vs/server/node/che/webClientServer.ts
@@ -9,7 +9,7 @@
  ***********************************************************************/
 /* eslint-disable header/header */
 
-import { existsSync, readFileSync } from 'fs';
+import { promises as fs } from 'fs';
 import * as http from 'http';
 import * as url from 'url';
 
@@ -19,11 +19,12 @@ const CHE_CONFIG_KEYBINDINGS_PATH = '/checode-config/keybindings.json';
  * Reads keybindings.json content from the ConfigMap mount path.
  * Returns the raw JSON string if the file exists, undefined otherwise.
  */
-export function getCheInitialKeybindings(): string | undefined {
-    if (existsSync(CHE_CONFIG_KEYBINDINGS_PATH)) {
-        return readFileSync(CHE_CONFIG_KEYBINDINGS_PATH, 'utf-8');
+export async function getCheInitialKeybindings(): Promise<string | undefined> {
+    try {
+        return await fs.readFile(CHE_CONFIG_KEYBINDINGS_PATH, 'utf-8');
+    } catch {
+        return undefined;
     }
-    return undefined;
 }
 
 export function getCheRedirectLocation(req: http.IncomingMessage, newQuery: any): string {

--- a/code/src/vs/server/node/che/webClientServer.ts
+++ b/code/src/vs/server/node/che/webClientServer.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021-2022 Red Hat, Inc.
+ * Copyright (c) 2021-2026 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,8 +9,22 @@
  ***********************************************************************/
 /* eslint-disable header/header */
 
+import { existsSync, readFileSync } from 'fs';
 import * as http from 'http';
 import * as url from 'url';
+
+const CHE_CONFIG_KEYBINDINGS_PATH = '/checode-config/keybindings.json';
+
+/**
+ * Reads keybindings.json content from the ConfigMap mount path.
+ * Returns the raw JSON string if the file exists, undefined otherwise.
+ */
+export function getCheInitialKeybindings(): string | undefined {
+    if (existsSync(CHE_CONFIG_KEYBINDINGS_PATH)) {
+        return readFileSync(CHE_CONFIG_KEYBINDINGS_PATH, 'utf-8');
+    }
+    return undefined;
+}
 
 export function getCheRedirectLocation(req: http.IncomingMessage, newQuery: any): string {
     let newLocation;

--- a/code/src/vs/server/node/webClientServer.ts
+++ b/code/src/vs/server/node/webClientServer.ts
@@ -388,7 +388,7 @@ export class WebClientServer {
 			workspaceUri: resolveWorkspaceURI(this._environmentService.args['default-workspace']),
 			productConfiguration,
 			callbackRoute: callbackRoute,
-			cheInitialKeybindings: getCheInitialKeybindings(),
+			cheInitialKeybindings: await getCheInitialKeybindings(),
 		};
 
 		const cookies = cookie.parse(req.headers.cookie || '');

--- a/code/src/vs/server/node/webClientServer.ts
+++ b/code/src/vs/server/node/webClientServer.ts
@@ -5,7 +5,7 @@
 
 import { createReadStream, promises } from 'fs';
 import * as http from 'http';
-import { getCheRedirectLocation } from './che/webClientServer.js';
+import { getCheInitialKeybindings, getCheRedirectLocation } from './che/webClientServer.js';
 import * as url from 'url';
 import * as cookie from 'cookie';
 import * as crypto from 'crypto';
@@ -387,7 +387,8 @@ export class WebClientServer {
 			folderUri: resolveWorkspaceURI(this._environmentService.args['default-folder']),
 			workspaceUri: resolveWorkspaceURI(this._environmentService.args['default-workspace']),
 			productConfiguration,
-			callbackRoute: callbackRoute
+			callbackRoute: callbackRoute,
+			cheInitialKeybindings: getCheInitialKeybindings(),
 		};
 
 		const cookies = cookie.parse(req.headers.cookie || '');

--- a/code/src/vs/workbench/browser/che/web.ts
+++ b/code/src/vs/workbench/browser/che/web.ts
@@ -10,6 +10,7 @@
 /* eslint-disable header/header */
 
 import { VSBuffer } from '../../../base/common/buffer.js';
+import * as json from '../../../base/common/json.js';
 import { IFileService } from '../../../platform/files/common/files.js';
 import { ILogService } from '../../../platform/log/common/log.js';
 import { IPolicyService, NullPolicyService } from '../../../platform/policy/common/policy.js';
@@ -58,7 +59,7 @@ export class CheKeybindingsInitializer implements IUserDataInitializer {
 
         let configmapEntries: KeybindingEntry[];
         try {
-            const parsed = JSON.parse(this.initialKeybindings);
+            const parsed = json.parse(this.initialKeybindings);
             if (!Array.isArray(parsed)) {
                 this.logService.warn('[Che] ConfigMap keybindings.json is not a JSON array, skipping.');
                 return;
@@ -75,12 +76,13 @@ export class CheKeybindingsInitializer implements IUserDataInitializer {
         if (await this.fileService.exists(resource)) {
             try {
                 const content = (await this.fileService.readFile(resource)).value.toString();
-                const existing = JSON.parse(content);
+                const existing = json.parse(content);
                 if (Array.isArray(existing)) {
                     userEntries = existing.filter((e: KeybindingEntry) => e._source !== CONFIGMAP_SOURCE_MARKER);
                 }
             } catch (e) {
-                this.logService.warn('[Che] Failed to parse existing keybindings, preserving ConfigMap entries only.', e);
+                this.logService.warn('[Che] Failed to parse existing keybindings. Aborting to prevent data loss.', e);
+                return;
             }
         }
 

--- a/code/src/vs/workbench/browser/che/web.ts
+++ b/code/src/vs/workbench/browser/che/web.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2025 Red Hat, Inc.
+ * Copyright (c) 2025-2026 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,10 +9,89 @@
  ***********************************************************************/
 /* eslint-disable header/header */
 
+import { VSBuffer } from '../../../base/common/buffer.js';
+import { IFileService } from '../../../platform/files/common/files.js';
 import { ILogService } from '../../../platform/log/common/log.js';
 import { IPolicyService, NullPolicyService } from '../../../platform/policy/common/policy.js';
 import { PolicyChannelClient } from '../../../platform/policy/common/policyIpc.js';
+import { IUserDataProfilesService } from '../../../platform/userDataProfile/common/userDataProfile.js';
 import { IRemoteAgentService } from '../../services/remote/common/remoteAgentService.js';
+import { IUserDataInitializer } from '../../services/userData/browser/userDataInit.js';
+import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
+
+const CONFIGMAP_SOURCE_MARKER = 'configmap';
+
+interface KeybindingEntry {
+    key: string;
+    command: string;
+    when?: string;
+    args?: unknown;
+    _source?: string;
+}
+
+/**
+ * Merges keybindings from ConfigMap into IndexedDB on every workspace start.
+ *
+ * Strategy: admin keybindings (from ConfigMap) are appended at the end of the
+ * array so they take priority over user keybindings (VS Code processes
+ * keybindings top-to-bottom, later entries win). Admin entries are tagged with
+ * `"_source": "configmap"` so they can be identified and replaced on the next
+ * start when the ConfigMap content changes.
+ */
+export class CheKeybindingsInitializer implements IUserDataInitializer {
+
+    constructor(
+        private readonly initialKeybindings: string,
+        private readonly fileService: IFileService,
+        private readonly userDataProfilesService: IUserDataProfilesService,
+        private readonly logService: ILogService,
+    ) { }
+
+    async requiresInitialization(): Promise<boolean> {
+        return true;
+    }
+
+    async whenInitializationFinished(): Promise<void> { }
+
+    async initializeRequiredResources(): Promise<void> {
+        const resource = this.userDataProfilesService.defaultProfile.keybindingsResource;
+
+        let configmapEntries: KeybindingEntry[];
+        try {
+            const parsed = JSON.parse(this.initialKeybindings);
+            if (!Array.isArray(parsed)) {
+                this.logService.warn('[Che] ConfigMap keybindings.json is not a JSON array, skipping.');
+                return;
+            }
+            configmapEntries = parsed;
+        } catch (e) {
+            this.logService.warn('[Che] ConfigMap keybindings.json is not valid JSON, skipping.', e);
+            return;
+        }
+
+        const markedEntries: KeybindingEntry[] = configmapEntries.map(entry => ({ ...entry, _source: CONFIGMAP_SOURCE_MARKER }));
+
+        let userEntries: KeybindingEntry[] = [];
+        if (await this.fileService.exists(resource)) {
+            try {
+                const content = (await this.fileService.readFile(resource)).value.toString();
+                const existing = JSON.parse(content);
+                if (Array.isArray(existing)) {
+                    userEntries = existing.filter((e: KeybindingEntry) => e._source !== CONFIGMAP_SOURCE_MARKER);
+                }
+            } catch (e) {
+                this.logService.warn('[Che] Failed to parse existing keybindings, preserving ConfigMap entries only.', e);
+            }
+        }
+
+        const merged = [...userEntries, ...markedEntries];
+        this.logService.info(`[Che] Merging keybindings: ${userEntries.length} user + ${markedEntries.length} admin (ConfigMap).`);
+        await this.fileService.writeFile(resource, VSBuffer.fromString(JSON.stringify(merged, null, '\t')));
+    }
+
+    async initializeInstalledExtensions(_instantiationService: IInstantiationService): Promise<void> { }
+    async initializeOtherResources(_instantiationService: IInstantiationService): Promise<void> { }
+}
 
 // Get policy service from remote agent if available, otherwise use NullPolicyService
 export function getPolicyService(remoteAgentService: IRemoteAgentService, logService: ILogService, remoteAuthority?: string): IPolicyService {

--- a/code/src/vs/workbench/browser/web.api.ts
+++ b/code/src/vs/workbench/browser/web.api.ts
@@ -300,6 +300,12 @@ export interface IWorkbenchConstructionOptions {
 
 	//#endregion
 
+	/**
+	 * Initial keybindings content from ConfigMap (JSON array string).
+	 * When set, keybindings are merged into IndexedDB on every workspace start.
+	 */
+	readonly cheInitialKeybindings?: string;
+
 	//#region Profile options
 
 	/**

--- a/code/src/vs/workbench/browser/web.main.ts
+++ b/code/src/vs/workbench/browser/web.main.ts
@@ -96,7 +96,7 @@ import { ISecretStorageService } from '../../platform/secrets/common/secrets.js'
 import { TunnelSource } from '../services/remote/common/tunnelModel.js';
 import { mainWindow } from '../../base/browser/window.js';
 import { INotificationService, Severity } from '../../platform/notification/common/notification.js';
-import { getPolicyService } from './che/web.js';
+import { CheKeybindingsInitializer, getPolicyService } from './che/web.js';
 import { IDefaultAccountService } from '../../platform/defaultAccount/common/defaultAccount.js';
 import { DefaultAccountService } from '../services/accounts/browser/defaultAccount.js';
 import { AccountPolicyService } from '../services/policies/common/accountPolicyService.js';
@@ -438,6 +438,9 @@ export class BrowserMain extends Disposable {
 		userDataInitializers.push(new UserDataSyncInitializer(environmentService, secretStorageService, userDataSyncStoreManagementService, fileService, userDataProfilesService, storageService, productService, requestService, logService, uriIdentityService));
 		if (environmentService.options.profile) {
 			userDataInitializers.push(new UserDataProfileInitializer(environmentService, fileService, userDataProfileService, storageService, logService, uriIdentityService, requestService));
+		}
+		if (environmentService.options.cheInitialKeybindings) {
+			userDataInitializers.push(new CheKeybindingsInitializer(environmentService.options.cheInitialKeybindings, fileService, userDataProfilesService, logService));
 		}
 		const userDataInitializationService = new UserDataInitializationService(userDataInitializers);
 		serviceCollection.set(IUserDataInitializationService, userDataInitializationService);

--- a/rebase.sh
+++ b/rebase.sh
@@ -428,6 +428,8 @@ resolve_conflicts() {
       apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/web.main.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/src/vs/workbench/browser/web.api.ts" ]]; then
+      apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/server/node/serverServices.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/server/node/serverEnvironmentService.ts" ]]; then


### PR DESCRIPTION
**TODO:**
- doc PR: https://github.com/eclipse-che/che-docs/pull/3166

### What does this PR do?
Adds ability to provide keybindings via the `vscode-editor-configurations` ConfigMap.

- Server reads `keybindings.json` from the ConfigMap mount path and passes content to the browser
- `CheKeybindingsInitializer` merges ConfigMap keybindings into `IndexedDB` on every workspace start
- Admin entries are tagged with `"_source": "configmap"` and appended at the end of the array — VS Code gives them priority (later entries win)
- On next start, old admin entries are replaced with current ConfigMap content; user entries are preserved

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-9166

### How to test this PR?

1. Add `keybindings.json` to the `vscode-editor-configurations` ConfigMap, see https://eclipse.dev/che/docs/stable/administration-guide/editor-configurations-for-microsoft-visual-studio-code/
   ```
   keybindings.json: |
    [
      {
        "key": "ctrl+shift+t",
        "command": "workbench.action.terminal.new"
      },
      {
        "key": "ctrl+shift+k",
        "command": "workbench.action.terminal.kill"
      },
      { 
        "key": "alt+cmd+n",
        "command": "-workbench.action.files.newUntitledFile"
      }
    ]
   ```
2. Start a workspace — verify:
  - `ctrl+shift+t` opens a terminal 
  - `ctrl+shift+k` kills a terminal
  -   `alt+cmd+n` does not create a new file anymore: there is `-` before the command
   
3. Add a custom keybinding via UI, restart — verify it's preserved
4. Update ConfigMap with a new keybinding, restart — verify it appears

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading initial CodePilot/CHE keybindings from a mounted configuration file.
  * Initial keybindings are merged into the user profile each time a workspace starts.
  * Existing administrator-provided keybindings are replaced cleanly while preserving user-defined keybindings.
  * Added support for improved web client redirect handling.

* **Bug Fixes**
  * Added validation and fallback handling for invalid or unavailable keybinding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->