### PR TITLE
[7.119] override brace-expansion to patched version

### DIFF
--- a/code/build/package-lock.json
+++ b/code/build/package-lock.json
@@ -2180,9 +2180,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/code/build/package.json
+++ b/code/build/package.json
@@ -79,6 +79,9 @@
     "path-scurry": {
       "lru-cache": "11.2.1"
     },
-    "lodash": "^4.18.1"
+    "lodash": "^4.18.1",
+    "@vscode/vsce": {
+      "brace-expansion": "5.0.7"
+    }
   }
 }

--- a/code/extensions/copilot/chat-lib/package-lock.json
+++ b/code/extensions/copilot/chat-lib/package-lock.json
@@ -3234,9 +3234,9 @@
 			}
 		},
 		"node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/code/extensions/copilot/chat-lib/package.json
+++ b/code/extensions/copilot/chat-lib/package.json
@@ -45,7 +45,10 @@
 		"vitest": "^3.0.5"
 	},
 	"overrides": {
-		"shell-quote": "^1.8.4"
+		"shell-quote": "^1.8.4",
+		"minimatch@10": {
+			"brace-expansion": "5.0.7"
+		}
 	},
 	"keywords": [
 		"chat",

--- a/code/extensions/copilot/package-lock.json
+++ b/code/extensions/copilot/package-lock.json
@@ -15848,9 +15848,9 @@
 			}
 		},
 		"node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"

--- a/code/extensions/copilot/package.json
+++ b/code/extensions/copilot/package.json
@@ -6401,7 +6401,8 @@
 		"zod": "3.25.76",
 		"shell-quote": "^1.8.4",
 		"ip-address": "^10.2.0",
-		"ws": "^8.21.0"
+		"ws": "^8.21.0",
+		"brace-expansion@5": "5.0.7"
 	},
 	"vscodeCommit": "94c8e2adc50e26ef70af85a0de3a9efed757acaa",
 	"__metadata": {

--- a/code/extensions/css-language-features/package-lock.json
+++ b/code/extensions/css-language-features/package-lock.json
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/code/extensions/css-language-features/package.json
+++ b/code/extensions/css-language-features/package.json
@@ -1000,6 +1000,11 @@
   "devDependencies": {
     "@types/node": "22.x"
   },
+  "overrides": {
+    "minimatch": {
+      "brace-expansion": "5.0.7"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"

--- a/code/extensions/html-language-features/package-lock.json
+++ b/code/extensions/html-language-features/package-lock.json
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/code/extensions/html-language-features/package.json
+++ b/code/extensions/html-language-features/package.json
@@ -271,6 +271,11 @@
   "devDependencies": {
     "@types/node": "22.x"
   },
+  "overrides": {
+    "minimatch": {
+      "brace-expansion": "5.0.7"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"

--- a/code/extensions/json-language-features/package-lock.json
+++ b/code/extensions/json-language-features/package-lock.json
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/code/extensions/json-language-features/package.json
+++ b/code/extensions/json-language-features/package.json
@@ -195,6 +195,11 @@
   "devDependencies": {
     "@types/node": "22.x"
   },
+  "overrides": {
+    "minimatch": {
+      "brace-expansion": "5.0.7"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -17570,9 +17570,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/code/package.json
+++ b/code/package.json
@@ -272,6 +272,9 @@
     "ip-address": "^10.2.0",
     "chrome-remote-interface": {
       "ws": "^7.5.11"
+    },
+    "test-exclude": {
+      "brace-expansion@5": "5.0.7"
     }
   },
   "repository": {


### PR DESCRIPTION
### What does this PR do?
backport of #745 

### What issues does this PR fix?


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
