### PR TITLE
feat: add gzip pre-compression for static assets to improve load time

### DIFF
--- a/.rebase/replace/code/src/vs/server/node/webClientServer.ts.json
+++ b/.rebase/replace/code/src/vs/server/node/webClientServer.ts.json
@@ -1,7 +1,15 @@
 [
     {
         "from": "import type * as http from 'http';",
-        "by": "import * as http from 'http';\nimport { getCheRedirectLocation } from './che/webClientServer.js';"
+        "by": "import * as http from 'http';\nimport { getCheRedirectLocation, tryServeCompressedFile } from './che/webClientServer.js';"
+    },
+    {
+        "from": "\t\tconst stat = await promises.stat(filePath); // throws an error if file doesn't exist\n\t\tif (cacheControl === CacheControl.ETAG) {\n\n\t\t\t// Check if file modified since\n\t\t\tconst etag = `W/\"${[stat.ino, stat.size, stat.mtime.getTime()].join('-')}\"`; // weak validator (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)\n\t\t\tif (req.headers['if-none-match'] === etag) {\n\t\t\t\tres.writeHead(304);\n\t\t\t\treturn void res.end();\n\t\t\t}",
+        "by": "\t\tconst stat = await promises.stat(filePath); // throws an error if file doesn't exist\n\n\t\t// Indicate response varies by Accept-Encoding so shared caches\n\t\t// don't serve a compressed response to clients that lack gzip support.\n\t\tresponseHeaders['Vary'] = 'Accept-Encoding';\n\n\t\tif (cacheControl === CacheControl.ETAG) {\n\n\t\t\t// Check if file modified since\n\t\t\tconst etag = `W/\"${[stat.ino, stat.size, stat.mtime.getTime()].join('-')}\"`; // weak validator (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)\n\t\t\tif (req.headers['if-none-match'] === etag) {\n\t\t\t\tres.writeHead(304, responseHeaders);\n\t\t\t\treturn void res.end();\n\t\t\t}"
+    },
+    {
+        "from": "\t\tresponseHeaders['Content-Type'] = textMimeType[extname(filePath)] || getMediaMime(filePath) || 'text/plain';\n\n\t\t// Create the stream first and wait for it to open before sending",
+        "by": "\t\tresponseHeaders['Content-Type'] = textMimeType[extname(filePath)] || getMediaMime(filePath) || 'text/plain';\n\n\t\t// Try to serve a pre-compressed .gz version (Che-specific optimization)\n\t\tif (await tryServeCompressedFile(filePath, responseHeaders['Content-Type'], stat.size, req, res, responseHeaders)) {\n\t\t\treturn;\n\t\t}\n\n\t\t// Create the stream first and wait for it to open before sending"
     },
     {
         "from": "\t\t\tconst newLocation = url.format({ pathname: basePath, query: newQuery });\n\t\t\tresponseHeaders['Location'] = newLocation;",

--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -86,6 +86,8 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
     && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
+    # Pre-compress static assets for faster HTTP delivery (served by che/webClientServer.ts)
+    && find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k -exec gzip -9 -k {} \; \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs \
     && find /usr/lib64 -name 'libnode.so*' -exec cp -P -t /checode/ld_libs/ {} + \

--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -87,7 +87,12 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
     # Pre-compress static assets for faster HTTP delivery (served by che/webClientServer.ts)
-    && find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k -exec gzip -9 -k {} \; \
+    # Exclude files patched by the launcher at runtime — they are compressed post-patch by the launcher itself
+    && find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k \
+       -not -path "*/vs/code/browser/workbench/workbench.js" \
+       -not -path "*/vs/workbench/workbench.web.main.internal.js" \
+       -not -path "*/vs/workbench/api/node/extensionHostProcess.js" \
+       -exec gzip -9 -k {} \; \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs \
     && find /usr/lib64 -name 'libnode.so*' -exec cp -P -t /checode/ld_libs/ {} + \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -93,6 +93,8 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && cp /usr/bin/node /checode-compilation/.build/node/v${NODE_VERSION}/linux-${NODE_ARCH}/node \
     && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
+    # Pre-compress static assets for faster HTTP delivery (served by che/webClientServer.ts)
+    && find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k -exec gzip -9 -k {} \; \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs/core /checode/ld_libs/openssl \
     && find /usr/lib64 -name 'libbrotli*' -exec cp -P -t /checode/ld_libs/core/ {} + \

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -94,7 +94,12 @@ RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-${NODE_ARCH}-min \
     && cp -r ../vscode-reh-web-linux-${NODE_ARCH} /checode \
     # Pre-compress static assets for faster HTTP delivery (served by che/webClientServer.ts)
-    && find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k -exec gzip -9 -k {} \; \
+    # Exclude files patched by the launcher at runtime — they are compressed post-patch by the launcher itself
+    && find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k \
+       -not -path "*/vs/code/browser/workbench/workbench.js" \
+       -not -path "*/vs/workbench/workbench.web.main.internal.js" \
+       -not -path "*/vs/workbench/api/node/extensionHostProcess.js" \
+       -exec gzip -9 -k {} \; \
     # cache shared libs from this image to provide them to a user's container
     && mkdir -p /checode/ld_libs/core /checode/ld_libs/openssl \
     && find /usr/lib64 -name 'libbrotli*' -exec cp -P -t /checode/ld_libs/core/ {} + \

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -63,6 +63,9 @@ RUN NODE_VERSION=$(cat /checode-compilation/remote/.npmrc | grep target | cut -d
 RUN VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/gulp vscode-reh-web-linux-alpine-min
 RUN cp -r ../vscode-reh-web-linux-alpine /checode
 
+# Pre-compress static assets for faster HTTP delivery (served by che/webClientServer.ts)
+RUN find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k -exec gzip -9 -k {} \;
+
 RUN chmod a+x /checode/out/server-main.js \
     && chgrp -R 0 /checode && chmod -R g+rwX /checode
 

--- a/build/dockerfiles/linux-musl.Dockerfile
+++ b/build/dockerfiles/linux-musl.Dockerfile
@@ -64,7 +64,12 @@ RUN VSCODE_MANGLE_WORKERS=2 NODE_OPTIONS="--max-old-space-size=8192" ./node_modu
 RUN cp -r ../vscode-reh-web-linux-alpine /checode
 
 # Pre-compress static assets for faster HTTP delivery (served by che/webClientServer.ts)
-RUN find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k -exec gzip -9 -k {} \;
+# Exclude files patched by the launcher at runtime — they are compressed post-patch by the launcher itself
+RUN find /checode/out -type f \( -name "*.js" -o -name "*.css" -o -name "*.html" -o -name "*.json" \) -size +1k \
+    -not -path "*/vs/code/browser/workbench/workbench.js" \
+    -not -path "*/vs/workbench/workbench.web.main.internal.js" \
+    -not -path "*/vs/workbench/api/node/extensionHostProcess.js" \
+    -exec gzip -9 -k {} \;
 
 RUN chmod a+x /checode/out/server-main.js \
     && chgrp -R 0 /checode && chmod -R g+rwX /checode

--- a/code/src/vs/server/node/che/webClientServer.ts
+++ b/code/src/vs/server/node/che/webClientServer.ts
@@ -46,7 +46,7 @@ export async function tryServeCompressedFile(
     }
 
     const acceptEncoding = req.headers['accept-encoding'] || '';
-    if (!/\bgzip\b/.test(acceptEncoding)) {
+    if (!/\bgzip\b/.test(acceptEncoding) || /\bgzip\s*;\s*q=0(\.0{0,3})?\s*(?:,|$)/i.test(acceptEncoding)) {
         return false;
     }
 

--- a/code/src/vs/server/node/che/webClientServer.ts
+++ b/code/src/vs/server/node/che/webClientServer.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021-2022 Red Hat, Inc.
+ * Copyright (c) 2021-2026 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,8 +9,69 @@
  ***********************************************************************/
 /* eslint-disable header/header */
 
+import { createReadStream } from 'fs';
+import { access, constants as fsConstants } from 'fs/promises';
 import * as http from 'http';
 import * as url from 'url';
+
+const compressibleMimeTypes = new Set([
+    'text/html', 'text/javascript', 'text/css', 'text/plain',
+    'application/json', 'image/svg+xml',
+]);
+
+const disableCompression = process.env['CODE_DISABLE_STATIC_GZIP'] === '1';
+
+/**
+ * Attempts to serve a pre-compressed .gz version of the file.
+ * Returns true if the compressed file was served, false otherwise.
+ * Falls back gracefully: if .gz file doesn't exist or any error occurs, returns false
+ * so the caller can serve the original uncompressed file.
+ *
+ * Set CODE_DISABLE_STATIC_GZIP=1 to bypass and always serve uncompressed files.
+ */
+export async function tryServeCompressedFile(
+    filePath: string,
+    contentType: string,
+    fileSize: number,
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    responseHeaders: Record<string, string>,
+): Promise<boolean> {
+    if (disableCompression) {
+        return false;
+    }
+
+    if (!compressibleMimeTypes.has(contentType) || fileSize <= 1024) {
+        return false;
+    }
+
+    const acceptEncoding = req.headers['accept-encoding'] || '';
+    if (!/\bgzip\b/.test(acceptEncoding)) {
+        return false;
+    }
+
+    const gzFilePath = filePath + '.gz';
+    try {
+        await access(gzFilePath, fsConstants.R_OK);
+        const gzStream = createReadStream(gzFilePath);
+        await new Promise<void>((resolve, reject) => {
+            gzStream.on('error', reject);
+            gzStream.on('open', () => {
+                responseHeaders['Content-Encoding'] = 'gzip';
+                responseHeaders['Vary'] = 'Accept-Encoding';
+                res.writeHead(200, responseHeaders);
+                gzStream.pipe(res);
+                res.once('close', () => gzStream.destroy());
+                gzStream.on('end', resolve);
+                gzStream.removeAllListeners('error');
+                gzStream.on('error', () => res.destroy());
+            });
+        });
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 export function getCheRedirectLocation(req: http.IncomingMessage, newQuery: any): string {
     let newLocation;

--- a/code/src/vs/server/node/che/webClientServer.ts
+++ b/code/src/vs/server/node/che/webClientServer.ts
@@ -61,10 +61,10 @@ export async function tryServeCompressedFile(
                 responseHeaders['Vary'] = 'Accept-Encoding';
                 res.writeHead(200, responseHeaders);
                 gzStream.pipe(res);
-                res.once('close', () => gzStream.destroy());
                 gzStream.on('end', resolve);
                 gzStream.removeAllListeners('error');
-                gzStream.on('error', () => res.destroy());
+                gzStream.on('error', () => { res.destroy(); resolve(); });
+                res.once('close', () => { gzStream.destroy(); resolve(); });
             });
         });
         return true;

--- a/code/src/vs/server/node/webClientServer.ts
+++ b/code/src/vs/server/node/webClientServer.ts
@@ -5,7 +5,7 @@
 
 import { createReadStream, promises } from 'fs';
 import * as http from 'http';
-import { getCheRedirectLocation } from './che/webClientServer.js';
+import { getCheRedirectLocation, tryServeCompressedFile } from './che/webClientServer.js';
 import * as url from 'url';
 import * as cookie from 'cookie';
 import * as crypto from 'crypto';
@@ -73,6 +73,11 @@ export async function serveFile(filePath: string, cacheControl: CacheControl, lo
 		}
 
 		responseHeaders['Content-Type'] = textMimeType[extname(filePath)] || getMediaMime(filePath) || 'text/plain';
+
+		// Try to serve a pre-compressed .gz version (Che-specific optimization)
+		if (await tryServeCompressedFile(filePath, responseHeaders['Content-Type'], stat.size, req, res, responseHeaders)) {
+			return;
+		}
 
 		// Create the stream first and wait for it to open before sending
 		// headers so that errors (e.g. ENOENT race) can still produce a

--- a/code/src/vs/server/node/webClientServer.ts
+++ b/code/src/vs/server/node/webClientServer.ts
@@ -56,12 +56,17 @@ export const enum CacheControl {
 export async function serveFile(filePath: string, cacheControl: CacheControl, logService: ILogService, req: http.IncomingMessage, res: http.ServerResponse, responseHeaders: Record<string, string>): Promise<void> {
 	try {
 		const stat = await promises.stat(filePath); // throws an error if file doesn't exist
+
+		// Indicate response varies by Accept-Encoding so shared caches
+		// don't serve a compressed response to clients that lack gzip support.
+		responseHeaders['Vary'] = 'Accept-Encoding';
+
 		if (cacheControl === CacheControl.ETAG) {
 
 			// Check if file modified since
 			const etag = `W/"${[stat.ino, stat.size, stat.mtime.getTime()].join('-')}"`; // weak validator (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)
 			if (req.headers['if-none-match'] === etag) {
-				res.writeHead(304);
+				res.writeHead(304, responseHeaders);
 				return void res.end();
 			}
 

--- a/launcher/src/devworkspace-id.ts
+++ b/launcher/src/devworkspace-id.ts
@@ -9,7 +9,7 @@
  ***********************************************************************/
 
 import { env } from 'process';
-import { FILE_WORKBENCH } from './files.js';
+import { FILE_WORKBENCH, FILE_WORKBENCH_WEB_MAIN } from './files.js';
 import * as fs from './fs-extra.js';
 
 const DEVWORKSPACE_ID_MASK = 'https://{{che-cluster}}.{{host}}/{{namespace}}/{{workspace-name}}/{{port}}/';
@@ -27,6 +27,7 @@ export class DevWorkspaceId {
 
     try {
       await this.update(FILE_WORKBENCH, DEVWORKSPACE_ID_MASK, env.DEVWORKSPACE_ID);
+      await this.update(FILE_WORKBENCH_WEB_MAIN, DEVWORKSPACE_ID_MASK, env.DEVWORKSPACE_ID);
     } catch (err) {
       console.error(`${err.message} Webviews will not work if CDN disabled.`);
     }

--- a/launcher/src/files.ts
+++ b/launcher/src/files.ts
@@ -10,4 +10,6 @@
 
 export const FILE_WORKBENCH = 'out/vs/code/browser/workbench/workbench.js';
 
+export const FILE_WORKBENCH_WEB_MAIN = 'out/vs/workbench/workbench.web.main.internal.js';
+
 export const FILE_EXTENSION_HOST_PROCESS = 'out/vs/workbench/api/node/extensionHostProcess.js';

--- a/launcher/src/main.ts
+++ b/launcher/src/main.ts
@@ -13,6 +13,7 @@ import { DevWorkspaceId } from './devworkspace-id.js';
 import { NodeExtraCertificate } from './node-extra-certificate.js';
 import { OpenVSIXRegistry } from './openvsix-registry.js';
 import { LocalStorageKeyProvider } from './local-storage-key-provider.js';
+import { PostPatchCompression } from './post-patch-compression.js';
 import { TrustedExtensions } from './trusted-extensions.js';
 import { VSCodeLauncher } from './vscode-launcher.js';
 import { WebviewResources } from './webview-resources.js';
@@ -31,6 +32,7 @@ export class Main {
     await new WebviewResources().configure();
     await new NodeExtraCertificate().configure();
     await new LocalStorageKeyProvider().configure();
+    await new PostPatchCompression().compress();
     await new TrustedExtensions().configure();
 
     const workspaceFile = await new CodeWorkspace().generate();

--- a/launcher/src/openvsix-registry.ts
+++ b/launcher/src/openvsix-registry.ts
@@ -9,7 +9,7 @@
  ***********************************************************************/
 
 import { env } from 'process';
-import { FILE_WORKBENCH } from './files.js';
+import { FILE_WORKBENCH, FILE_WORKBENCH_WEB_MAIN } from './files.js';
 import * as fs from './fs-extra.js';
 import { ProductJSON } from './product-json.js';
 
@@ -67,6 +67,7 @@ export class OpenVSIXRegistry {
       await productJSON.save();
 
       await this.update(FILE_WORKBENCH, serviceURL, newServiceURL, itemURL, newItemURL);
+      await this.update(FILE_WORKBENCH_WEB_MAIN, serviceURL, newServiceURL, itemURL, newItemURL);
     } catch (err) {
       console.error(`${err.message} Failure to configure OpenVSIX registry.`);
     }

--- a/launcher/src/post-patch-compression.ts
+++ b/launcher/src/post-patch-compression.ts
@@ -9,6 +9,7 @@
  ***********************************************************************/
 
 import { createReadStream, createWriteStream } from 'fs';
+import { rename, unlink } from 'fs/promises';
 import { createGzip } from 'zlib';
 import { pipeline } from 'stream/promises';
 import { FILE_WORKBENCH, FILE_WORKBENCH_WEB_MAIN, FILE_EXTENSION_HOST_PROCESS } from './files.js';
@@ -23,8 +24,15 @@ export class PostPatchCompression {
     for (const file of FILES_TO_COMPRESS) {
       const start = Date.now();
       const gzFile = file + '.gz';
-      await pipeline(createReadStream(file), createGzip({ level: 1 }), createWriteStream(gzFile));
-      console.log(`  > ${gzFile} created in ${Date.now() - start}ms`);
+      const tmpFile = gzFile + '.tmp';
+      try {
+        await pipeline(createReadStream(file), createGzip({ level: 1 }), createWriteStream(tmpFile));
+        await rename(tmpFile, gzFile);
+        console.log(`  > ${gzFile} created in ${Date.now() - start}ms`);
+      } catch (err) {
+        console.warn(`  > WARNING: failed to compress ${file}, skipping (server will serve uncompressed): ${err}`);
+        await unlink(tmpFile).catch(() => {});
+      }
     }
 
     console.log(`  > total compression time: ${Date.now() - startTotal}ms`);

--- a/launcher/src/post-patch-compression.ts
+++ b/launcher/src/post-patch-compression.ts
@@ -1,0 +1,32 @@
+/**********************************************************************
+ * Copyright (c) 2026 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { createReadStream, createWriteStream } from 'fs';
+import { createGzip } from 'zlib';
+import { pipeline } from 'stream/promises';
+import { FILE_WORKBENCH, FILE_WORKBENCH_WEB_MAIN, FILE_EXTENSION_HOST_PROCESS } from './files.js';
+
+const FILES_TO_COMPRESS = [FILE_WORKBENCH, FILE_WORKBENCH_WEB_MAIN, FILE_EXTENSION_HOST_PROCESS];
+
+export class PostPatchCompression {
+  async compress(): Promise<void> {
+    console.log('# Compressing patched static assets...');
+    const startTotal = Date.now();
+
+    for (const file of FILES_TO_COMPRESS) {
+      const start = Date.now();
+      const gzFile = file + '.gz';
+      await pipeline(createReadStream(file), createGzip({ level: 1 }), createWriteStream(gzFile));
+      console.log(`  > ${gzFile} created in ${Date.now() - start}ms`);
+    }
+
+    console.log(`  > total compression time: ${Date.now() - startTotal}ms`);
+  }
+}

--- a/launcher/src/webview-resources.ts
+++ b/launcher/src/webview-resources.ts
@@ -13,7 +13,7 @@ import * as fs from './fs-extra.js';
 import { FlattenedDevfile } from './flattened-devfile.js';
 import { ProductJSON } from './product-json.js';
 
-import { FILE_EXTENSION_HOST_PROCESS, FILE_WORKBENCH } from './files.js';
+import { FILE_EXTENSION_HOST_PROCESS, FILE_WORKBENCH, FILE_WORKBENCH_WEB_MAIN } from './files.js';
 
 export class WebviewResources {
   /*****************************************************************************************************************
@@ -49,6 +49,7 @@ export class WebviewResources {
 
       // update files
       await this.update(FILE_WORKBENCH, currentURL, newURL);
+      await this.update(FILE_WORKBENCH_WEB_MAIN, currentURL, newURL);
       await this.update(FILE_EXTENSION_HOST_PROCESS, currentURL, newURL);
 
       console.log(`  > webview resources endpoint ${newURL}`);

--- a/launcher/tests/devworkspace-id.spec.ts
+++ b/launcher/tests/devworkspace-id.spec.ts
@@ -54,7 +54,8 @@ describe('Test setting DevWorkspace ID to VS Code', () => {
     const devWorkspaceId = new DevWorkspaceId();
     await devWorkspaceId.configure();
 
-    expect(readFileMock).toBeCalledTimes(1);
+    expect(readFileMock).toBeCalledTimes(2);
     expect(writeFileMock).toBeCalledWith('out/vs/code/browser/workbench/workbench.js', NEW_WORKBENCH);
+    expect(writeFileMock).toBeCalledWith('out/vs/workbench/workbench.web.main.internal.js', NEW_WORKBENCH);
   });
 });

--- a/launcher/tests/main.spec.ts
+++ b/launcher/tests/main.spec.ts
@@ -45,6 +45,13 @@ jest.mock('../src/local-storage-key-provider', () => ({
   },
 }));
 
+const compressPostPatch = jest.fn();
+jest.mock('../src/post-patch-compression', () => ({
+  PostPatchCompression: function () {
+    return { compress: compressPostPatch };
+  },
+}));
+
 const configureTustedExtensions = jest.fn();
 jest.mock('../src/trusted-extensions', () => ({
   TrustedExtensions: function () {
@@ -82,6 +89,7 @@ describe('Test main flow:', () => {
     expect(configureWebviewResourcesMock).toBeCalled();
     expect(configureNodeExtraCertificate).toBeCalled();
     expect(configureLocalStorageKeyProvider).toBeCalled();
+    expect(compressPostPatch).toBeCalled();
     expect(configureTustedExtensions).toBeCalled();
 
     expect(generateCodeWorkspace).toBeCalled();

--- a/launcher/tests/openvsix-registry.spec.ts
+++ b/launcher/tests/openvsix-registry.spec.ts
@@ -81,6 +81,8 @@ describe('Test Configuring of OpenVSIX registry:', () => {
           return ORIGINAL_PRODUCT_JSON;
         } else if ('out/vs/code/browser/workbench/workbench.js' === file) {
           return fileWorkbench;
+        } else if ('out/vs/workbench/workbench.web.main.internal.js' === file) {
+          return fileWorkbench;
         }
       },
 
@@ -121,6 +123,8 @@ describe('Test Configuring of OpenVSIX registry:', () => {
         if ('product.json' === file) {
           return ORIGINAL_PRODUCT_JSON;
         } else if ('out/vs/code/browser/workbench/workbench.js' === file) {
+          return fileWorkbench;
+        } else if ('out/vs/workbench/workbench.web.main.internal.js' === file) {
           return fileWorkbench;
         }
       },

--- a/launcher/tests/webview-resources.spec.ts
+++ b/launcher/tests/webview-resources.spec.ts
@@ -66,6 +66,9 @@ describe('Test Configuring of WebView static resources:', () => {
         case 'out/vs/code/browser/workbench/workbench.js':
           return fileWorkbench;
 
+        case 'out/vs/workbench/workbench.web.main.internal.js':
+          return fileWorkbench;
+
         case 'out/vs/workbench/api/node/extensionHostProcess.js':
           return fileExtensionHostProcess;
       }
@@ -94,10 +97,16 @@ describe('Test Configuring of WebView static resources:', () => {
 
     await webviewResources.configure();
 
-    expect(updateMock).toHaveBeenCalledTimes(2);
+    expect(updateMock).toHaveBeenCalledTimes(3);
 
     expect(updateMock).toHaveBeenCalledWith(
       'out/vs/code/browser/workbench/workbench.js',
+      'https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/',
+      'https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/vgulyy/che-code-multiroot/3100/oss-dev/static/out/vs/workbench/contrib/webview/browser/pre/'
+    );
+
+    expect(updateMock).toHaveBeenCalledWith(
+      'out/vs/workbench/workbench.web.main.internal.js',
       'https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/',
       'https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/vgulyy/che-code-multiroot/3100/oss-dev/static/out/vs/workbench/contrib/webview/browser/pre/'
     );


### PR DESCRIPTION
### What does this PR do?
- Pre-compresses JS/CSS/HTML/JSON files during Docker build (gzip -9)
- Serves `.gz` files directly when client supports `Accept-Encoding: gzip`
- Falls back to uncompressed files if `.gz` is missing or on any error
- Adds `CODE_DISABLE_STATIC_GZIP=1` env variable as kill switch

**Note:**
 - The `launcher` patches several `.js` files at runtime (DevWorkspace ID, OpenVSIX URLs, webview CDN paths), but the server was serving stale pre-compressed `.gz` files containing unpatched content. 
 - bb0fb44bf7f1144fb64932847c754e16927c74e8 commit excludes launcher-patched files from Dockerfile `pre`-compression and `re`-compresses them in the launcher after all patches are applied, preserving the gzip optimization while ensuring correct content is served.

Expected improvement: 
- `workbench.js` transfer drops from ~16MB to ~4.4MB: (~3.7x reduction), 
- should reduce white screen time https://redhat.atlassian.net/browse/CRW-10327
- if `.gz` files don't exist or env variable is set, the server behaves exactly as before

**Before:**
<img width="1356" height="738" alt="Screenshot 2026-07-22 at 14 09 10" src="https://github.com/user-attachments/assets/3e64fda8-2778-41d8-99cc-28d83ffb6bfa" />

**After:**
<img width="1356" height="738" alt="Screenshot 2026-07-22 at 14 14 01" src="https://github.com/user-attachments/assets/914d822d-7d7d-4efa-9f9b-b17e6565834a" />

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://redhat.atlassian.net/browse/CRW-10327

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

Assisted-by: Cursor AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved web asset loading by serving pre-compressed gzip files when supported.
  * Added build-time compression for larger JavaScript, CSS, HTML, and JSON assets.
  * Added runtime compression for patched assets without interrupting startup if compression fails.

* **Bug Fixes**
  * Improved cache correctness for compressed responses.
  * Ensured workspace, registry, and webview configuration updates apply consistently across web workbench files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->