### PR TITLE
[DO NOT MERGE] Build CheCode editor image to test PR-363

### DIFF
--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -12,7 +12,7 @@ FROM linux-libc-ubi9 as linux-libc-ubi9-content
 FROM linux-musl as linux-musl-content
 
 # https://quay.io/eclipse/che-machine-exec#^7\.
-FROM quay.io/rnikitenko/che-machine-exec:latest as machine-exec
+FROM quay.io/vrubezhny/che-machine-exec:PR-363-01 as machine-exec
 
 # https://registry.access.redhat.com/ubi8/ubi
 FROM registry.access.redhat.com/ubi8/ubi:8.10 AS ubi-builder

--- a/build/dockerfiles/assembly.Dockerfile
+++ b/build/dockerfiles/assembly.Dockerfile
@@ -12,7 +12,7 @@ FROM linux-libc-ubi9 as linux-libc-ubi9-content
 FROM linux-musl as linux-musl-content
 
 # https://quay.io/eclipse/che-machine-exec#^7\.
-FROM quay.io/eclipse/che-machine-exec:7.56.0 as machine-exec
+FROM quay.io/rnikitenko/che-machine-exec:latest as machine-exec
 
 # https://registry.access.redhat.com/ubi8/ubi
 FROM registry.access.redhat.com/ubi8/ubi:8.10 AS ubi-builder
@@ -26,16 +26,18 @@ COPY --from=linux-musl-content --chown=0:0 /checode-linux-musl /mnt/rootfs/checo
 COPY --from=linux-libc-ubi8-content --chown=0:0 /checode-linux-libc/ubi8 /mnt/rootfs/checode-linux-libc/ubi8
 COPY --from=linux-libc-ubi9-content --chown=0:0 /checode-linux-libc/ubi9 /mnt/rootfs/checode-linux-libc/ubi9
 
-RUN mkdir -p /mnt/rootfs/projects && mkdir -p /mnt/rootfs/home/che && mkdir -p /mnt/rootfs/bin/
+RUN mkdir -p /mnt/rootfs/projects && mkdir -p /mnt/rootfs/home/che
 RUN cat /mnt/rootfs/etc/passwd | sed s#root:x.*#root:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g > /mnt/rootfs/home/che/.passwd.template \
     && cat /mnt/rootfs/etc/group | sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g > /mnt/rootfs/home/che/.group.template
-RUN for f in "/mnt/rootfs/bin/" "/mnt/rootfs/home/che" "/mnt/rootfs/etc/group" "/mnt/rootfs/projects" ; do\
+RUN for f in "/mnt/rootfs/home/che" "/mnt/rootfs/etc/group" "/mnt/rootfs/projects" ; do\
            chgrp -R 0 ${f} && \
            chmod -R g+rwX ${f}; \
        done
 RUN chmod -R g-w /mnt/rootfs/etc/passwd
 
-COPY --from=machine-exec --chown=0:0 /go/bin/che-machine-exec /mnt/rootfs/bin/machine-exec
+COPY --from=machine-exec --chown=0:0 /go/ubi8/bin/che-machine-exec /mnt/rootfs/checode-linux-libc/ubi8/machine-exec
+COPY --from=machine-exec --chown=0:0 /go/ubi9/bin/che-machine-exec /mnt/rootfs/checode-linux-libc/ubi9/machine-exec
+COPY --from=machine-exec --chown=0:0 /go/bin/che-machine-exec /mnt/rootfs/checode-linux-musl/machine-exec
 COPY --chmod=755 /build/scripts/*.sh /mnt/rootfs/
 COPY --chmod=755 /build/remote-config /mnt/rootfs/remote/data/Machine/
 

--- a/build/scripts/entrypoint-init-container.sh
+++ b/build/scripts/entrypoint-init-container.sh
@@ -13,9 +13,6 @@
 
 # Copy checode stuff to the shared volume
 cp -r /checode-* /checode/
-# Copy machine-exec as well
-mkdir -p /checode/bin
-cp /bin/machine-exec /checode/bin/
 # Copy entrypoint
 cp /entrypoint-volume.sh /checode/
 # Copy remote configuration

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -69,10 +69,6 @@ fi
 # list checode
 ls -la /checode/
 
-# Start the machine-exec component in background
-export MACHINE_EXEC_PORT=3333
-nohup /checode/bin/machine-exec --url "127.0.0.1:${MACHINE_EXEC_PORT}" &
-
 runtime_ld_library_path=""
 
 # detect if we're using alpine/musl (avoid grep dependency for micro images)
@@ -125,6 +121,10 @@ export VSCODE_AGENT_FOLDER=/checode/remote
 # Controls where LD_LIBRARY_PATH sanitization is applied.
 # Supported values: all | none | shellEnv | terminal
 export LD_SANITIZE_SCOPE="${LD_SANITIZE_SCOPE:-terminal}"
+
+# Start the machine-exec component in background
+export MACHINE_EXEC_PORT=3333
+nohup ./machine-exec --url "127.0.0.1:${MACHINE_EXEC_PORT}" &
 
 if [ -z "$VSCODE_NODEJS_RUNTIME_DIR" ]; then
   export VSCODE_NODEJS_RUNTIME_DIR="$(pwd)"


### PR DESCRIPTION
### What does this PR do?

Opened to create a CheCode editor image to test:

https://github.com/eclipse-che/che-machine-exec/pull/363

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup and initialization of the machine execution service.
  * Added support for machine execution binaries across UBI 8, UBI 9, and musl environments.
  * Updated shared runtime volume setup to include the required CheCode components.
  * Improved execution reliability by starting the service from its correct runtime location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->