### PR TITLE
Fix multiple CVEs by updating postcss to patched version

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
+#### @sbouchet
+CVE-2026-69153: update postcss to ^8.5.23
+
+- code/package.json
+- code/build/vite/package.json
+- code/extensions/copilot/package.json
+- code/extensions/copilot/chat-lib/package.json
+- code/extensions/mermaid-markdown-features/package.json
+- code/test/monaco/package.json
+---
+
 #### @rnikitenko
 https://github.com/che-incubator/che-code/commit/177a26a8ef76ea41a26eb6ac0ef9d6006b9af53e
 

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -3,7 +3,7 @@
 The file to keep a list of changed files which will potentionaly help to resolve rebase conflicts.
 
 #### @sbouchet
-CVE-2026-69153: update postcss to ^8.5.23
+https://github.com/che-incubator/che-code/pull/791
 
 - code/package.json
 - code/build/vite/package.json

--- a/.rebase/add/code/build/vite/package.json
+++ b/.rebase/add/code/build/vite/package.json
@@ -1,0 +1,7 @@
+{
+    "overrides": {
+        "vite": {
+            "postcss": "^8.5.23"
+        }
+    }
+}

--- a/.rebase/add/code/build/vite/package.json
+++ b/.rebase/add/code/build/vite/package.json
@@ -1,7 +1,7 @@
 {
     "overrides": {
         "vite": {
-            "postcss": "^8.5.23"
+            "postcss": "^8.5.26"
         }
     }
 }

--- a/.rebase/add/code/extensions/copilot/chat-lib/package.json
+++ b/.rebase/add/code/extensions/copilot/chat-lib/package.json
@@ -2,7 +2,7 @@
     "overrides": {
         "shell-quote": "^1.8.4",
         "vite": {
-            "postcss": "^8.5.23"
+            "postcss": "^8.5.26"
         },
         "minimatch@10": {
             "brace-expansion": "5.0.7"

--- a/.rebase/add/code/extensions/copilot/chat-lib/package.json
+++ b/.rebase/add/code/extensions/copilot/chat-lib/package.json
@@ -1,6 +1,9 @@
 {
     "overrides": {
         "shell-quote": "^1.8.4",
+        "vite": {
+            "postcss": "^8.5.23"
+        },
         "minimatch@10": {
             "brace-expansion": "5.0.7"
         }

--- a/.rebase/add/code/extensions/copilot/package.json
+++ b/.rebase/add/code/extensions/copilot/package.json
@@ -13,7 +13,7 @@
             "protobufjs": "^7.6.5"
         },
         "vite": {
-            "postcss": "^8.5.23"
+            "postcss": "^8.5.26"
         }
     }
 }

--- a/.rebase/add/code/extensions/copilot/package.json
+++ b/.rebase/add/code/extensions/copilot/package.json
@@ -11,6 +11,9 @@
         },
         "@grpc/proto-loader": {
             "protobufjs": "^7.6.5"
+        },
+        "vite": {
+            "postcss": "^8.5.23"
         }
     }
 }

--- a/.rebase/add/code/extensions/mermaid-markdown-features/package.json
+++ b/.rebase/add/code/extensions/mermaid-markdown-features/package.json
@@ -1,0 +1,7 @@
+{
+    "overrides": {
+        "@zenuml/core": {
+            "postcss": "^8.5.23"
+        }
+    }
+}

--- a/.rebase/add/code/extensions/mermaid-markdown-features/package.json
+++ b/.rebase/add/code/extensions/mermaid-markdown-features/package.json
@@ -1,7 +1,7 @@
 {
     "overrides": {
         "@zenuml/core": {
-            "postcss": "^8.5.23"
+            "postcss": "^8.5.26"
         }
     }
 }

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -8,7 +8,7 @@
     },
     "overrides": {
         "@gulp-sourcemaps/identity-map": {
-            "postcss": "^8.5.23"
+            "postcss": "^8.5.26"
         },
         "micromatch": "4.0.8",
         "braces": "3.0.3",

--- a/.rebase/add/code/package.json
+++ b/.rebase/add/code/package.json
@@ -8,7 +8,7 @@
     },
     "overrides": {
         "@gulp-sourcemaps/identity-map": {
-            "postcss": "8.4.33"
+            "postcss": "^8.5.23"
         },
         "micromatch": "4.0.8",
         "braces": "3.0.3",

--- a/.rebase/override/code/test/monaco/package.json
+++ b/.rebase/override/code/test/monaco/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "postcss": "^8.5.23"
+    }
+}

--- a/.rebase/override/code/test/monaco/package.json
+++ b/.rebase/override/code/test/monaco/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "postcss": "^8.5.23"
+        "postcss": "^8.5.26"
     }
 }

--- a/code/build/vite/package-lock.json
+++ b/code/build/vite/package-lock.json
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1081,9 +1081,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1101,7 +1101,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/code/build/vite/package.json
+++ b/code/build/vite/package.json
@@ -8,6 +8,11 @@
     "build": "vite build",
     "preview": "vite preview"
   },
+  "overrides": {
+    "vite": {
+      "postcss": "^8.5.23"
+    }
+  },
   "devDependencies": {
     "@vscode/component-explorer": "^0.2.1-58",
     "@vscode/component-explorer-vite-plugin": "^0.2.1-58",

--- a/code/build/vite/package.json
+++ b/code/build/vite/package.json
@@ -10,7 +10,7 @@
   },
   "overrides": {
     "vite": {
-      "postcss": "^8.5.23"
+      "postcss": "^8.5.26"
     }
   },
   "devDependencies": {

--- a/code/extensions/copilot/chat-lib/package-lock.json
+++ b/code/extensions/copilot/chat-lib/package-lock.json
@@ -3575,9 +3575,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4070,9 +4070,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4090,7 +4090,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/code/extensions/copilot/chat-lib/package.json
+++ b/code/extensions/copilot/chat-lib/package.json
@@ -72,7 +72,7 @@
   "overrides": {
     "shell-quote": "^1.8.4",
     "vite": {
-      "postcss": "^8.5.23"
+      "postcss": "^8.5.26"
     },
     "minimatch@10": {
       "brace-expansion": "5.0.7"

--- a/code/extensions/copilot/chat-lib/package.json
+++ b/code/extensions/copilot/chat-lib/package.json
@@ -71,6 +71,9 @@
   },
   "overrides": {
     "shell-quote": "^1.8.4",
+    "vite": {
+      "postcss": "^8.5.23"
+    },
     "minimatch@10": {
       "brace-expansion": "5.0.7"
     }

--- a/code/extensions/copilot/package-lock.json
+++ b/code/extensions/copilot/package-lock.json
@@ -12958,9 +12958,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -14029,9 +14029,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -14049,7 +14049,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/code/extensions/copilot/package.json
+++ b/code/extensions/copilot/package.json
@@ -7261,7 +7261,7 @@
       "protobufjs": "^7.6.5"
     },
     "vite": {
-      "postcss": "^8.5.23"
+      "postcss": "^8.5.26"
     }
   },
   "vscodeCommit": "94c8e2adc50e26ef70af85a0de3a9efed757acaa",

--- a/code/extensions/copilot/package.json
+++ b/code/extensions/copilot/package.json
@@ -7259,6 +7259,9 @@
     },
     "@grpc/proto-loader": {
       "protobufjs": "^7.6.5"
+    },
+    "vite": {
+      "postcss": "^8.5.23"
     }
   },
   "vscodeCommit": "94c8e2adc50e26ef70af85a0de3a9efed757acaa",

--- a/code/extensions/mermaid-markdown-features/package-lock.json
+++ b/code/extensions/mermaid-markdown-features/package-lock.json
@@ -2338,9 +2338,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -2523,9 +2523,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2542,7 +2542,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/code/extensions/mermaid-markdown-features/package.json
+++ b/code/extensions/mermaid-markdown-features/package.json
@@ -264,6 +264,9 @@
     "mermaid": "^11.15.0"
   },
   "overrides": {
-    "lodash-es": "4.18.1"
+    "lodash-es": "4.18.1",
+    "@zenuml/core": {
+      "postcss": "^8.5.23"
+    }
   }
 }

--- a/code/extensions/mermaid-markdown-features/package.json
+++ b/code/extensions/mermaid-markdown-features/package.json
@@ -266,7 +266,7 @@
   "overrides": {
     "lodash-es": "4.18.1",
     "@zenuml/core": {
-      "postcss": "^8.5.23"
+      "postcss": "^8.5.26"
     }
   }
 }

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -13663,9 +13663,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -14953,9 +14953,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.33",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -14973,9 +14973,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/code/package.json
+++ b/code/package.json
@@ -282,7 +282,7 @@
       "ws": "^7.5.11"
     },
     "@gulp-sourcemaps/identity-map": {
-      "postcss": "^8.5.23"
+      "postcss": "^8.5.26"
     },
     "micromatch": "4.0.8",
     "braces": "3.0.3",

--- a/code/package.json
+++ b/code/package.json
@@ -282,7 +282,7 @@
       "ws": "^7.5.11"
     },
     "@gulp-sourcemaps/identity-map": {
-      "postcss": "8.4.33"
+      "postcss": "^8.5.23"
     },
     "micromatch": "4.0.8",
     "braces": "3.0.3",

--- a/code/test/monaco/package-lock.json
+++ b/code/test/monaco/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "postcss": "^8.5.23"
+        "postcss": "^8.5.26"
       },
       "devDependencies": {
         "@types/chai": "^4.2.14",

--- a/code/test/monaco/package-lock.json
+++ b/code/test/monaco/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "postcss": "^8.5.12"
+        "postcss": "^8.5.23"
       },
       "devDependencies": {
         "@types/chai": "^4.2.14",
@@ -1273,9 +1273,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1399,9 +1399,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1418,7 +1418,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/code/test/monaco/package.json
+++ b/code/test/monaco/package.json
@@ -22,7 +22,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "postcss": "^8.5.12"
+    "postcss": "^8.5.23"
   },
   "overrides": {
     "lodash": "^4.18.1"

--- a/code/test/monaco/package.json
+++ b/code/test/monaco/package.json
@@ -22,7 +22,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "postcss": "^8.5.23"
+    "postcss": "^8.5.26"
   },
   "overrides": {
     "lodash": "^4.18.1"

--- a/rebase.sh
+++ b/rebase.sh
@@ -508,6 +508,8 @@ resolve_conflicts() {
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/test/monaco/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/mermaid-markdown-features/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/notebook-renderers/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/css-language-features/package.json" ]]; then


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2026-45623](https://github.com/advisories/GHSA-6g55-p6wh-862q) and [CVE-2026-69153](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp)
`postcss` version is updated to `8.5.26`

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-12201
https://redhat.atlassian.net/browse/CRW-12157
https://redhat.atlassian.net/browse/CRW-12709

### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PostCSS requirements across build tools, extensions, and the Monaco test environment for improved compatibility and consistency.
  * Refined related dependency version handling for more reliable package installation.
* **Chores**
  * Added safeguards for consistent dependency resolution.
  * Improved handling of package configuration conflicts during rebasing.
  * Corrected changelog wording and documented the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->