### PR TITLE
Fix downstream build

### DIFF
--- a/code/build/rspack/package-lock.json
+++ b/code/build/rspack/package-lock.json
@@ -62,7 +62,8 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz"
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -71,7 +72,8 @@
       "peer": true,
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz"
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
@@ -81,13 +83,15 @@
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
@@ -97,7 +101,8 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -412,7 +417,8 @@
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz"
     },
     "node_modules/@types/eslint-scope": {
       "version": "3.7.7",
@@ -422,19 +428,22 @@
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -443,7 +452,8 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz"
     },
     "node_modules/@vscode/component-explorer": {
       "version": "0.2.1-58",
@@ -451,7 +461,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@vscode/component-explorer/-/component-explorer-0.2.1-58.tgz"
     },
     "node_modules/@vscode/component-explorer-webpack-plugin": {
       "version": "0.3.1-53",
@@ -461,7 +472,8 @@
       },
       "peerDependencies": {
         "@vscode/component-explorer": "*"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@vscode/component-explorer-webpack-plugin/-/component-explorer-webpack-plugin-0.3.1-53.tgz"
     },
     "node_modules/@vscode/esm-url-webpack-plugin": {
       "version": "1.0.1-5",
@@ -469,7 +481,8 @@
       "license": "MIT",
       "peerDependencies": {
         "webpack": "^5.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@vscode/esm-url-webpack-plugin/-/esm-url-webpack-plugin-1.0.1-5.tgz"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -479,25 +492,29 @@
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz"
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
@@ -508,13 +525,15 @@
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz"
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
@@ -526,7 +545,8 @@
         "@webassemblyjs/helper-buffer": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
         "@webassemblyjs/wasm-gen": "1.14.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz"
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.13.2",
@@ -535,7 +555,8 @@
       "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz"
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.13.2",
@@ -544,13 +565,15 @@
       "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz"
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
@@ -566,7 +589,8 @@
         "@webassemblyjs/wasm-opt": "1.14.1",
         "@webassemblyjs/wasm-parser": "1.14.1",
         "@webassemblyjs/wast-printer": "1.14.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz"
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.14.1",
@@ -579,7 +603,8 @@
         "@webassemblyjs/ieee754": "1.13.2",
         "@webassemblyjs/leb128": "1.13.2",
         "@webassemblyjs/utf8": "1.13.2"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz"
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.14.1",
@@ -591,7 +616,8 @@
         "@webassemblyjs/helper-buffer": "1.14.1",
         "@webassemblyjs/wasm-gen": "1.14.1",
         "@webassemblyjs/wasm-parser": "1.14.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz"
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.14.1",
@@ -605,7 +631,8 @@
         "@webassemblyjs/ieee754": "1.13.2",
         "@webassemblyjs/leb128": "1.13.2",
         "@webassemblyjs/utf8": "1.13.2"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz"
     },
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.14.1",
@@ -615,19 +642,22 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -639,7 +669,8 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
     },
     "node_modules/acorn-import-phases": {
       "version": "1.0.4",
@@ -651,7 +682,8 @@
       },
       "peerDependencies": {
         "acorn": "^8.14.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz"
     },
     "node_modules/ajv": {
       "version": "8.18.0",
@@ -667,7 +699,8 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
@@ -684,7 +717,8 @@
         "ajv": {
           "optional": true
         }
-      }
+      },
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz"
     },
     "node_modules/ajv-keywords": {
       "version": "5.1.0",
@@ -696,7 +730,8 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.27",
@@ -708,7 +743,8 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz"
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
@@ -741,13 +777,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001791",
@@ -767,7 +805,8 @@
         }
       ],
       "license": "CC-BY-4.0",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
@@ -776,13 +815,15 @@
       "peer": true,
       "engines": {
         "node": ">=6.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.345",
       "dev": true,
       "license": "ISC",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
@@ -795,13 +836,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz"
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -810,7 +853,8 @@
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -823,7 +867,8 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
@@ -835,7 +880,8 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz"
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
@@ -844,7 +890,8 @@
       "peer": true,
       "engines": {
         "node": ">=4.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
@@ -853,7 +900,8 @@
       "peer": true,
       "engines": {
         "node": ">=4.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -862,13 +910,15 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -884,7 +934,8 @@
         }
       ],
       "license": "BSD-3-Clause",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -899,19 +950,22 @@
         "picomatch": {
           "optional": true
         }
-      }
+      },
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
       "license": "ISC",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -920,7 +974,8 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -934,17 +989,20 @@
       },
       "engines": {
         "node": ">= 10.13.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz"
     },
     "node_modules/loader-runner": {
       "version": "4.3.2",
@@ -957,7 +1015,8 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -967,13 +1026,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -982,25 +1043,29 @@
       "peer": true,
       "engines": {
         "node": ">= 0.6"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
     },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
       "license": "ISC",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
@@ -1010,7 +1075,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -1020,7 +1086,8 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
@@ -1031,7 +1098,8 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -1040,19 +1108,22 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz"
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -1071,7 +1142,8 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -1080,7 +1152,8 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1088,7 +1161,8 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
     },
     "node_modules/source-map-loader": {
       "version": "5.0.0",
@@ -1107,7 +1181,8 @@
       },
       "peerDependencies": {
         "webpack": "^5.72.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz"
     },
     "node_modules/source-map-loader/node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -1118,7 +1193,8 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
@@ -1128,7 +1204,8 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -1143,7 +1220,8 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -1156,7 +1234,8 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz"
     },
     "node_modules/terser": {
       "version": "5.46.2",
@@ -1174,7 +1253,8 @@
       },
       "engines": {
         "node": ">=10"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz"
     },
     "node_modules/terser-webpack-plugin": {
       "version": "5.5.0",
@@ -1207,13 +1287,15 @@
         "uglify-js": {
           "optional": true
         }
-      }
+      },
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz"
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -1227,19 +1309,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -1269,7 +1354,8 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz"
     },
     "node_modules/watchpack": {
       "version": "2.5.1",
@@ -1282,7 +1368,8 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz"
     },
     "node_modules/webpack": {
       "version": "5.106.2",
@@ -1329,7 +1416,8 @@
         "webpack-cli": {
           "optional": true
         }
-      }
+      },
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz"
     },
     "node_modules/webpack-sources": {
       "version": "3.4.1",
@@ -1338,7 +1426,8 @@
       "peer": true,
       "engines": {
         "node": ">=10.13.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz"
     }
   }
 }

--- a/code/extensions/che-api/package.json
+++ b/code/extensions/che-api/package.json
@@ -58,7 +58,7 @@
     "ip-address": "^10.2.0",
     "ws": "^8.21.0",
     "@devfile/api": {
-      "form-data": "^2.5.6"
+      "form-data@2": "^2.5.6"
     },
     "@kubernetes/client-node": {
       "form-data": "^4.0.6"

--- a/code/extensions/che-commands/package.json
+++ b/code/extensions/che-commands/package.json
@@ -46,7 +46,7 @@
     "ip-address": "^10.2.0",
     "ws": "^8.21.0",
     "@devfile/api": {
-      "form-data": "^2.5.6"
+      "form-data@2": "^2.5.6"
     },
     "@kubernetes/client-node": {
       "form-data": "^4.0.6"

--- a/code/extensions/che-github-authentication/package.json
+++ b/code/extensions/che-github-authentication/package.json
@@ -68,7 +68,7 @@
     "ip-address": "^10.2.0",
     "ws": "^8.21.0",
     "@devfile/api": {
-      "form-data": "^2.5.6"
+      "form-data@2": "^2.5.6"
     },
     "@kubernetes/client-node": {
       "form-data": "^4.0.6"

--- a/code/extensions/che-remote/package.json
+++ b/code/extensions/che-remote/package.json
@@ -49,7 +49,7 @@
   },
   "overrides": {
     "@devfile/api": {
-      "form-data": "^2.5.6"
+      "form-data@2": "^2.5.6"
     },
     "@types/node-fetch": {
       "form-data": "^4.0.6"

--- a/code/extensions/che-resource-monitor/package.json
+++ b/code/extensions/che-resource-monitor/package.json
@@ -52,7 +52,7 @@
     "ip-address": "^10.2.0",
     "ws": "^8.21.0",
     "@devfile/api": {
-      "form-data": "^2.5.6"
+      "form-data@2": "^2.5.6"
     },
     "@kubernetes/client-node": {
       "form-data": "^4.0.6"


### PR DESCRIPTION
### What does this PR do?
- Qualify @devfile/api form-data override to avoid npm 11 conflict
- fix: Add resolved URLs to build/rspack peer dependencies in lockfile


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://redhat.atlassian.net/browse/CRW-11625

### How to test this PR?
Build should pass successfully

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution for the Devfile API integrations.
  * Ensured the application consistently uses the compatible version of the form-data package across affected extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->