### PR TITLE
Fix injected environment variables by surrounding with quotes.

### DIFF
--- a/build/scripts/sshd.start
+++ b/build/scripts/sshd.start
@@ -79,7 +79,7 @@ for rc in $HOME/.profile $HOME/.bashrc; do
   fi
 done
 
-env | sed 's|^|export |' > $HOME/.sshd_profile
+env | sed -e 's|^|export |' -e 's|=|="|' -e 's|$|"|' > $HOME/.sshd_profile
 echo 'export PATH=$PATH:$HOME/bin' >> $HOME/.sshd_profile
 
 # Configure SSHD as non-root user


### PR DESCRIPTION
On certain devfiles, there may be issues reading in all environment variables when they contain whitespace. This even causes subsequent environment variables to be skipped.

**Before**
```
$ source ~/.bashrc 
-bash: export: `Node.js': not a valid identifier
-bash: export: `18': not a valid identifier
-bash: /opt/app-root/src/.bashrc: line 14: unexpected EOF while looking for matching `''
-bash: /opt/app-root/src/.bashrc: line 71: syntax error: unexpected end of file
$ env | wc -l
127
$ env | grep DEVW
DEVWORKSPACE_CREATOR=6dc46320-a4a1-48b9-97ec-2649a0410700
DEVWORKSPACE_NAME=nodejs
```

**After**
```
$ source ~/.bashrc 
$
$ env | wc -l
177
$ env | grep DEVW
DEVWORKSPACE_CREATOR=6dc46320-a4a1-48b9-97ec-2649a0410700
DEVWORKSPACE_NAME=nodejs
DEVWORKSPACE_METADATA=/devworkspace-metadata
DEVWORKSPACE_NAMESPACE=rgrunber-dev
DEVWORKSPACE_FLATTENED_DEVFILE=/devworkspace-metadata/flattened.devworkspace.yaml
DEVWORKSPACE_ORIGINAL_DEVFILE=/devworkspace-metadata/original.devworkspace.yaml
DEVWORKSPACE_ID=workspaced69d50db028a4d75
DEVWORKSPACE_IDLE_TIMEOUT=15m
DEVWORKSPACE_COMPONENT_NAME=runtime
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variable values generated for SSH profiles are now enclosed in double quotes, improving handling of values that contain spaces or special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->