### PR TITLE
fix: override axios to patched version

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,7 +3,7 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
-https://github.com/che-incubator/che-code/pull/
+https://github.com/che-incubator/che-code/pull/770
 
 - code/package.json
 ---

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,6 +3,12 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
+https://github.com/che-incubator/che-code/pull/
+
+- code/package.json
+---
+
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/750
 
 - code/extensions/copilot/package.json

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -27,6 +27,9 @@
         },
         "form-data@3": "^3.0.5",
         "form-data@4": "^4.0.6",
+        "@microsoft/dev-tunnels-management": {
+            "axios": "1.15.2"
+        },
         "axios": {
             "form-data": "^4.0.6"
         },

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -5505,9 +5505,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/code/package.json
+++ b/code/package.json
@@ -282,6 +282,9 @@
     },
     "form-data@3": "^3.0.5",
     "form-data@4": "^4.0.6",
+    "@microsoft/dev-tunnels-management": {
+      "axios": "1.15.2"
+    },
     "axios": {
       "form-data": "^4.0.6"
     },


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2026-42264](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj)

`axios` versions are updated to `1.15.2`

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-11639


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
