### PR TITLE
fix: enable CentOS Stream repos for UBI9 aarch64 build deps

### DIFF
--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -20,6 +20,14 @@ ENV GITHUB_TOKEN=$GITHUB_TOKEN
 # For example, vscode ripgrep downloading is an example of such case.
 RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi
 
+# UBI AppStream can temporarily omit packages on some arches (seen on aarch64).
+# Enable CentOS Stream repos so build deps resolve reliably.
+RUN ARCH=$(uname -m) \
+    && yum install -y \
+      "https://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-9.0-38.el9.noarch.rpm" \
+      "https://mirror.stream.centos.org/9-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-9.0-38.el9.noarch.rpm" \
+    && yum -y clean all && rm -rf /var/cache/yum
+
 # Install libsecret-devel on s390x and ppc64le for keytar build (binary included in npm package for x86)
 RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
       https://mirror.stream.centos.org/9-stream/AppStream/s390x/os/Packages/libsecret-0.20.4-4.el9.s390x.rpm \
@@ -31,8 +39,8 @@ RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
       https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/libsecret-devel-0.20.4-4.el9.x86_64.rpm \
       libsecret"; \
     elif [[ $(uname -m) == "aarch64" ]]; then LIBSECRET="\
-      https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/libsecret-devel-0.20.4-4.el9.aarch64.rpm \
-      libsecret"; \
+      https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/libsecret-0.20.4-4.el9.aarch64.rpm \
+      https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/libsecret-devel-0.20.4-4.el9.aarch64.rpm"; \
     else \
       LIBSECRET=""; echo "Warning: arch $(uname -m) not supported"; \
     fi; } \


### PR DESCRIPTION

### What does this PR do?
UBI AppStream stopped providing packages needed by the builder on aarch64 (libsecret, cmake, libX11-devel, etc.), causing yum install to fail. Fall back to CentOS Stream repos and pin libsecret RPMs.


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
Build is failing for ubi9-based asssebly
The error is:
```
Error: Unable to find a match: libsecret cmake libX11-devel libxkbcommon krb5-devel patch
```
Restarting the corresponding job few times didn't help me

### How to test this PR?
Jobs should pass successfully

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Assisted-by: Cursor AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux UBI 9 build configuration to enable CentOS Stream repositories.
  * Adjusted ARM64 libsecret dependency retrieval for improved build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->