### PR TITLE
[7.119] Update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2025 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -35,17 +35,20 @@ jobs:
             echo arch="arm64" >> $GITHUB_ENV
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Docker Build
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker buildx build --memory-swap -1 --memory 10g --platform linux/${{env.arch}} -f build/dockerfiles/linux-${{matrix.dist}}.Dockerfile --load -t linux-${{matrix.dist}}-${{env.arch}} .
-      - name: Upload image
-        uses: ishworkh/container-image-artifact-upload@v2.0.0
+      - name: Compress image to a file
+        run: docker save linux-${{matrix.dist}}-${{env.arch}} | gzip > linux-${{matrix.dist}}-${{env.arch}}.tgz
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v7
         with:
-          image: "linux-${{matrix.dist}}-${{env.arch}}"
+          name: linux-${{matrix.dist}}-${{env.arch}}
+          path: linux-${{matrix.dist}}-${{env.arch}}.tgz
 
   assemble:
     name: assemble
@@ -57,7 +60,7 @@ jobs:
     runs-on: ${{matrix.runners}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set branch environment variable
         run: |
           BRANCH_NAME=${{ github.ref }}
@@ -77,18 +80,19 @@ jobs:
           elif [[ ${{env.BRANCH_NAME}} =~ ^7\.[0-9]+\.[0-9]+$ ]]; then
             echo "tag_suffix=${{ env.BRANCH_NAME }}" >> $GITHUB_ENV
           fi
-      - name: Download linux-libc-ubi8-amd64 image
-        uses: ishworkh/container-image-artifact-download@v2.0.0
+      - name: Download image artifacts
+        uses: actions/download-artifact@v7
         with:
-          image: "linux-libc-ubi8-${{env.arch}}"
-      - name: Download linux-libc-ubi9-amd64 image
-        uses: ishworkh/container-image-artifact-download@v2.0.0
-        with:
-          image: "linux-libc-ubi9-${{env.arch}}"
-      - name: Download linux-musl image
-        uses: ishworkh/container-image-artifact-download@v2.0.0
-        with:
-          image: "linux-musl-${{env.arch}}"
+          # Downloads all platform-specific images: linux-{dist}-{arch}.tgz
+          # Matches artifacts uploaded by the 'build' job above
+          pattern: linux-*-${{env.arch}}
+          merge-multiple: true
+          path: .
+      - name: Load docker images
+        run: |
+          docker load -i linux-libc-ubi8-${{env.arch}}.tgz
+          docker load -i linux-libc-ubi9-${{env.arch}}.tgz
+          docker load -i linux-musl-${{env.arch}}.tgz
       - name: Display docker images
         run: docker images
       - name: Update assembly.Dockerfile
@@ -97,7 +101,7 @@ jobs:
           sed  "s|FROM linux-libc-ubi9|FROM linux-libc-ubi9-${{env.arch}}|" -i "build/dockerfiles/assembly.Dockerfile"
           sed  "s|FROM linux-musl|FROM linux-musl-${{env.arch}}|" -i "build/dockerfiles/assembly.Dockerfile"
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -117,7 +121,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set branch environment variable
         run: |
           BRANCH_NAME=${{ github.ref }}
@@ -131,7 +135,7 @@ jobs:
             echo "tag_suffix=${{ env.BRANCH_NAME }}" >> $GITHUB_ENV
           fi
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -184,9 +188,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Login to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/pull-request-check-licenses.yml
+++ b/.github/workflows/pull-request-check-licenses.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.base_ref == 'main' }}
     steps:
       - name: Checkout che-code source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check che-activity-tracker dependencies usage restrictions
         run: |
           docker run --rm -t \

--- a/.github/workflows/pull-request-check-publish.yml
+++ b/.github/workflows/pull-request-check-publish.yml
@@ -28,14 +28,14 @@ jobs:
           df -h
 
       - name: Login to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_PULL_REQUESTS_USERNAME }}
           password: ${{ secrets.QUAY_PULL_REQUESTS_PASSWORD }}
 
       - name: Download Pull Request Number artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pull-request-number
           run-id: ${{ github.event.workflow_run.id }}
@@ -56,7 +56,7 @@ jobs:
           docker system prune -af
 
       - name: Download che-code docker image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: che-*
           merge-multiple: true

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout che-code source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install jq
         uses: dcarbone/install-jq-action@v3
         with:
@@ -53,7 +53,7 @@ jobs:
             echo arch="arm64" >> $GITHUB_ENV
           fi
       - name: Checkout che-code source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cleanup docker images
         run: docker system prune -af
       - name: Compile che-code
@@ -68,7 +68,7 @@ jobs:
       - name: Compress image to a file
         run: docker save linux-${{matrix.dist}}-${{env.arch}} | gzip > linux-${{matrix.dist}}-${{env.arch}}.tgz
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-${{matrix.dist}}-${{env.arch}}
           path: linux-${{matrix.dist}}-${{env.arch}}.tgz
@@ -90,11 +90,11 @@ jobs:
             echo arch="arm64" >> $GITHUB_ENV
           fi
       - name: Checkout che-code source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cleanup docker images
         run: docker system prune -af
       - name: Download editor artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: linux-*
           merge-multiple: true
@@ -125,7 +125,7 @@ jobs:
       - name: Compress image to a file
         run: docker save che-code-${{env.arch}} | gzip > che-code-${{env.arch}}.tgz
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: che-code-${{env.arch}}
           path: che-code-${{env.arch}}.tgz
@@ -133,7 +133,7 @@ jobs:
         run: echo "${{ github.event.number }}" > PR_NUMBER
       # Upload PR number artifact only once
       - name: Upload PR Number artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ env.arch == 'amd64' }}
         with:
           name: pull-request-number
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout che-code source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free up disk space
         run: |
@@ -172,7 +172,7 @@ jobs:
           docker save che-dev | gzip > che-dev.tgz
 
       - name: Upload che-dev docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: che-dev
           path: che-dev.tgz

--- a/.github/workflows/rebase-insiders.yml
+++ b/.github/workflows/rebase-insiders.yml
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
            fetch-depth: 0
            token: ${{ secrets.CHE_INCUBATOR_BOT_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: configure git
         run: |
           git config --global user.email "fbenoit+sync-checode@redhat.com"

--- a/.github/workflows/rebase-release-branch.yml
+++ b/.github/workflows/rebase-release-branch.yml
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
            fetch-depth: 0
            token: ${{ secrets.CHE_INCUBATOR_BOT_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: configure git
         run: |
           git config --global user.email "fbenoit+sync-checode@redhat.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,14 @@ jobs:
     steps:
       -
         name: "Checkout Che Code source code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.CHE_INCUBATOR_BOT_TOKEN }}
       -
         name: "Setup Node"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version-file: 'code/.nvmrc'
       -
         name: Check existing tags
         run: |

--- a/.github/workflows/smoke-test-pr-check.yaml
+++ b/.github/workflows/smoke-test-pr-check.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
 
       - name: Checkout che-code source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare Che-Code Dockerfile ( remove tests )
         run: |
@@ -174,14 +174,14 @@ jobs:
 
       - name: Store e2e artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts
           path: /tmp/tests
       
       - name: Store k8s logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: k8s-logs
           path: /tmp/devworkspace-happy-path-artifacts/admin-che-info


### PR DESCRIPTION
* Update GitHub Actions to Node 24-compatible versions
* backport of #714 

GitHub is deprecating Node 20 on Actions runners (June 16, 2026). Upgrade all action versions to their Node 24-compatible releases:
- actions/checkout v4 → v6
- actions/upload-artifact v4 → v6
- actions/download-artifact v4 → v6
- actions/setup-node v4 → v6
- docker/login-action v2/v3 → v4
- docker/setup-qemu-action v2 → v4
- docker/setup-buildx-action v2 → v4
- node-version "18" → "22" (EOL mitigation)

Also replace ishworkh/container-image-artifact actions with docker save/load + actions/upload-artifact@v6 / download-artifact@v6 pattern to eliminate third-party dependency.

Add Dependabot configuration for weekly GitHub Actions updates.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>


* Update .github/workflows/image-publish.yml



* using vscode .nvmrc file for using correct node version.



* Bump upload-artifact and download-artifact from v6 to v7

actions/download-artifact@v6 still uses Node.js 20, which GitHub will force to Node.js 24 on June 16, 2026. Align both upload-artifact and download-artifact to v7 which uses Node.js 24 natively.



---------

### What does this PR do?


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
