### PR TITLE
[7.121] chore: Update @vscode/ripgrep to 1.18.0, remove artifacts entries

### DIFF
--- a/build/artifacts/artifacts.lock.yaml
+++ b/build/artifacts/artifacts.lock.yaml
@@ -18,19 +18,3 @@ artifacts:
   - download_url: https://open-vsx.org/api/devfile/vscode-devfile/0.0.4/file/devfile.vscode-devfile-0.0.4.vsix
     filename: devfile.vscode-devfile.0.0.4.vsix
     checksum: sha256:c55a6c1d087e7715bfacb01c0c2b52ef0f935d85f0707265d9068cd64143744c
-  # ripgrep-ppc64le
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-4/ripgrep-v13.0.0-4-powerpc64le-unknown-linux-gnu.tar.gz
-    filename: ripgrep-v13.0.0-4-powerpc64le-unknown-linux-gnu.tar.gz
-    checksum: sha256:3ddd7c0797c14cefd3ee61f13f15ac219bfecee8e6f6e27fd15c102ef229653a
-  # ripgrep-s390x
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-4/ripgrep-v13.0.0-4-s390x-unknown-linux-gnu.tar.gz
-    filename: ripgrep-v13.0.0-4-s390x-unknown-linux-gnu.tar.gz
-    checksum: sha256:61fa877688b721897cee33d572b64d8217ef16fe2cecf5f6f899f5ce55870e28
-  # ripgrep-x86_64
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v15.0.1/ripgrep-v15.0.1-x86_64-unknown-linux-musl.tar.gz
-    filename: ripgrep-v15.0.1-x86_64-unknown-linux-musl.tar.gz
-    checksum: sha256:4499958bfd5252df3d9e7504127fd448e4a14fbf2805ef4f14baaa1bcf775188
-  # ripgrep-aarch64
-  - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v15.0.1/ripgrep-v15.0.1-aarch64-unknown-linux-musl.tar.gz
-    filename: ripgrep-v15.0.1-aarch64-unknown-linux-musl.tar.gz
-    checksum: sha256:dd3738a4b6e8df0fb3bc3edc5af352c4c39e0d97ad118a23e5176bdc5d48ba08

--- a/build/artifacts/generate.sh
+++ b/build/artifacts/generate.sh
@@ -43,39 +43,7 @@ makeArtifactsLockYaml () {
     echo "    filename: $FILENAME"          >> "$ARTIFACTS_LOCK_YAML"
     echo "    checksum: sha256:$SHA256"     >> "$ARTIFACTS_LOCK_YAML"
   done
-
-  # Generate artifacts for ripgrep dependency
-  PACKAGE_LOCK_JSON="$ROOT_DIR/code/package-lock.json"
-  VSCODE_RIPGREP_VERSION=$(grep '"node_modules/@vscode/ripgrep"' "$PACKAGE_LOCK_JSON" -A 2 | grep '"version"' | head -1 | cut -d '"' -f 4)
-  POST_INSTALL_SCRIPT=$(curl -sSL https://raw.githubusercontent.com/microsoft/vscode-ripgrep/v${VSCODE_RIPGREP_VERSION}/lib/postinstall.js)
-  VSIX_RIPGREP_PREBUILT_VERSION=$(echo "${POST_INSTALL_SCRIPT}" | grep "const VERSION" | cut -d"'" -f 2 )
-  VSIX_RIPGREP_PREBUILT_MULTIARCH_VERSION=$(echo "${POST_INSTALL_SCRIPT}" | grep "const MULTI_ARCH_LINUX_VERSION" | cut -d"'" -f 2 )
-
-  PLATFORMS=("ppc64le" "s390x" "x86_64" "aarch64")
-  for PLATFORM in "${PLATFORMS[@]}"; do
-    case $PLATFORM in
-      'ppc64le') RG_ARCH_SUFFIX='powerpc64le-unknown-linux-gnu';;
-      's390x') RG_ARCH_SUFFIX='s390x-unknown-linux-gnu';;
-      'x86_64') RG_ARCH_SUFFIX='x86_64-unknown-linux-musl';;
-      'aarch64') RG_ARCH_SUFFIX='aarch64-unknown-linux-musl';;
-    esac
-    case $PLATFORM in
-      'ppc64le' | 's390x') RG_VERSION=${VSIX_RIPGREP_PREBUILT_MULTIARCH_VERSION};;
-      'x86_64' | 'aarch64') RG_VERSION="${VSIX_RIPGREP_PREBUILT_VERSION}";;
-    esac
-
-    FILENAME="ripgrep-${RG_VERSION}-${RG_ARCH_SUFFIX}.tar.gz"
-    DOWNLOAD_URL="https://github.com/microsoft/ripgrep-prebuilt/releases/download/${RG_VERSION}/${FILENAME}"
-    checkUrlExistence "$DOWNLOAD_URL"
-
-    read -r SHA256 rest <<< "$(curl -sL "$DOWNLOAD_URL" | shasum -a 256)"
-
-    echo "  # ripgrep-${PLATFORM}"            >> "$ARTIFACTS_LOCK_YAML"
-    echo "  - download_url: $DOWNLOAD_URL"    >> "$ARTIFACTS_LOCK_YAML"
-    echo "    filename: $FILENAME"            >> "$ARTIFACTS_LOCK_YAML"
-    echo "    checksum: sha256:$SHA256"       >> "$ARTIFACTS_LOCK_YAML"
-  done
-
+  
   echo "[INFO] Completed ${ARTIFACTS_LOCK_YAML}"
 }
 

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -3942,23 +3942,199 @@
       }
     },
     "node_modules/@vscode/ripgrep": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.17.1.tgz",
-      "integrity": "sha512-xTs7DGyAO3IsJYOCTBP8LnTvPiYVKEuyv8s0xyJDBXfs8rhBfqnZPvb6xDT+RnwWzcXqW27xLS/aGrkjX7lNWw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "https-proxy-agent": "^7.0.2",
-        "proxy-from-env": "^1.1.0",
-        "yauzl": "^2.9.2"
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
       }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@vscode/ripgrep-universal": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/@vscode/ripgrep-universal/-/ripgrep-universal-1.18.0.tgz",
       "integrity": "sha512-kgrAVy1L/v/8erAjo+I720ifTf7o4rvYUwgsuEu97XAEBtPT9sk3HhcSgFpxMydvNmwdJtXo9/AVee7JjocTrg==",
       "license": "MIT"
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vscode/sandbox-runtime": {
       "version": "0.0.1",
@@ -14941,12 +15117,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/pseudo-localization": {
       "version": "2.4.0",


### PR DESCRIPTION
Backport of https://github.com/che-incubator/che-code/pull/790

### What does this PR do?
- `@vscode/ripgrep` 1.18.0 ships binaries in the npm tarball via platform-specific packages, eliminating the `postinstall` download 
- Remove corresponding `artifacts.lock.yaml` entries


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://redhat.atlassian.net/browse/CRW-11625

### How to test this PR?
I tested build in downstream for all platforms - it was successful

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder
