### PR TITLE
fix: default empty workspace to open the projects root folder

### DIFF
--- a/launcher/src/code-workspace.ts
+++ b/launcher/src/code-workspace.ts
@@ -40,6 +40,8 @@ export class CodeWorkspace {
       return;
     }
 
+    const projectsRoot = env.PROJECTS_ROOT;
+
     let path: string | undefined;
     let workspace: Workspace | undefined;
 
@@ -109,6 +111,15 @@ export class CodeWorkspace {
       }
 
       if (await this.synchronizeProjects(workspace!, devfile.starterProjects)) {
+        saveRequired = true;
+      }
+
+      // Ensure the workspace always opens at least the projects root.
+      // Empty workspaces (no projects, dependentProjects or starterProjects) would
+      // otherwise produce a `.code-workspace` file with no `folders`, causing the
+      // editor to open with an empty Explorer and nothing mounted.
+      if (!workspace!.folders || workspace!.folders.length === 0) {
+        workspace!.folders = [{ name: 'projects', path: projectsRoot }];
         saveRequired = true;
       }
 

--- a/launcher/tests/_data/flattened.devworkspace.empty.yaml
+++ b/launcher/tests/_data/flattened.devworkspace.empty.yaml
@@ -1,0 +1,20 @@
+attributes:
+  controller.devfile.io/devworkspace-config:
+    name: devworkspace-config
+    namespace: dogfooding
+  controller.devfile.io/storage-type: per-workspace
+components:
+- attributes:
+    app.kubernetes.io/component: che-code-runtime
+    app.kubernetes.io/part-of: che-code.eclipse.org
+    controller.devfile.io/merged-contributions: editor
+  container:
+    cpuLimit: "4"
+    image: quay.io/che-incubator/che-code-dev:insiders
+    memoryLimit: 13Gi
+    memoryRequest: 320Mi
+    sourceMapping: /projects
+  name: dev
+- name: projects
+  volume:
+    size: 3Gi

--- a/launcher/tests/code-workspace.spec.ts
+++ b/launcher/tests/code-workspace.spec.ts
@@ -78,6 +78,15 @@ const WORKSPACE_WITH_FIVE_PROJECTS = `{
 \t]
 }`;
 
+const WORKSPACE_WITH_PROJECTS_ROOT = `{
+\t"folders": [
+\t\t{
+\t\t\t"name": "projects",
+\t\t\t"path": "/tmp/projects"
+\t\t}
+\t]
+}`;
+
 const WORKSPACE_WITH_DEPENDENT_PROJECTS = `{
 \t"folders": [
 \t\t{
@@ -460,6 +469,43 @@ describe('Test generating VS Code Workspace file:', () => {
     expect(readFileMock).toBeCalledWith(env.DEVWORKSPACE_FLATTENED_DEVFILE);
 
     expect(writeFileMock).toBeCalledWith('/tmp/projects/.code-workspace', WORKSPACE_WITH_DEPENDENT_PROJECTS);
+  });
+
+  test('should add PROJECTS_ROOT as a default folder when the workspace has no projects', async () => {
+    env.PROJECTS_ROOT = '/tmp/projects';
+
+    env.DEVWORKSPACE_FLATTENED_DEVFILE = path.join(__dirname, '_data', 'flattened.devworkspace.empty.yaml');
+
+    const pathExistsMock = jest.fn();
+    const writeFileMock = jest.fn();
+    const readFileMock = jest.fn();
+
+    Object.assign(fs, {
+      pathExists: pathExistsMock,
+      writeFile: writeFileMock,
+      readFile: readFileMock,
+    });
+
+    readFileMock.mockImplementation(async (path) => {
+      if (path === env.DEVWORKSPACE_FLATTENED_DEVFILE) {
+        return originalReadFile(path);
+      }
+
+      return undefined;
+    });
+
+    // no project directories exist and no default .code-workspace file is present
+    pathExistsMock.mockImplementation(async () => false);
+
+    const codeWorkspace = new CodeWorkspace();
+    await codeWorkspace.generate();
+
+    // should read only the flattened devworkspace file
+    expect(readFileMock).toBeCalledTimes(1);
+    expect(readFileMock).toBeCalledWith(env.DEVWORKSPACE_FLATTENED_DEVFILE);
+
+    // should create a default workspace file that opens the projects root
+    expect(writeFileMock).toBeCalledWith('/tmp/projects/.code-workspace', WORKSPACE_WITH_PROJECTS_ROOT);
   });
 
   test('should parse .code-workspace file if the file has extra characters', async () => {


### PR DESCRIPTION
### What does this PR do?

Ensures an **empty workspace** always opens with the `PROJECTS_ROOT` directory mounted in the Explorer.

Previously, when a workspace had no `projects`, `dependentProjects`, or `starterProjects` (for example the dashboard's built-in "Empty Workspace" sample, whose devfile is just `schemaVersion` + `generateName: empty`), the launcher's `CodeWorkspace.generate()` produced a `.code-workspace` file with **no `folders` array**:

```json
{
	"extensions": { "recommendations": ["..."] }
}
```

VS Code / che-code then opens this as a multi-root workspace with zero folders, so the Explorer is empty and nothing is mounted, even though `/projects` exists and is where the user is expected to work.

The fix adds a small fallback in `generate()`: after synchronizing devfile projects, if `folders` is still empty or absent, it defaults to a single entry pointing at `PROJECTS_ROOT`:

```ts
if (!workspace!.folders || workspace!.folders.length === 0) {
  workspace!.folders = [{ name: 'projects', path: projectsRoot }];
  saveRequired = true;
}
```

This is a **no-op** for workspaces that already resolve folders (single-project, multi-repo, or a `VSCODE_DEFAULT_WORKSPACE` file that already lists folders), so existing behavior is unchanged.

### What issues does this PR fix?

Fixes eclipse-che/che#23938

### How to test this PR?

1. Start an **Empty Workspace** (a devfile with no projects, e.g. the dashboard's "Empty Workspace" sample).
2. Wait for the editor to open.
3. The Explorer should now show the `/projects` (PROJECTS_ROOT) folder mounted instead of opening empty.
4. Inspect the generated file: `cat /projects/.code-workspace` — it should contain a `folders` entry for the projects root alongside the extension recommendations.

Automated coverage: a new unit test (`should add PROJECTS_ROOT as a default folder when the workspace has no projects`) and an empty devworkspace fixture were added. The full launcher build (`npm install` → format + `tsc` + eslint + jest) passes with all 66 tests green.

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder

_Note: this change is entirely within `launcher/` and does not touch the `code/` folder, so the CHANGELOG.md / `.rebase` items above do not apply._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspaces without configured projects now automatically include a `projects` folder based on the configured projects location.
  * Empty workspace configurations are now preserved with the default projects folder.

* **Tests**
  * Added coverage for generating workspaces with a default projects folder.
  * Added test data for empty flattened development workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->