### PR TITLE
ci: Fix build of ubi8-based assembly

### DIFF
--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -69,8 +69,12 @@ RUN git init .
 # change network timeout (slow using multi-arch build)
 RUN npm config set fetch-retry-mintimeout 100000 && npm config set fetch-retry-maxtimeout 600000
 
-# node-gyp's make generator execs gyp entrypoints via shebang; UBI npm may ship them without +x
+# node-gyp's make generator execs gyp entrypoints via shebang; UBI npm may
+# ship them without +x and with a stale Python shebang (e.g. python3.8)
 RUN chmod +x \
+      /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py \
+      /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp \
+    && sed -i '1s|^#!.*python[^ ]*|#!/usr/bin/python3|' \
       /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py \
       /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp
 

--- a/build/dockerfiles/linux-libc-ubi8.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi8.Dockerfile
@@ -48,7 +48,7 @@ RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
     else \
       LIBKEYBOARD=""; echo "Warning: arch $(uname -m) not supported"; \
     fi; } \
-    && yum install -y $LIBSECRET $LIBKEYBOARD curl make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbcommon bash tar gzip rsync patch \
+    && yum install -y $LIBSECRET $LIBKEYBOARD curl make cmake gcc gcc-c++ git git-core-doc openssh less libX11-devel libxkbcommon bash tar gzip rsync patch \
     && yum -y clean all && rm -rf /var/cache/yum
 
 #########################################################

--- a/build/dockerfiles/linux-libc-ubi9.Dockerfile
+++ b/build/dockerfiles/linux-libc-ubi9.Dockerfile
@@ -56,7 +56,7 @@ RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
     else \
       LIBKEYBOARD=""; echo "Warning: arch $(uname -m) not supported"; \
     fi; } \
-    && yum install -y $LIBSECRET $LIBKEYBOARD make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbcommon krb5-devel bash tar gzip rsync patch npm \
+    && yum install -y $LIBSECRET $LIBKEYBOARD make cmake gcc gcc-c++ git git-core-doc openssh less libX11-devel libxkbcommon krb5-devel bash tar gzip rsync patch npm \
     && yum -y clean all && rm -rf /var/cache/yum
 
 #########################################################


### PR DESCRIPTION
### What does this PR do?

`npm install` fails during Docker build on `linux-libc-ubi8.Dockerfile` with:

```
/bin/sh: /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py: /usr/bin/python3.8: bad interpreter: No such file or directory
make: *** [Makefile:343: Makefile] Error 126
```

**Root cause:** Red Hat's `ubi8/nodejs-24` (and `nodejs-22`) images ship node-gyp's gyp_main.py with shebang `#!/usr/bin/python3.8` (baked in by brp-mangle-shebangs during RPM build), but the actual Python in the image is `3.12` at `/usr/bin/python3`. 

**Fix:** Add `sed` to rewrite the shebang to `#!/usr/bin/python3` alongside the existing `chmod +x` in `linux-libc-ubi8.Dockerfile`

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://redhat.atlassian.net/browse/CRW-12125

### How to test this PR?
ubi8-based assembly should be built without errors

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux build environments to use the appropriate Python configuration.
  * Improved native module build compatibility across supported enterprise Linux versions.
  * Added essential archive, synchronization, and patching utilities to the Linux 9 build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->