### PR TITLE
fix: handle ENOENT when scanning TCP proc files

### DIFF
--- a/code/extensions/che-port/src/port-scanner.ts
+++ b/code/extensions/che-port/src/port-scanner.ts
@@ -54,9 +54,12 @@ export class PortScanner {
    */
   public async getListeningPorts(): Promise<ListeningPort[]> {
     const ipConverter = new IpConverter();
-    const outIPV6 = this.scanner.getListeningPortV6();
-    const outIPV4 = this.scanner.getListeningPortV4();
-    const output = (await Promise.all([outIPV4, outIPV6])).join();
+    const [outputIPV4, outputIPV6] = await Promise.all([
+      this.readListeningPorts(() => this.scanner.getListeningPortV4()),
+      this.readListeningPorts(() => this.scanner.getListeningPortV6()),
+    ]);
+
+    const output = outputIPV4 + outputIPV6;
 
     // parse
     const regex = /:\s(.*):(.*)\s[0-9].*\s0A\s/gm;
@@ -72,5 +75,16 @@ export class PortScanner {
       ports.push(port);
     }
     return ports;
+  }
+
+  private async readListeningPorts(reader: () => Promise<string>): Promise<string> {
+    try {
+      return await reader();
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        return '';
+      }
+      throw error;
+    }
   }
 }

--- a/code/extensions/che-port/tests/port-scanner/port-scanner.spec.ts
+++ b/code/extensions/che-port/tests/port-scanner/port-scanner.spec.ts
@@ -63,4 +63,49 @@ describe('Test Port Scanner with real path', () => {
     await portScanner.getListeningPorts();
     await portScanner.getListeningPorts();
   });
+
+  test('should continue scanning IPv4 ports when IPv6 is unavailable', async () => {
+    const spyReadfile = jest.spyOn(fs, 'readFile') as jest.Mock;
+
+    spyReadfile
+      .mockResolvedValueOnce('ipv4-content')
+      .mockRejectedValueOnce(Object.assign(new Error('IPv6 is disabled'), { code: 'ENOENT' }));
+
+    await expect(portScanner.getListeningPorts()).resolves.toBeDefined();
+  });
+
+  test('should continue scanning IPv6 ports when IPv4 is unavailable', async () => {
+    const spyReadfile = jest.spyOn(fs, 'readFile') as jest.Mock;
+
+    spyReadfile
+      .mockRejectedValueOnce(Object.assign(new Error('IPv4 is disabled'), { code: 'ENOENT' }))
+      .mockResolvedValueOnce('ipv6-content');
+
+    await expect(portScanner.getListeningPorts()).resolves.toBeDefined();
+  });
+
+  test('should return empty ports when both IPv4 and IPv6 are unavailable', async () => {
+    const spyReadfile = jest.spyOn(fs, 'readFile') as jest.Mock;
+
+    spyReadfile
+      .mockRejectedValueOnce(Object.assign(new Error('IPv4 is disabled'), { code: 'ENOENT' }))
+      .mockRejectedValueOnce(Object.assign(new Error('IPv6 is disabled'), { code: 'ENOENT' }));
+
+    const ports = await portScanner.getListeningPorts();
+
+    expect(ports).toEqual([]);
+  });
+
+  test('should propagate errors other than ENOENT', async () => {
+    const spyReadfile = jest.spyOn(fs, 'readFile') as jest.Mock;
+
+    const error = Object.assign(new Error('Permission denied'), { code: 'EACCES' });
+
+    spyReadfile
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce('');
+
+    await expect(portScanner.getListeningPorts()).rejects.toThrow('Permission denied');
+  });
+  
 });


### PR DESCRIPTION
### What does this PR do?

Handles missing /proc/net/tcp and /proc/net/tcp6 files in the Che port scanner.

When IPv4 or IPv6 is disabled, the corresponding proc file may not exist, causing the port scanner to fail with an ENOENT error. This change treats ENOENT as an unavailable protocol and continues scanning ports from the available protocol.

When both IPv4 and IPv6 are available, both files continue to be scanned as before.

### What issues does this PR fix?
Fixes [Eclipse Che #23619](https://github.com/eclipse-che/che/issues/23619).


### How to test this PR?

- Run the existing port scanner tests.
- Verify that ports are detected when both IPv4 and IPv6 proc files are available.
- Verify that port scanning continues successfully when /proc/net/tcp6 is unavailable.
- Verify that port scanning continues successfully when /proc/net/tcp is unavailable.
- Verify that an empty result is returned when both proc files are unavailable.
- Verify that errors other than ENOENT are still propagated.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved listening-port detection across IPv4 and IPv6 connections.
  * Port scanning now continues when one or both protocol data sources are unavailable.
  * Unexpected scanning errors continue to be reported instead of being silently ignored.

* **Tests**
  * Added coverage for partial, complete, and unexpected port-data availability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->