### PR TITLE
fix: ensure node-gyp gyp entrypoints are executable in UBI builds

### DIFF
--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -69,6 +69,11 @@ RUN git init .
 # change network timeout (slow using multi-arch build)
 RUN npm config set fetch-retry-mintimeout 100000 && npm config set fetch-retry-maxtimeout 600000
 
+# node-gyp's make generator execs gyp entrypoints via shebang; UBI npm may ship them without +x
+RUN chmod +x \
+      /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py \
+      /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp
+
 # Grab dependencies (and force to rebuild them)
 RUN rm -rf /checode-compilation/node_modules && npm install --force
 

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -76,6 +76,11 @@ RUN git init .
 # change network timeout (slow using multi-arch build)
 RUN npm config set fetch-retry-mintimeout 100000 && npm config set fetch-retry-maxtimeout 600000
 
+# node-gyp's make generator execs gyp entrypoints via shebang; UBI npm may ship them without +x
+RUN chmod +x \
+      /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py \
+      /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp
+
 # Grab dependencies (and force to rebuild them)
 RUN rm -rf /checode-compilation/node_modules && npm install --force
 


### PR DESCRIPTION
### What does this PR do?
**Problem**
On UBI nodejs images, npm’s bundled node-gyp ships gyp/gyp_main.py and gyp/gyp without the execute bit. When make regenerates the Makefile during a native addon build (e.g. @vscode/deviceid), it runs those files via shebang and fails with Permission denied (exit 126). This only shows up when regeneration is triggered (timestamp race), so the failure looks intermittent.

**Solution**
Before npm install, set +x on those gyp entrypoints in the UBI8 and UBI9 Dockerfiles so make can exec them reliably whenever Makefile regeneration runs.

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
It fixes error like:
```
#12 24.16 npm error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
#12 24.16 npm error /bin/sh: /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py: Permission denied
#12 24.16 npm error make: *** [Makefile:343: Makefile] Error 126
``` 

### How to test this PR?
Jobs should pass successfully

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Assisted-by: Cursor AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved builds on UBI 8 and UBI 9 environments by ensuring required native build scripts have the correct executable permissions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->