### PR TITLE
fix: Handle workspace restart when DWO restarts the pod before the restart command reaches the browser

### DIFF
--- a/code/extensions/che-remote/src/extension.ts
+++ b/code/extensions/che-remote/src/extension.ts
@@ -243,8 +243,21 @@ async function updateDevfile(cheApi: any): Promise<boolean> {
   }
 
   try {
+    await vscode.commands.executeCommand('che-remote.command.prepareForRestart');
+  } catch (error) {
+    // Best-effort: if the signal doesn't reach the browser, the restart
+    // flow falls back to the normal disconnection handling.
+  }
+
+  try {
     await devfileService.updateDevfile(devfileContext.devWorkspace.spec?.template);
   } catch (error) {
+    try {
+      await vscode.commands.executeCommand('che-remote.command.cancelRestart');
+    } catch (_) {
+      // best-effort cleanup
+    }
+
     if (error.body && error.body.message) {
       const action = await vscode.window.showErrorMessage('Failed to update Devfile.', {
         modal: true,

--- a/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/devWorkspaceAssistant.ts
@@ -47,7 +47,13 @@ export class DevWorkspaceAssistant {
 	private static readonly POLL_INTERVAL_MS = 2000;
 	private static readonly STOP_TIMEOUT_MS = 10000;
 
-	private _isStopping = false;
+	/**
+	 * Tracks the intentional workspace lifecycle action in progress:
+	 * - 'idle': no action, disconnection handler shows normal dialogs
+	 * - 'restartPending': devfile update is about to happen; if extension host dies, redirect to dashboard
+	 * - 'stopping': doRestart/stopWorkspace is running on browser side, handler should not interfere
+	 */
+	private _pendingAction: 'idle' | 'restartPending' | 'stopping' = 'idle';
 	private dashboardUrl: string | undefined;
 	private getDevWorkspaceUrl: string | undefined;
 	private startingDevWorkspaceUrl: string | undefined;
@@ -61,6 +67,12 @@ export class DevWorkspaceAssistant {
 		});
 		CommandsRegistry.registerCommand('che-remote.command.stopWorkspaceAndRedirectToDashboard', () => {
 			this.stopWorkspaceAndRedirectToDashboard();
+		});
+		CommandsRegistry.registerCommand('che-remote.command.prepareForRestart', () => {
+			this._pendingAction = 'restartPending';
+		});
+		CommandsRegistry.registerCommand('che-remote.command.cancelRestart', () => {
+			this._pendingAction = 'idle';
 		});
 	}
 
@@ -193,29 +205,29 @@ export class DevWorkspaceAssistant {
 		);
 	}
 
-	get isStopping(): boolean {
-		return this._isStopping;
+	get pendingAction(): 'idle' | 'restartPending' | 'stopping' {
+		return this._pendingAction;
 	}
 
 	private async doRestart(): Promise<void> {
-		this._isStopping = true;
+		this._pendingAction = 'stopping';
 		try {
 			await this.stopWorkspaceViaDashboardApi();
 			await this.waitForStopped();
 			this.startWorkspace();
 		} catch (e) {
-			this._isStopping = false;
+			this._pendingAction = 'idle';
 			throw e;
 		}
 	}
 
 	async stopWorkspaceAndRedirectToDashboard(): Promise<void> {
-		this._isStopping = true;
+		this._pendingAction = 'stopping';
 		try {
 			await this.stopWorkspaceViaDashboardApi();
 			this.goToDashboard();
 		} catch (e) {
-			this._isStopping = false;
+			this._pendingAction = 'idle';
 			throw e;
 		}
 	}

--- a/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
+++ b/code/src/vs/workbench/contrib/remote/browser/che/remote.ts
@@ -95,7 +95,12 @@ export class CheDisconnectionHandler {
 			return;
 		}
 
-		if (this.devWorkspaceAssistant.isStopping) {
+		const pendingAction = this.devWorkspaceAssistant.pendingAction;
+		if (pendingAction === 'restartPending') {
+			this.devWorkspaceAssistant.startWorkspace();
+			return;
+		}
+		if (pendingAction === 'stopping') {
 			return;
 		}
 


### PR DESCRIPTION

### What does this PR do?
When `Restart from Local Devfile` updates `spec.template` with significant changes (e.g. adding a project), the DevWorkspace Operator may restart the pod before the browser-side `restartWorkspace` command is invoked, causing the disconnection handler to show an unexpected `workspace not running` dialog instead of redirecting to the dashboard.

Signal the browser before the K8s patch so the disconnection handler can redirect to the dashboard if the extension host dies.


### What issues does this PR fix?
<!-- Please include any related issue from the Eclipse Che repository (or from another issue tracker). -->
https://redhat.atlassian.net/browse/CRW-9559

### How to test this PR?

#### 1. Restart Workspace from Local Devfile for Empty Workspace use case
1. Go to the Dashboard
2. Set `quay.io/che-incubator-pull-requests/che-code:pr-794-amd64` in the `Editor Image` field
3. Click `Empty Workspace`
4. Create a terminal => 
```
git clone https://github.com/crw-qe/ubi9-based-sample-public.git && \
cd ubi9-based-sample-public && \
git checkout ubi9-init
```
5. `F1` => `Restart Workspace from Local Devfile`

Expected result: 
- the workspace should be restarted successfully
- `Cannot reconnect. Please reload the window.` dialog is not displayed.

#### 2. Restart Workspace from Local Devfile for NOT Empty Workspace use case
1. Go to the Dashboard
2. Set `quay.io/che-incubator-pull-requests/che-code:pr-794-amd64` in the `Editor Image` field
3. Set `https://github.com/RomanNikitenko/web-nodejs-sample` in the `Git repo URL` field
4. Click `Create & Open`
5. Open devfile => provide some changes
6. `F1` => `Restart Workspace from Local Devfile`

Expected result: 
- the workspace should be restarted successfully
- `Cannot reconnect. Please reload the window.` dialog is not displayed.
- devfile changes should be applied 

#### 3. Restart Workspace command use case
`Restart Workspace` command is also affected by the current PR changes  
1. Go to the Dashboard
2. Set `quay.io/che-incubator-pull-requests/che-code:pr-794-amd64` in the `Editor Image` field
3. Create any workspace
4. `F1` => `Restart Workspace` when the workspace is ready to use

Expected result: 
- the workspace should be restarted successfully
- `Cannot reconnect. Please reload the window.` dialog is not displayed.

#### 4. Stop Workspace command use case
`Stop Workspace` command is also affected by the current PR changes  
1. Go to the Dashboard
2. Set `quay.io/che-incubator-pull-requests/che-code:pr-794-amd64` in the `Editor Image` field
3. Create any workspace
4. `F1` => `Stop Workspace` when the workspace is ready to use

Expected result: 
- the workspace should be stopped successfully
- user should be redirected to the dashboard


### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace restart handling during Devfile updates.
  * Automatically resumes the workspace when a planned restart disconnects the remote connection.
  * Prevented unintended disconnect handling while the workspace is stopping.
  * Cancels restart preparation if a Devfile update fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->