### PR TITLE
Fix CVE-2026-71436 by updating mermaid to patched version

### DIFF
--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -14,7 +14,7 @@ https://github.com/che-incubator/che-code/pull/791
 ---
 
 #### @sbouchet
-https://github.com/che-incubator/che-code/pull/NNN
+https://github.com/che-incubator/che-code/pull/797
 
 - code/extensions/mermaid-markdown-features/package.json
 - code/extensions/markdown-language-features/package.json

--- a/.rebase/CHANGELOG.md
+++ b/.rebase/CHANGELOG.md
@@ -13,6 +13,13 @@ https://github.com/che-incubator/che-code/pull/791
 - code/test/monaco/package.json
 ---
 
+#### @sbouchet
+https://github.com/che-incubator/che-code/pull/NNN
+
+- code/extensions/mermaid-markdown-features/package.json
+- code/extensions/markdown-language-features/package.json
+---
+
 #### @rnikitenko
 https://github.com/che-incubator/che-code/commit/177a26a8ef76ea41a26eb6ac0ef9d6006b9af53e
 

--- a/.rebase/override/code/extensions/markdown-language-features/package.json
+++ b/.rebase/override/code/extensions/markdown-language-features/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "mermaid": "^11.17.0"
+        "mermaid": "^11.17.1"
     }
 }

--- a/.rebase/override/code/extensions/markdown-language-features/package.json
+++ b/.rebase/override/code/extensions/markdown-language-features/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "mermaid": "^11.17.0"
+    }
+}

--- a/.rebase/override/code/extensions/mermaid-markdown-features/package.json
+++ b/.rebase/override/code/extensions/mermaid-markdown-features/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "mermaid": "^11.17.0"
+        "mermaid": "^11.17.1"
     }
 }

--- a/.rebase/override/code/extensions/mermaid-markdown-features/package.json
+++ b/.rebase/override/code/extensions/mermaid-markdown-features/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "mermaid": "^11.17.0"
+    }
+}

--- a/code/extensions/markdown-language-features/package-lock.json
+++ b/code/extensions/markdown-language-features/package-lock.json
@@ -15,7 +15,7 @@
         "highlight.js": "^11.8.0",
         "katex": "^0.16.33",
         "markdown-it": "^14.2.0",
-        "mermaid": "^11.15.0",
+        "mermaid": "^11.17.0",
         "morphdom": "^2.7.7",
         "picomatch": "^2.3.2",
         "punycode": "^2.3.1",
@@ -85,12 +85,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@microsoft/1ds-core-js": {
@@ -1392,6 +1392,15 @@
         "benchmarks"
       ]
     },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
+      }
+    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
@@ -1561,26 +1570,27 @@
       "license": "MIT"
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.17.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.1.tgz",
+      "integrity": "sha512-G1BP6qU4BRwEGk2SdsxgDk1cSuApimT32Nkb52YRSv+856FrmB8qo28BaNk9Ee8Fvuon3OxpXDJ4L6cD5AykXg==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.34.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.21",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -2295,6 +2305,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
     },
     "node_modules/stylis": {
       "version": "4.4.0",

--- a/code/extensions/markdown-language-features/package-lock.json
+++ b/code/extensions/markdown-language-features/package-lock.json
@@ -15,7 +15,7 @@
         "highlight.js": "^11.8.0",
         "katex": "^0.16.33",
         "markdown-it": "^14.2.0",
-        "mermaid": "^11.17.0",
+        "mermaid": "^11.17.1",
         "morphdom": "^2.7.7",
         "picomatch": "^2.3.2",
         "punycode": "^2.3.1",

--- a/code/extensions/markdown-language-features/package.json
+++ b/code/extensions/markdown-language-features/package.json
@@ -904,7 +904,7 @@
     "highlight.js": "^11.8.0",
     "katex": "^0.16.33",
     "markdown-it": "^14.2.0",
-    "mermaid": "^11.15.0",
+    "mermaid": "^11.17.0",
     "morphdom": "^2.7.7",
     "picomatch": "^2.3.2",
     "punycode": "^2.3.1",

--- a/code/extensions/markdown-language-features/package.json
+++ b/code/extensions/markdown-language-features/package.json
@@ -904,7 +904,7 @@
     "highlight.js": "^11.8.0",
     "katex": "^0.16.33",
     "markdown-it": "^14.2.0",
-    "mermaid": "^11.17.0",
+    "mermaid": "^11.17.1",
     "morphdom": "^2.7.7",
     "picomatch": "^2.3.2",
     "punycode": "^2.3.1",

--- a/code/extensions/mermaid-markdown-features/package-lock.json
+++ b/code/extensions/mermaid-markdown-features/package-lock.json
@@ -15,7 +15,7 @@
         "@mermaid-js/layout-tidy-tree": "^0.2.0",
         "@mermaid-js/mermaid-zenuml": "^0.2.0",
         "dompurify": "^3.4.10",
-        "mermaid": "^11.15.0"
+        "mermaid": "^11.17.0"
       },
       "devDependencies": {
         "@types/markdown-it": "^14.1.0",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@braintree/sanitize-url": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz",
-      "integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
     },
     "node_modules/@chevrotain/types": {
@@ -299,12 +299,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -1319,9 +1319,9 @@
       }
     },
     "node_modules/cytoscape": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.1.tgz",
+      "integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -1818,9 +1818,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "license": "MIT"
     },
     "node_modules/delaunator": {
@@ -1931,6 +1931,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
       }
     },
     "node_modules/fastq": {
@@ -2186,9 +2195,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.44",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.44.tgz",
-      "integrity": "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -2273,26 +2282,27 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.0.tgz",
+      "integrity": "sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.34.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.21",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -2969,6 +2979,12 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/code/extensions/mermaid-markdown-features/package-lock.json
+++ b/code/extensions/mermaid-markdown-features/package-lock.json
@@ -15,7 +15,7 @@
         "@mermaid-js/layout-tidy-tree": "^0.2.0",
         "@mermaid-js/mermaid-zenuml": "^0.2.0",
         "dompurify": "^3.4.10",
-        "mermaid": "^11.17.0"
+        "mermaid": "^11.17.1"
       },
       "devDependencies": {
         "@types/markdown-it": "^14.1.0",
@@ -2282,9 +2282,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.0.tgz",
-      "integrity": "sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==",
+      "version": "11.17.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.1.tgz",
+      "integrity": "sha512-G1BP6qU4BRwEGk2SdsxgDk1cSuApimT32Nkb52YRSv+856FrmB8qo28BaNk9Ee8Fvuon3OxpXDJ4L6cD5AykXg==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",

--- a/code/extensions/mermaid-markdown-features/package.json
+++ b/code/extensions/mermaid-markdown-features/package.json
@@ -261,7 +261,7 @@
     "@mermaid-js/layout-tidy-tree": "^0.2.0",
     "@mermaid-js/mermaid-zenuml": "^0.2.0",
     "dompurify": "^3.4.10",
-    "mermaid": "^11.17.0"
+    "mermaid": "^11.17.1"
   },
   "overrides": {
     "lodash-es": "4.18.1",

--- a/code/extensions/mermaid-markdown-features/package.json
+++ b/code/extensions/mermaid-markdown-features/package.json
@@ -261,7 +261,7 @@
     "@mermaid-js/layout-tidy-tree": "^0.2.0",
     "@mermaid-js/mermaid-zenuml": "^0.2.0",
     "dompurify": "^3.4.10",
-    "mermaid": "^11.15.0"
+    "mermaid": "^11.17.0"
   },
   "overrides": {
     "lodash-es": "4.18.1",

--- a/rebase.sh
+++ b/rebase.sh
@@ -519,6 +519,8 @@ resolve_conflicts() {
       apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/extensions/markdown-language-features/package.json" ]]; then
       apply_package_changes_by_path "$conflictingFile"
+    elif [[ "$conflictingFile" == "code/extensions/mermaid-markdown-features/package.json" ]]; then
+      apply_package_changes_by_path "$conflictingFile"
     elif [[ "$conflictingFile" == "code/src/vs/platform/workspaces/common/workspaceIdentifier.ts" ]]; then
       apply_changes_multi_line "$conflictingFile"
     else


### PR DESCRIPTION
### What does this PR do?
This PR fixes [CVE-2026-71436](https://github.com/advisories/GHSA-2v8p-3f2j-5mp7)
mermaid version is updated to 11.17.1

### What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-12326


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [x] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [x] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [x] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Mermaid support to version 11.17.1.
  * Improved compatibility and consistency for Mermaid diagrams in Markdown.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->