### PR TITLE
chore: align machine-exec version with che-code version at release

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -108,7 +108,10 @@ fi
 
 set -e
 
+# update package version
 npm --no-git-tag-version version --allow-same-version "${VERSION}"
+# update machine-exec depencency
+sed_in_place -e "s|\(FROM quay.io/eclipse/che-machine-exec:\)[^ ]\+|\1${VERSION}|" build/dockerfiles/assembly.Dockerfile
 
 # commit change into branch
 if [[ ${NOCOMMIT} -eq 0 ]]; then


### PR DESCRIPTION
### What does this PR do?
If machine-exec's newest version is meant to be used in the same version of the code.
Then release script should update the reference during release commit creation.

This PR should be merged after https://github.com/che-incubator/che-code/pull/748

### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release packaging now automatically keeps the container image version aligned with the selected release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->