### PR TITLE
[7.119] override undici to patched versions

### DIFF
--- a/code/extensions/copilot/chat-lib/package-lock.json
+++ b/code/extensions/copilot/chat-lib/package-lock.json
@@ -20,7 +20,7 @@
 				"jsonc-parser": "^3.3.1",
 				"monaco-editor": "0.44.0",
 				"openai": "^6.7.0",
-				"undici": "^7.24.1",
+				"undici": "^7.28.0",
 				"vscode-languageserver-protocol": "^3.17.5",
 				"vscode-languageserver-textdocument": "^1.0.12",
 				"web-tree-sitter": "^0.23.0",
@@ -4792,9 +4792,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-			"integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"

--- a/code/extensions/copilot/chat-lib/package.json
+++ b/code/extensions/copilot/chat-lib/package.json
@@ -24,7 +24,7 @@
 		"jsonc-parser": "^3.3.1",
 		"monaco-editor": "0.44.0",
 		"openai": "^6.7.0",
-		"undici": "^7.24.1",
+		"undici": "^7.28.0",
 		"vscode-languageserver-protocol": "^3.17.5",
 		"vscode-languageserver-textdocument": "^1.0.12",
 		"web-tree-sitter": "^0.23.0",

--- a/code/extensions/copilot/package-lock.json
+++ b/code/extensions/copilot/package-lock.json
@@ -51,7 +51,7 @@
 				"lru-cache": "^11.1.0",
 				"markdown-it": "^14.1.1",
 				"minimatch": "^10.2.1",
-				"undici": "^7.24.1",
+				"undici": "^7.28.0",
 				"vscode-tas-client": "^0.1.84",
 				"web-tree-sitter": "^0.23.0"
 			},
@@ -21343,9 +21343,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-			"integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -22407,9 +22407,9 @@
 			}
 		},
 		"node_modules/webdriver/node_modules/undici": {
-			"version": "6.24.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-			"integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/code/extensions/copilot/package.json
+++ b/code/extensions/copilot/package.json
@@ -6390,7 +6390,7 @@
 		"lru-cache": "^11.1.0",
 		"markdown-it": "^14.1.1",
 		"minimatch": "^10.2.1",
-		"undici": "^7.24.1",
+		"undici": "^7.28.0",
 		"vscode-tas-client": "^0.1.84",
 		"web-tree-sitter": "^0.23.0"
 	},
@@ -6401,7 +6401,10 @@
 		"zod": "3.25.76",
 		"shell-quote": "^1.8.4",
 		"ip-address": "^10.2.0",
-		"ws": "^8.21.0"
+		"ws": "^8.21.0",
+		"webdriver": {
+			"undici@6": "^6.27.0"
+		}
 	},
 	"vscodeCommit": "94c8e2adc50e26ef70af85a0de3a9efed757acaa",
 	"__metadata": {

--- a/code/extensions/notebook-renderers/package-lock.json
+++ b/code/extensions/notebook-renderers/package-lock.json
@@ -605,9 +605,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-			"integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/code/extensions/notebook-renderers/package.json
+++ b/code/extensions/notebook-renderers/package.json
@@ -52,6 +52,9 @@
 		"@types/vscode-notebook-renderer": "^1.60.0",
 		"jsdom": "^28.1.0"
 	},
+	"overrides": {
+		"undici": "^7.28.0"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/vscode.git"

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -61,7 +61,7 @@
         "playwright-core": "1.59.1",
         "ssh2": "^1.16.0",
         "tas-client": "0.3.1",
-        "undici": "^7.24.0",
+        "undici": "^7.28.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -18277,9 +18277,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -18759,9 +18759,9 @@
       }
     },
     "node_modules/webdriver/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/code/package.json
+++ b/code/package.json
@@ -137,7 +137,7 @@
     "playwright-core": "1.59.1",
     "ssh2": "^1.16.0",
     "tas-client": "0.3.1",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "v8-inspect-profiler": "^0.1.1",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",
@@ -272,6 +272,9 @@
     "ip-address": "^10.2.0",
     "chrome-remote-interface": {
       "ws": "^7.5.11"
+    },
+    "webdriver": {
+      "undici@6": "^6.27.0"
     }
   },
   "repository": {

--- a/code/remote/package-lock.json
+++ b/code/remote/package-lock.json
@@ -2327,9 +2327,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/code/remote/package.json
+++ b/code/remote/package.json
@@ -58,6 +58,7 @@
       "cpu-features": "0.0.0"
     },
     "shell-quote": "^1.8.4",
-    "ip-address": "^10.2.0"
+    "ip-address": "^10.2.0",
+    "undici": "^7.28.0"
   }
 }

--- a/rebase.sh
+++ b/rebase.sh
@@ -506,6 +506,8 @@ resolve_conflicts() {
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/test/smoke/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/notebook-renderers/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
     else
       # Smart fallback: check if the file has che-specific changes
       local upstream_path="${conflictingFile#code/}"


### PR DESCRIPTION

### What does this PR do?
Fix CVE-2026-12151, CVE-2026-9697, CVE-2026-6734 by updating undici to 7.28.0

backport of #739 


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
