### PR TITLE
fix: Bump actions/github-script from v7 to v8 for Node.js 24

### DIFF
--- a/.github/workflows/pull-request-check-publish.yml
+++ b/.github/workflows/pull-request-check-publish.yml
@@ -116,7 +116,7 @@ jobs:
           docker system prune -af
           
       - name: 'Comment PR'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
          script: |
            const { repo: { owner, repo } } = context;


### PR DESCRIPTION
### What does this PR do?
Node.js 20 is deprecated on GitHub Actions runners. This was the last remaining action targeting Node.js 20.

### What issues does this PR fix?
leftover of #714 


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request publishing workflow’s comment action to a newer version.
  * No changes to the workflow’s behavior or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->