### PR TITLE
SSHD startup script should refresh environment variables on restart

### DIFF
--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -71,12 +71,20 @@ mkdir -p $HOME/bin
 cp $sshd_libdir/tar $sshd_libdir/gzip $sshd_libdir/which $HOME/bin/
 
 # Set up environment variables injected into PID 1 (.profile & .bashrc)
-grep -q 'export DEVWORKSPACE_NAME=' $HOME/.profile
+
+grep -q 'source $HOME/.sshd_profile' $HOME/.profile
 if [ ! $? -eq 0 ]; then
-  env | sed 's|^|export |' >> $HOME/.profile
-  echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.profile
-  cat $HOME/.profile >> $HOME/.bashrc
+  touch $HOME/.sshd_profile
+  echo "source $HOME/.sshd_profile" >> $HOME/.profile
+  echo "source $HOME/.sshd_profile" >> $HOME/.bashrc
 fi
+
+if [ -f $HOME/.sshd_profile ]; then
+  env | sed 's|^|export |' >> $HOME/.sshd_profile
+  echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.sshd_profile
+fi
+
+
 
 # Configure SSHD as non-root user
 

--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -72,18 +72,19 @@ cp $sshd_libdir/tar $sshd_libdir/gzip $sshd_libdir/which $HOME/bin/
 
 # Set up environment variables injected into PID 1 (.profile & .bashrc)
 
-grep -q 'source $HOME/.sshd_profile' $HOME/.profile
-if [ ! $? -eq 0 ]; then
-  touch $HOME/.sshd_profile
-  echo "source $HOME/.sshd_profile" >> $HOME/.profile
-  echo "source $HOME/.sshd_profile" >> $HOME/.bashrc
-fi
+touch $HOME/.sshd_profile
 
-if [ -f $HOME/.sshd_profile ]; then
-  echo "" > $HOME/.sshd_profile
-  env | sed 's|^|export |' >> $HOME/.sshd_profile
-  echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.sshd_profile
-fi
+# Each file is validated independently, so a missing source line in either one
+# (or a deleted .sshd_profile) is repaired instead of skipping the whole block.
+for rc in $HOME/.profile $HOME/.bashrc; do
+  if ! grep -qsF '.sshd_profile' "$rc"; then
+    echo 'source $HOME/.sshd_profile' >> "$rc"
+  fi
+done
+
+echo "" > $HOME/.sshd_profile
+env | sed 's|^|export |' >> $HOME/.sshd_profile
+echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.sshd_profile
 
 # Configure SSHD as non-root user
 

--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -80,11 +80,10 @@ if [ ! $? -eq 0 ]; then
 fi
 
 if [ -f $HOME/.sshd_profile ]; then
+  echo "" > $HOME/.sshd_profile
   env | sed 's|^|export |' >> $HOME/.sshd_profile
   echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.sshd_profile
 fi
-
-
 
 # Configure SSHD as non-root user
 

--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -82,8 +82,7 @@ for rc in $HOME/.profile $HOME/.bashrc; do
   fi
 done
 
-echo "" > $HOME/.sshd_profile
-env | sed 's|^|export |' >> $HOME/.sshd_profile
+env | sed 's|^|export |' > $HOME/.sshd_profile
 echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.sshd_profile
 
 # Configure SSHD as non-root user

--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -71,9 +71,6 @@ mkdir -p $HOME/bin
 cp $sshd_libdir/tar $sshd_libdir/gzip $sshd_libdir/which $HOME/bin/
 
 # Set up environment variables injected into PID 1 (.profile & .bashrc)
-
-touch $HOME/.sshd_profile
-
 # Each file is validated independently, so a missing source line in either one
 # (or a deleted .sshd_profile) is repaired instead of skipping the whole block.
 for rc in $HOME/.profile $HOME/.bashrc; do


### PR DESCRIPTION
### What does this PR do?

Create a new file ($HOME/.profile) in the home folder that will get the env var from the process and  source it from .bashrc. 

### What issues does this PR fix?

https://github.com/eclipse-che/che/issues/23947


### How to test this PR?

### Does this PR contain changes that override default upstream Code-OSS behavior?
- [ ] the PR contains changes in the [code](https://github.com/che-incubator/che-code/tree/main/code) folder (you can skip it if your changes are placed in a che extension )
- [ ] the corresponding items were added to the [CHANGELOG.md](https://github.com/che-incubator/che-code/blob/main/.rebase/CHANGELOG.md) file
- [ ] rules for automatic `git rebase` were added to the [.rebase](https://github.com/che-incubator/che-code/tree/main/.rebase) folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment setup during SSH sessions by consistently updating the dedicated SSH profile with current environment variables and PATH settings.
  * Ensured `.profile` and `.bashrc` independently load the SSH profile when needed.
  * Streamlined profile validation and updates to keep environment configuration consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->