### PR TITLE
fix: override DOMPurify to patched version

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -1,6 +1,14 @@
-# che-code chagelog
+# che-code changelog
 
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
+
+#### @sbouchet
+https://github.com/che-incubator/che-code/pull/NNN
+
+- code/extensions/markdown-language-features/package.json
+- code/extensions/mermaid-chat-features/package.json
+- code/extensions/copilot/package.json
+---
 
 #### @sbouchet
 https://github.com/che-incubator/che-code/pull/750
@@ -9,6 +17,7 @@ https://github.com/che-incubator/che-code/pull/750
 - code/extensions/copilot/chat-lib/package.json
 ---
 
+#### @sbouchet
 https://github.com/che-incubator/che-code/pull/745
 
 - code/package.json

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,7 +3,7 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
-https://github.com/che-incubator/che-code/pull/NNN
+https://github.com/che-incubator/che-code/pull/778
 
 - code/extensions/markdown-language-features/package.json
 - code/extensions/mermaid-chat-features/package.json

--- a/.rebase/override/code/extensions/copilot/package.json
+++ b/.rebase/override/code/extensions/copilot/package.json
@@ -4,6 +4,7 @@
         "vitest": "^3.2.6"
     },
     "dependencies": {
+        "dompurify": "^3.4.12",
         "undici": "^7.28.0"
     }
 }

--- a/.rebase/override/code/extensions/markdown-language-features/package.json
+++ b/.rebase/override/code/extensions/markdown-language-features/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "dompurify": "^3.4.2"
+    "dompurify": "^3.4.12"
   }
 }

--- a/.rebase/override/code/extensions/mermaid-chat-features/package.json
+++ b/.rebase/override/code/extensions/mermaid-chat-features/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "dompurify": "^3.4.2"
+    "dompurify": "^3.4.12"
   }
 }

--- a/code/extensions/copilot/package-lock.json
+++ b/code/extensions/copilot/package-lock.json
@@ -43,7 +43,7 @@
 				"applicationinsights": "^2.9.7",
 				"best-effort-json-parser": "^1.2.1",
 				"diff": "^8.0.3",
-				"dompurify": "^3.3.2",
+				"dompurify": "^3.4.7",
 				"express": "^5.2.1",
 				"ignore": "^7.0.5",
 				"isbinaryfile": "^5.0.4",
@@ -11030,13 +11030,10 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-			"integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+			"version": "3.4.12",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
-			"engines": {
-				"node": ">=20"
-			},
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
 			}

--- a/code/extensions/copilot/package.json
+++ b/code/extensions/copilot/package.json
@@ -6382,7 +6382,7 @@
 		"applicationinsights": "^2.9.7",
 		"best-effort-json-parser": "^1.2.1",
 		"diff": "^8.0.3",
-		"dompurify": "^3.3.2",
+		"dompurify": "^3.4.12",
 		"express": "^5.2.1",
 		"ignore": "^7.0.5",
 		"isbinaryfile": "^5.0.4",

--- a/code/extensions/markdown-language-features/package-lock.json
+++ b/code/extensions/markdown-language-features/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",
-        "dompurify": "^3.4.2",
+        "dompurify": "^3.4.7",
         "highlight.js": "^11.8.0",
         "markdown-it": "^12.3.2",
         "markdown-it-front-matter": "^0.2.4",
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/code/extensions/markdown-language-features/package.json
+++ b/code/extensions/markdown-language-features/package.json
@@ -782,7 +782,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.12",
     "highlight.js": "^11.8.0",
     "markdown-it": "^12.3.2",
     "markdown-it-front-matter": "^0.2.4",

--- a/code/extensions/mermaid-chat-features/package-lock.json
+++ b/code/extensions/mermaid-chat-features/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^3.4.2",
+        "dompurify": "^3.4.7",
         "mermaid": "^11.12.3"
       },
       "devDependencies": {
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/code/extensions/mermaid-chat-features/package.json
+++ b/code/extensions/mermaid-chat-features/package.json
@@ -130,7 +130,7 @@
     "@vscode/codicons": "^0.0.36"
   },
   "dependencies": {
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.12",
     "mermaid": "^11.12.3"
   },
   "overrides": {


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2026-49978](https://github.com/advisories/GHSA-rp9w-3fw7-7cwq)

`DOMPurify` version is updated to `3.4.12`

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-11874


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
